### PR TITLE
Suppress compiler warnings on `override` keyword.

### DIFF
--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -231,7 +231,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
      * @param out_data     output vectors
      **/
     void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) { 
+                             std::vector<tensor_t*>&       out_data) override { 
         // forward convolutional op context
         auto ctx = OpKernelContext(in_data, out_data);
              ctx.setParallelize(layer::parallelize());
@@ -255,7 +255,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
     void back_propagation(const std::vector<tensor_t*>& in_data,
                           const std::vector<tensor_t*>& out_data,
                           std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) {
+                          std::vector<tensor_t*>&       in_grad) override {
         // activations
         // TODO(edgar/nyanp): refactor and move activations outside
         this->backward_activation(*out_grad[0], *out_data[0], *out_grad[1]);
@@ -410,7 +410,7 @@ private:
                conv_out_length(in_height, window_height, h_stride, pad_type);
     }
 
-    void createOp() {
+    void createOp() override {
         init_backend(layer::engine());
     }
 

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -127,7 +127,7 @@ class max_pooling_layer : public feedforward_layer<Activation> {
     }
 
     void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) {
+                             std::vector<tensor_t*>&       out_data) override {
         // launch maxpool kernel
         Base::backend_->maxpool(in_data, out_data);
 
@@ -138,7 +138,7 @@ class max_pooling_layer : public feedforward_layer<Activation> {
     void back_propagation(const std::vector<tensor_t*>& in_data,
                           const std::vector<tensor_t*>& out_data,
                           std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) {
+                          std::vector<tensor_t*>&       in_grad) override {
         // launch maxpool kernel
         Base::backend_->maxpool(in_data, out_data, out_grad, in_grad);
     }

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -325,7 +325,7 @@ class graph : public nodes {
         }
     }
 
-    std::vector<tensor_t> forward(const std::vector<tensor_t>& in_data) {
+    std::vector<tensor_t> forward(const std::vector<tensor_t>& in_data) override {
 
         cnn_size_t input_data_channel_count = in_data[0].size();
 


### PR DESCRIPTION
This simple patch suppress missing override keyword warning, e.g.

```
In file included from train.cpp:29:
In file included from ../../tiny_dnn/tiny_dnn.h:45:
../../tiny_dnn/layers/max_pooling_layer.h:138:10: warning: 'back_propagation' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    void back_propagation(const std::vector<tensor_t*>& in_data,
         ^
```