### PR TITLE
Add option to speedup compilation time

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -39,15 +39,16 @@ endif(NOT CMAKE_BUILD_TYPE)
 
 ####
 # Define user options
-option(USE_SSE    "Build tiny-dnn with SSE library support"     ON)
-option(USE_AVX    "Build tiny-dnn with AVX library support"     ON)
-option(USE_AVX2   "Build tiny-dnn with AVX2 library support"   OFF)
-option(USE_TBB    "Build tiny-dnn with TBB library support"    OFF)
-option(USE_OMP    "Build tiny-dnn with OMP library support"    OFF)
-option(USE_NNPACK "Build tiny-dnn with NNPACK library support" OFF)
-option(USE_OPENCV "Build tiny-dnn with OpenCV library support" OFF)
-option(USE_OPENCL "Build tiny-dnn with OpenCL library support" OFF) 
-option(USE_LIBDNN "Build tiny-dnn with GreenteaLibDNN library support" OFF)
+option(USE_SSE        "Build tiny-dnn with SSE library support"     ON)
+option(USE_AVX        "Build tiny-dnn with AVX library support"     ON)
+option(USE_AVX2       "Build tiny-dnn with AVX2 library support"   OFF)
+option(USE_TBB        "Build tiny-dnn with TBB library support"    OFF)
+option(USE_OMP        "Build tiny-dnn with OMP library support"    OFF)
+option(USE_NNPACK     "Build tiny-dnn with NNPACK library support" OFF)
+option(USE_OPENCV     "Build tiny-dnn with OpenCV library support" OFF)
+option(USE_OPENCL     "Build tiny-dnn with OpenCL library support" OFF) 
+option(USE_LIBDNN     "Build tiny-dnn with GreenteaLibDNN library support" OFF)
+option(USE_SERIALIZER "Build tiny-dnn with Serialization support" ON)
 
 option(BUILD_TESTS    "Set to ON to build tests"              OFF)
 option(BUILD_EXAMPLES "Set to ON to build examples"           OFF)
@@ -92,6 +93,10 @@ elseif(USE_TBB AND NOT TBB_FOUND)
     # set the paths to headers and libs by hand.
     message(FATAL_ERROR "Intel TBB not found. Please set TBB_INCLUDE_DIRS & "
             "TBB_LIBRARIES")
+endif()
+
+if(NOT USE_SERIALIZER)
+    add_definitions(-DCNN_NO_SERIALIZATION)
 endif()
 
 # Find Open Multi-Processing (OpenMP)

--- a/README.md
+++ b/README.md
@@ -120,18 +120,21 @@ Some cmake options are available:
 
 |options|description|default|additional requirements to use|
 |-----|-----|----|----|
-|USE_TBB|Use [Intel TBB](https://www.threadingbuildingblocks.org/) for parallelization|OFF*|[Intel TBB](https://www.threadingbuildingblocks.org/)|
-|USE_OMP|Use OpenMP for parallelization|OFF*|[OpenMP Compiler](http://openmp.org/wp/openmp-compilers/)|
+|USE_TBB|Use [Intel TBB](https://www.threadingbuildingblocks.org/) for parallelization|OFF*1|[Intel TBB](https://www.threadingbuildingblocks.org/)|
+|USE_OMP|Use OpenMP for parallelization|OFF*1|[OpenMP Compiler](http://openmp.org/wp/openmp-compilers/)|
 |USE_SSE|Use Intel SSE instruction set|ON|Intel CPU which supports SSE|
 |USE_AVX|Use Intel AVX instruction set|ON|Intel CPU which supports AVX|
 |USE_OPENCV|Use OpenCV for sample/test programs|ON|[Open Source Computer Vision Library](http://opencv.org/)|
-|BUILD_TESTS|Build unit tests|OFF|-**|
+|USE_SERIALIZER|Enable model serialization|ON*2|-|
+|BUILD_TESTS|Build unit tests|OFF|-*3|
 |BUILD_EXAMPLES|Build example projects|ON|-|
 |BUILD_DOCS|Build documentation|OFF|[Doxygen](http://www.doxygen.org/)|
 
-*tiny-dnn use c++11 standard library for parallelization by default
+*1 tiny-dnn use c++11 standard library for parallelization by default
 
-**tiny-dnn requires picotest as submodule. You need to use ```git submodule update --init``` command to run unit tests
+*2 If you don't use serialization, you can switch off to speedup compilation time.
+
+*3 tiny-dnn requires picotest as submodule. You need to use ```git submodule update --init``` command to run unit tests
 
 For example, type the following commands if you want to use intel TBB and build tests:
 ```bash

--- a/tiny_dnn/config.h
+++ b/tiny_dnn/config.h
@@ -57,6 +57,14 @@
  */
 #define CNN_USE_STDOUT
 
+
+/**
+ * disable serialization/deserialization function
+ * You can uncomment this to speedup compilation&linking time,
+ * if you don't use network::save / network::load functions.
+ **/
+//#define CNN_NO_SERIALIZATION
+
 /**
  * number of task in batch-gradient-descent.
  * @todo automatic optimization
@@ -67,16 +75,8 @@
 #define CNN_TASK_SIZE 8
 #endif
 
-#if !defined(_MSC_VER) || (_MSC_VER >= 1900) // default generation of move constructor is unsupported in VS2013
-#define CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-#endif
-
-#if !defined(_MSC_VER)
-#define CNN_USE_GEMMLOWP // gemmlowp doesn't support MSVC
-#endif
-
-#if defined _WIN32
-#define CNN_WINDOWS
+#if !defined(_MSC_VER) && !defined(_WIN32) && !defined(WIN32)
+#define CNN_USE_GEMMLOWP // gemmlowp doesn't support MSVC/mingw
 #endif
 
 namespace tiny_dnn {

--- a/tiny_dnn/util/macro.h
+++ b/tiny_dnn/util/macro.h
@@ -40,3 +40,12 @@
 #else
 #define CNN_ALIGNOF(x) alignof(x)
 #endif
+
+#if !defined(_MSC_VER) || (_MSC_VER >= 1900) // default generation of move constructor is unsupported in VS2013
+#define CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
+#endif
+
+#if defined _WIN32
+#define CNN_WINDOWS
+#endif
+


### PR DESCRIPTION
Serialization functionality requires cereal, and it increase the compilation time of tiny-dnn a lot.

We will provide a new option ```USE_SERIALIZER``` to exclude serialization. we can use this option if we don't need ```network::save``` and ```network::load``` functions.