### PR TITLE
Fix/duplicate symbols 2

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -4,6 +4,6 @@ add_executable(print_device print_device.cpp)
 target_link_libraries(print_device
     ${project_library_target_name} ${REQUIRED_LIBRARIES})
 
-add_executable(tiny_dnn_test test.cpp)
+add_executable(tiny_dnn_test test.cpp test_no_duplicate_symbols.cpp)
 target_link_libraries(tiny_dnn_test 
     ${project_library_target_name} ${REQUIRED_LIBRARIES})

--- a/test/test_no_duplicate_symbols.cpp
+++ b/test/test_no_duplicate_symbols.cpp
@@ -27,7 +27,7 @@
 
 #define _CRT_SECURE_NO_WARNINGS
 #include "picotest/picotest.h"
-#include "tiny_cnn/tiny_cnn.h"
+#include "tiny_dnn/tiny_dnn.h"
 
 TEST(no_duplicate_symbols, no_duplicate_symbols) { 
     // The real test is that the tests link without errors due to duplicate symbols

--- a/tiny_dnn/core/framework/device.fwd.h
+++ b/tiny_dnn/core/framework/device.fwd.h
@@ -75,7 +75,7 @@ class Device {
      *
      * @param type The device type. Can be only CPU.
      */
-    explicit Device(device_t type);
+    inline explicit Device(device_t type);
 
     /* CPU/GPU OpenCL constructor.
      * Device context is initialized in constructor.
@@ -84,7 +84,7 @@ class Device {
      * @param platform_id The platform identification number.
      * @param device_id The device identification number.
      */
-    explicit Device(device_t type,
+    inline explicit Device(device_t type,
                     const int platform_id,
                     const int device_id);
 
@@ -125,7 +125,7 @@ class Device {
      *
      * @param l The layer to be registered
      */
-    void registerOp(layer& l);
+    inline void registerOp(layer& l);
 
  private:
     /* The device type */

--- a/tiny_dnn/core/framework/device.fwd.h
+++ b/tiny_dnn/core/framework/device.fwd.h
@@ -85,8 +85,8 @@ class Device {
      * @param device_id The device identification number.
      */
     inline explicit Device(device_t type,
-                    const int platform_id,
-                    const int device_id);
+                           const int platform_id,
+                           const int device_id);
 
     // Returns the device type
     device_t type() const { return type_; }

--- a/tiny_dnn/core/framework/device.h
+++ b/tiny_dnn/core/framework/device.h
@@ -49,7 +49,7 @@
 
 namespace tiny_dnn {
  
-Device::Device(device_t type)
+inline Device::Device(device_t type)
         : type_(type), has_clcuda_api_(false) {
     nn_info("Initializing Non-OpenCL device ...");
     if (type == device_t::GPU) {
@@ -59,7 +59,7 @@ Device::Device(device_t type)
     nn_info("Initializing Non-OpenCL device ... OK");
 }
 
-Device::Device(device_t type,
+inline Device::Device(device_t type,
                 const int platform_id,
                 const int device_id)
         : type_(type)
@@ -110,7 +110,7 @@ Device::Device(device_t type,
 #endif
 }
 
-void Device::registerOp(layer& l) {
+inline void Device::registerOp(layer& l) {
     // TODO(egdar/nyanp): Should we raise an error here?
     if (!hasCLCudaAPI()) {
         throw nn_error("Cannot register layer: " + l.layer_type() +

--- a/tiny_dnn/core/framework/device.h
+++ b/tiny_dnn/core/framework/device.h
@@ -60,8 +60,8 @@ inline Device::Device(device_t type)
 }
 
 inline Device::Device(device_t type,
-                const int platform_id,
-                const int device_id)
+                      const int platform_id,
+                      const int device_id)
         : type_(type)
         , has_clcuda_api_(true)
         , platform_id_(platform_id)

--- a/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
@@ -34,11 +34,11 @@ namespace core {
 namespace kernels {
 
 inline void tiny_quantized_conv2d_kernel(const conv_params& params,
-                                  const vec_t&       in,
-                                  const vec_t&       W,
-                                  const vec_t&       bias,
-                                  vec_t&             a,
-                                  const bool layer_parallelize) {
+                                         const vec_t&       in,
+                                         const vec_t&       W,
+                                         const vec_t&       bias,
+                                         vec_t&             a,
+                                         const bool layer_parallelize) {
     // image quantization
     float min_input(in[0]);
     float max_input(in[0]);
@@ -157,12 +157,12 @@ inline void tiny_quantized_conv2d_kernel(const conv_params& params,
 }
 
 inline void tiny_quantized_conv2d_back_kernel(const conv_params& params,
-                                       const vec_t& prev_out,
-                                       const vec_t& W,
-                                       vec_t&       dW,
-                                       vec_t&       db,
-                                       vec_t&       curr_delta,
-                                       vec_t*       prev_delta) {
+                                              const vec_t& prev_out,
+                                              const vec_t& W,
+                                              vec_t&       dW,
+                                              vec_t&       db,
+                                              vec_t&       curr_delta,
+                                              vec_t*       prev_delta) {
     // previous output quantization
     float min_prev_out(prev_out[0]);
     float max_prev_out(prev_out[0]);
@@ -341,15 +341,15 @@ inline void tiny_quantized_conv2d_back_kernel(const conv_params& params,
 }
 
 inline void tiny_quantized_conv2d_kernel(const conv_params& params,
-                                  const vec_t&       in,
-                                  const vec_t&       W,
-                                  const vec_t&       bias,
-                                  const vec_t&       in_r,
-                                  const vec_t&       W_r,
-                                  const vec_t&       b_r,
-                                  vec_t&             a,
-                                  vec_t&             a_r,
-                                  const bool layer_parallelize) {
+                                         const vec_t&       in,
+                                         const vec_t&       W,
+                                         const vec_t&       bias,
+                                         const vec_t&       in_r,
+                                         const vec_t&       W_r,
+                                         const vec_t&       b_r,
+                                         vec_t&             a,
+                                         vec_t&             a_r,
+                                         const bool layer_parallelize) {
     // filter range
     float min_filter(W_r[0]);
     float max_filter(W_r[1]);

--- a/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
@@ -33,7 +33,7 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-void tiny_quantized_conv2d_kernel(const conv_params& params,
+inline void tiny_quantized_conv2d_kernel(const conv_params& params,
                                   const vec_t&       in,
                                   const vec_t&       W,
                                   const vec_t&       bias,
@@ -156,7 +156,7 @@ void tiny_quantized_conv2d_kernel(const conv_params& params,
     a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
 }
 
-void tiny_quantized_conv2d_back_kernel(const conv_params& params,
+inline void tiny_quantized_conv2d_back_kernel(const conv_params& params,
                                        const vec_t& prev_out,
                                        const vec_t& W,
                                        vec_t&       dW,
@@ -340,7 +340,7 @@ void tiny_quantized_conv2d_back_kernel(const conv_params& params,
     }
 }
 
-void tiny_quantized_conv2d_kernel(const conv_params& params,
+inline void tiny_quantized_conv2d_kernel(const conv_params& params,
                                   const vec_t&       in,
                                   const vec_t&       W,
                                   const vec_t&       bias,

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -34,11 +34,11 @@ namespace core {
 namespace kernels {
 
 inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
-                                    const vec_t&         in,
-                                    const vec_t&         W,
-                                    const vec_t&         bias,
-                                    vec_t&               a,
-                                    const bool layer_parallelize) {
+                                           const vec_t&         in,
+                                           const vec_t&         W,
+                                           const vec_t&         bias,
+                                           vec_t&               a,
+                                           const bool layer_parallelize) {
     // image quantization
     float min_input(in[0]);
     float max_input(in[0]);
@@ -155,12 +155,12 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
 }
 
 inline void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
-                             const vec_t& prev_out,
-                             const vec_t& W,
-                             vec_t&       dW,
-                             vec_t&       db,
-                             vec_t&       curr_delta,
-                             vec_t*       prev_delta) {
+                                                const vec_t& prev_out,
+                                                const vec_t& W,
+                                                vec_t&       dW,
+                                                vec_t&       db,
+                                                vec_t&       curr_delta,
+                                                vec_t*       prev_delta) {
     // previous output quantization
     float min_prev_out(prev_out[0]);
     float max_prev_out(prev_out[0]);
@@ -338,15 +338,15 @@ inline void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
 }
 
 inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
-                                    const vec_t&         in,
-                                    const vec_t&         W,
-                                    const vec_t&         bias,
-                                    const vec_t&         in_r,
-                                    const vec_t&         W_r,
-                                    const vec_t&         b_r,
-                                    vec_t&               a,
-                                    vec_t&               a_r,
-                                    const bool layer_parallelize) {
+                                           const vec_t&         in,
+                                           const vec_t&         W,
+                                           const vec_t&         bias,
+                                           const vec_t&         in_r,
+                                           const vec_t&         W_r,
+                                           const vec_t&         b_r,
+                                           vec_t&               a,
+                                           vec_t&               a_r,
+                                           const bool layer_parallelize) {
     // filter range
     float min_filter(W_r[0]);
     float max_filter(W_r[1]);

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -33,7 +33,7 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-void tiny_quantized_deconv2d_kernel(const deconv_params& params,
+inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
                                     const vec_t&         in,
                                     const vec_t&         W,
                                     const vec_t&         bias,
@@ -154,7 +154,7 @@ void tiny_quantized_deconv2d_kernel(const deconv_params& params,
     a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
 }
 
-void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
+inline void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
                              const vec_t& prev_out,
                              const vec_t& W,
                              vec_t&       dW,
@@ -337,7 +337,7 @@ void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
     }
 }
 
-void tiny_quantized_deconv2d_kernel(const deconv_params& params,
+inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
                                     const vec_t&         in,
                                     const vec_t&         W,
                                     const vec_t&         bias,

--- a/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
@@ -35,11 +35,11 @@ namespace core {
 namespace kernels {
 
 inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
-                                           const vec_t&        in,
-                                           const vec_t&        W,
-                                           const vec_t&        b,
-                                           vec_t&              a,
-                                           const bool          layer_parallelize) {
+                                                  const vec_t&        in,
+                                                  const vec_t&        W,
+                                                  const vec_t&        b,
+                                                  vec_t&              a,
+                                                  const bool          layer_parallelize) {
     // input quantization
     float min_input(in[0]);
     float max_input(in[0]);
@@ -143,13 +143,13 @@ inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
 }
 
 inline void tiny_quantized_fully_connected_back_kernel(const fully_params& params,
-                                                const vec_t& prev_out,
-                                                const vec_t& W,
-                                                vec_t&       dW,
-                                                vec_t&       prev_delta,
-                                                vec_t&       curr_delta,
-                                                vec_t&       db,
-                                                const bool   layer_parallelize) {
+                                                       const vec_t& prev_out,
+                                                       const vec_t& W,
+                                                       vec_t&       dW,
+                                                       vec_t&       prev_delta,
+                                                       vec_t&       curr_delta,
+                                                       vec_t&       db,
+                                                       const bool   layer_parallelize) {
     // previous output quantization
     float min_prev_out(prev_out[0]);
     float max_prev_out(prev_out[0]);
@@ -263,15 +263,15 @@ inline void tiny_quantized_fully_connected_back_kernel(const fully_params& param
 }
 
 inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
-                                           const vec_t&        in,
-                                           const vec_t&        W,
-                                           const vec_t&        b,
-                                           const vec_t&        in_r,
-                                           const vec_t&        W_r,
-                                           const vec_t&        b_r,
-                                           vec_t&              a,
-                                           vec_t&              a_r,
-                                           const bool          layer_parallelize) {
+                                                  const vec_t&        in,
+                                                  const vec_t&        W,
+                                                  const vec_t&        b,
+                                                  const vec_t&        in_r,
+                                                  const vec_t&        W_r,
+                                                  const vec_t&        b_r,
+                                                  vec_t&              a,
+                                                  vec_t&              a_r,
+                                                  const bool          layer_parallelize) {
     // filter range
     float min_filter(W_r[0]);
     float max_filter(W_r[1]);

--- a/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
@@ -34,7 +34,7 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-void tiny_quantized_fully_connected_kernel(const fully_params& params,
+inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
                                            const vec_t&        in,
                                            const vec_t&        W,
                                            const vec_t&        b,
@@ -142,7 +142,7 @@ void tiny_quantized_fully_connected_kernel(const fully_params& params,
     a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
 }
 
-void tiny_quantized_fully_connected_back_kernel(const fully_params& params,
+inline void tiny_quantized_fully_connected_back_kernel(const fully_params& params,
                                                 const vec_t& prev_out,
                                                 const vec_t& W,
                                                 vec_t&       dW,
@@ -262,7 +262,7 @@ void tiny_quantized_fully_connected_back_kernel(const fully_params& params,
     dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized, max_dW_requantized);
 }
 
-void tiny_quantized_fully_connected_kernel(const fully_params& params,
+inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
                                            const vec_t&        in,
                                            const vec_t&        W,
                                            const vec_t&        b,

--- a/tiny_dnn/core/params/fully_params.h
+++ b/tiny_dnn/core/params/fully_params.h
@@ -39,7 +39,7 @@ class fully_params : public Params {
 };
 
 // TODO(nyanp): can we do better here?
-fully_params Params::fully() const {
+inline fully_params Params::fully() const {
     return *(static_cast<const fully_params*>(this));
 }
 


### PR DESCRIPTION
The duplicate symbols test originally added in #171 has become disabled (not sure why, couldn't find the commit that removed it in the history).

This re-enables the test and also fixes a number of new duplicate symbols. There may still be others in configurations that I'm not building but the test should find them hopefully.