### PR TITLE
Add clang tooling

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,93 @@
+---
+Language:        Cpp
+# BasedOnStyle:  Google
+AccessModifierOffset: -1
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: false
+AlignConsecutiveDeclarations: false
+AlignEscapedNewlinesLeft: true
+AlignOperands:   true
+AlignTrailingComments: true
+AllowAllParametersOfDeclarationOnNextLine: true
+AllowShortBlocksOnASingleLine: false
+AllowShortCaseLabelsOnASingleLine: false
+AllowShortFunctionsOnASingleLine: All
+AllowShortIfStatementsOnASingleLine: true
+AllowShortLoopsOnASingleLine: true
+AlwaysBreakAfterDefinitionReturnType: None
+AlwaysBreakAfterReturnType: None
+AlwaysBreakBeforeMultilineStrings: true
+AlwaysBreakTemplateDeclarations: true
+BinPackArguments: true
+BinPackParameters: true
+BraceWrapping:   
+  AfterClass:      false
+  AfterControlStatement: false
+  AfterEnum:       false
+  AfterFunction:   false
+  AfterNamespace:  false
+  AfterObjCDeclaration: false
+  AfterStruct:     false
+  AfterUnion:      false
+  BeforeCatch:     false
+  BeforeElse:      false
+  IndentBraces:    false
+BreakBeforeBinaryOperators: None
+BreakBeforeBraces: Attach
+BreakBeforeTernaryOperators: true
+BreakConstructorInitializersBeforeComma: false
+BreakAfterJavaFieldAnnotations: false
+BreakStringLiterals: true
+ColumnLimit:     80
+CommentPragmas:  '^ IWYU pragma:'
+ConstructorInitializerAllOnOneLineOrOnePerLine: true
+ConstructorInitializerIndentWidth: 4
+ContinuationIndentWidth: 4
+Cpp11BracedListStyle: true
+DerivePointerAlignment: true
+DisableFormat:   false
+ExperimentalAutoDetectBinPacking: false
+ForEachMacros:   [ foreach, Q_FOREACH, BOOST_FOREACH ]
+IncludeCategories: 
+  - Regex:           '^<.*\.h>'
+    Priority:        1
+  - Regex:           '^<.*'
+    Priority:        2
+  - Regex:           '.*'
+    Priority:        3
+IncludeIsMainRegex: '([-_](test|unittest))?$'
+IndentCaseLabels: true
+IndentWidth:     2
+IndentWrappedFunctionNames: false
+JavaScriptQuotes: Leave
+JavaScriptWrapImports: true
+KeepEmptyLinesAtTheStartOfBlocks: false
+MacroBlockBegin: ''
+MacroBlockEnd:   ''
+MaxEmptyLinesToKeep: 1
+NamespaceIndentation: None
+ObjCBlockIndentWidth: 2
+ObjCSpaceAfterProperty: false
+ObjCSpaceBeforeProtocolList: false
+PenaltyBreakBeforeFirstCallParameter: 1
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 200
+PointerAlignment: Left
+ReflowComments:  true
+SortIncludes:    true
+SpaceAfterCStyleCast: false
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesBeforeTrailingComments: 2
+SpacesInAngles:  false
+SpacesInContainerLiterals: true
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+Standard:        Auto
+TabWidth:        8
+UseTab:          Never

--- a/test/print_device.cpp
+++ b/test/print_device.cpp
@@ -8,19 +8,17 @@ using namespace tiny_dnn;
 
 int main(int argc, char *argv[]) {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    if (argc < 3) {
-        nn_warn("Need two parameters: platform_id and device_id.");
-        return 0;
-    }
-
-    const int platform_id = atoi(argv[1]);
-    const int device_id   = atoi(argv[2]);
-
-    printAvailableDevice(platform_id, device_id);
-#else
-    nn_warn("TinyDNN was not compiled with OpenCL or CUDA support.");
-#endif
+  if (argc < 3) {
+    nn_warn("Need two parameters: platform_id and device_id.");
     return 0;
+  }
+
+  const int platform_id = atoi(argv[1]);
+  const int device_id = atoi(argv[2]);
+
+  printAvailableDevice(platform_id, device_id);
+#else
+  nn_warn("TinyDNN was not compiled with OpenCL or CUDA support.");
+#endif
+  return 0;
 }
-
-

--- a/test/print_device.cpp
+++ b/test/print_device.cpp
@@ -1,47 +1,6 @@
-/*
-    COPYRIGHT
-
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-cnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #include "tiny_dnn/tiny_dnn.h"
 

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
 #endif

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -13,29 +13,29 @@ using namespace tiny_dnn::activation;
 #ifndef CNN_NO_SERIALIZATION
 #include "test_serialization.h"
 #endif
-#include "test_network.h"
 #include "test_average_pooling_layer.h"
+#include "test_network.h"
 // TODO(yida): fix broken test
 //#include "test_average_unpooling_layer.h"
-#include "test_dropout_layer.h"
-#include "test_max_pooling_layer.h"
-#include "test_fully_connected_layer.h"
-#include "test_deconvolutional_layer.h"
+#include "test_batch_norm_layer.h"
 #include "test_convolutional_layer.h"
-#include "test_target_cost.h"
+#include "test_deconvolutional_layer.h"
+#include "test_dropout_layer.h"
+#include "test_fully_connected_layer.h"
 #include "test_large_thread_count.h"
 #include "test_lrn_layer.h"
-#include "test_batch_norm_layer.h"
+#include "test_max_pooling_layer.h"
 #include "test_nodes.h"
+#include "test_target_cost.h"
 // TODO(edgar): build apart GPU tests
 //#include "test_core.h"
-#include "test_models.h"
-#include "test_slice_layer.h"
 #include "test_concat_layer.h"
+#include "test_models.h"
 #include "test_power_layer.h"
 #include "test_quantization.h"
 #include "test_quantized_convolutional_layer.h"
 #include "test_quantized_deconvolutional_layer.h"
+#include "test_slice_layer.h"
 #ifdef CNN_USE_GEMMLOWP
 #include "test_quantized_fully_connected_layer.h"
 #endif
@@ -46,6 +46,4 @@ using namespace tiny_dnn::activation;
 
 #include "test_image.h"
 
-int main(void) {
-    return RUN_ALL_TESTS();
-}
+int main(void) { return RUN_ALL_TESTS(); }

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -9,81 +9,65 @@
 
 namespace tiny_dnn {
 
-TEST(ave_pool, gradient_check) { // sigmoid - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef activation::sigmoid activation;
-    typedef network<sequential> network;
+TEST(ave_pool, gradient_check) {  // sigmoid - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef activation::sigmoid activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(3, 8)
-        << average_pooling_layer<activation>(4, 2, 1, 2); // 4x2 => 2x1
+  network nn;
+  nn << fully_connected_layer<activation>(3, 8)
+     << average_pooling_layer<activation>(4, 2, 1, 2);  // 4x2 => 2x1
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
 
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(ave_pool, forward) {
-    average_pooling_layer<identity> l(4, 4, 1, 2);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  average_pooling_layer<identity> l(4, 4, 1, 2);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        4, 4,
-        1.5, -0.5
-    };
+  vec_t expected = {4, 4, 1.5, -0.5};
 
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.0));
+  l.init_weight();
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.0));
-    l.init_weight();
+  vec_t res = l.forward({{in}})[0][0];
 
-    vec_t res = l.forward({ { in } })[0][0];
-
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(ave_pool, forward_stride) {
-    average_pooling_layer<identity> l(4, 4, 1, 2, 1);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  average_pooling_layer<identity> l(4, 4, 1, 2, 1);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        16.0/4, 15.0/4, 16.0/4,
-        22.0/4, 16.0/4, 14.0/4,
-         6.0/4,  1.0/4, -2.0/4
-    };
+  vec_t expected = {16.0 / 4, 15.0 / 4, 16.0 / 4, 22.0 / 4, 16.0 / 4,
+                    14.0 / 4, 6.0 / 4,  1.0 / 4,  -2.0 / 4};
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.0));
-    l.init_weight();
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.0));
+  l.init_weight();
 
-    vec_t res = l.forward({ { in } })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(ave_pool, read_write) {
-    average_pooling_layer<tan_h> l1(100, 100, 5, 2);
-    average_pooling_layer<tan_h> l2(100, 100, 5, 2);
+  average_pooling_layer<tan_h> l1(100, 100, 5, 2);
+  average_pooling_layer<tan_h> l2(100, 100, 5, 2);
 
-    l1.setup(true);
-    l2.setup(true);
+  l1.setup(true);
+  l2.setup(true);
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -9,82 +9,69 @@
 
 namespace tiny_dnn {
 
-TEST(ave_unpool, gradient_check) { // sigmoid - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef activation::sigmoid activation;
-    typedef network<sequential> network;
+TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef activation::sigmoid activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(3, 4)
-        << average_unpooling_layer<activation>(2, 2, 1, 2) // 2x2 => 4x4
-        << average_pooling_layer<activation>(4, 4, 1, 2);
+  network nn;
+  nn << fully_connected_layer<activation>(3, 4)
+     << average_unpooling_layer<activation>(2, 2, 1, 2)  // 2x2 => 4x4
+     << average_pooling_layer<activation>(4, 4, 1, 2);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
 
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(ave_unpool, forward) {
-    average_unpooling_layer<identity> l(2, 2, 1, 2);
-    vec_t in = {
-        4, 3,
-        1.5, -0.5
-    };
+  average_unpooling_layer<identity> l(2, 2, 1, 2);
+  vec_t in = {4, 3, 1.5, -0.5};
 
-    vec_t expected = {
-        4, 4, 3, 3,
-        4, 4, 3, 3,
-        1.5, 1.5, -0.5, -0.5,
-        1.5, 1.5, -0.5, -0.5,
-    };
+  vec_t expected = {
+      4, 4, 3, 3, 4, 4, 3, 3, 1.5, 1.5, -0.5, -0.5, 1.5, 1.5, -0.5, -0.5,
+  };
 
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.0));
+  l.init_weight();
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.0));
-    l.init_weight();
+  vec_t res = l.forward({{in}})[0][0];
 
-    vec_t res = l.forward({ { in } })[0][0];
-
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(ave_unpool, forward_stride) {
-    average_unpooling_layer<identity> l(3, 3, 1, 2, 1);
-    vec_t in = {
-        0, 1, 2,
-        8, 7, 5,
-        4, 3, 1,
-    };
+  average_unpooling_layer<identity> l(3, 3, 1, 2, 1);
+  vec_t in = {
+      0, 1, 2, 8, 7, 5, 4, 3, 1,
+  };
 
-    vec_t expected = {
-        0, 1, 3, 2,
-        8, 16, 15, 7,
-        12, 22, 16, 6,
-        4, 7, 4, 1
-    };
+  vec_t expected = {0, 1, 3, 2, 8, 16, 15, 7, 12, 22, 16, 6, 4, 7, 4, 1};
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.0));
-    l.init_weight();
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.0));
+  l.init_weight();
 
-    vec_t res = l.forward({ { in } })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(ave_unpool, read_write) {
-    average_unpooling_layer<tan_h> l1(100, 100, 5, 2);
-    average_unpooling_layer<tan_h> l2(100, 100, 5, 2);
+  average_unpooling_layer<tan_h> l1(100, 100, 5, 2);
+  average_unpooling_layer<tan_h> l2(100, 100, 5, 2);
 
-    l1.setup(true);
-    l2.setup(true);
+  l1.setup(true);
+  l2.setup(true);
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_batch_norm_layer.h
+++ b/test/test_batch_norm_layer.h
@@ -10,213 +10,130 @@
 namespace tiny_dnn {
 
 TEST(batchnorm, gradient_check) {
-    int num = 4;
-    int spatial_dim = 4;
-    int channels = 2;
-    batch_normalization_layer bn(spatial_dim, channels);
+  int num = 4;
+  int spatial_dim = 4;
+  int channels = 2;
+  batch_normalization_layer bn(spatial_dim, channels);
 
-    /* following values are extracted from caffe */
-    /* confirming that batch-norm layer is compatible with caffe's bn */
+  /* following values are extracted from caffe */
+  /* confirming that batch-norm layer is compatible with caffe's bn */
 
-    float_t top_diff[] = {
-        0.554228544,
-        -0.823364496,
-        -0.103415221,
-        0.669684947,
-        0.142640188,
-        -0.171076611,
-        0.292261183,
-        -0.067076027,
-        -0.00277741,
-        0.058186941,
-        0.046050139,
-        -0.006042562,
-        -0.004771964,
-        0.025202896,
-        -0.062344212,
-        0.030099955,
-        -0.023314178,
-        -0.030725746,
-        0.070954606,
-        0.055909708,
-        -0.019887319,
-        0.076775789,
-        0.014769247,
-        -0.025637595,
-        0.004412052,
-        -0.013895055,
-        -0.001271803,
-        3.15E-05,
-        -0.013110356,
-        0.008091689,
-        -0.005485342,
-        0.007250476
-    };
+  float_t top_diff[] = {0.554228544,  -0.823364496, -0.103415221, 0.669684947,
+                        0.142640188,  -0.171076611, 0.292261183,  -0.067076027,
+                        -0.00277741,  0.058186941,  0.046050139,  -0.006042562,
+                        -0.004771964, 0.025202896,  -0.062344212, 0.030099955,
+                        -0.023314178, -0.030725746, 0.070954606,  0.055909708,
+                        -0.019887319, 0.076775789,  0.014769247,  -0.025637595,
+                        0.004412052,  -0.013895055, -0.001271803, 3.15E-05,
+                        -0.013110356, 0.008091689,  -0.005485342, 0.007250476};
 
+  float_t top_data[] = {-0.430924207, -2.23937607,  1.7876749,    1.41079676,
+                        0.578419685,  0.662835836,  -2.1911881,   -0.002405337,
+                        1.49315703,   -0.836038888, 0.006807627,  -0.012308626,
+                        0.424309582,  -0.56077528,  0.095194906,  0.34416762,
+                        -0.755284429, -1.02720368,  0.802836478,  -0.06101859,
+                        2.17714667,   -0.994640052, -0.497716337, 0.397495717,
+                        -0.545207798, 0.320612997,  -0.016919944, 0.102396645,
+                        0.551594019,  -1.44724381,  -0.530790627, 0.993595243};
 
-    float_t top_data[] = {
-        -0.430924207,
-        -2.23937607,
-        1.7876749,
-        1.41079676,
-        0.578419685,
-        0.662835836,
-        -2.1911881,
-        -0.002405337,
-        1.49315703,
-        -0.836038888,
-        0.006807627,
-        -0.012308626,
-        0.424309582,
-        -0.56077528,
-        0.095194906,
-        0.34416762,
-        -0.755284429,
-        -1.02720368,
-        0.802836478,
-        -0.06101859,
-        2.17714667,
-        -0.994640052,
-        -0.497716337,
-        0.397495717,
-        -0.545207798,
-        0.320612997,
-        -0.016919944,
-        0.102396645,
-        0.551594019,
-        -1.44724381,
-        -0.530790627,
-        0.993595243
-    };
+  float_t stddev[] = {5.13347721, 6.15658283};
 
-    float_t stddev[] = {
-        5.13347721,
-        6.15658283
-    };
+  float_t expected_gradients[] = {
+      0.115063809,  -0.100263298, -0.078099057, 0.083551511,  0.025724376,
+      -0.024521608, 0.026721604,  -0.01322682,  -0.049858954, 0.030313857,
+      0.003235561,  -0.006351554, 0.000483762,  -0.002936667, -0.011636967,
+      0.00547356,   0.012069567,  0.018599048,  -0.015254314, 0.007145011,
+      0.01277818,   0.001789367,  -0.004100761, -0.003131026, 0.011310737,
+      -0.017643189, -0.005286998, -0.008531732, 0.000200434,  -0.013175356,
+      -0.007668978, 0.007226899};
 
-    float_t expected_gradients[] = {
-        0.115063809,
-        -0.100263298,
-        -0.078099057,
-        0.083551511,
-        0.025724376,
-        -0.024521608,
-        0.026721604,
-        -0.01322682,
-        -0.049858954,
-        0.030313857,
-        0.003235561,
-        -0.006351554,
-        0.000483762,
-        -0.002936667,
-        -0.011636967,
-        0.00547356,
-        0.012069567,
-        0.018599048,
-        -0.015254314,
-        0.007145011,
-        0.01277818,
-        0.001789367,
-        -0.004100761,
-        -0.003131026,
-        0.011310737,
-        -0.017643189,
-        -0.005286998,
-        -0.008531732,
-        0.000200434,
-        -0.013175356,
-        -0.007668978,
-        0.007226899
-    };
+  tensor_t outd, ing, outg;
+  std::vector<tensor_t*> in_data, out_data, in_grad, out_grad;
 
-    tensor_t outd, ing, outg;
-    std::vector<tensor_t*> in_data, out_data, in_grad, out_grad;
+  for (int i = 0; i < num; i++) {
+    int first = i * spatial_dim * channels;
+    int last = first + spatial_dim * channels;
 
-    for (int i = 0; i < num; i++) {
-        int first = i*spatial_dim*channels;
-        int last = first + spatial_dim*channels;
+    ing.push_back(vec_t(spatial_dim * channels));
+    outg.push_back(vec_t(top_diff + first, top_diff + last));
+    outd.push_back(vec_t(top_data + first, top_data + last));
+  }
+  in_grad.push_back(&ing);
+  out_grad.push_back(&outg);
+  out_data.push_back(&outd);
 
-        ing.push_back(vec_t(spatial_dim*channels));
-        outg.push_back(vec_t(top_diff + first, top_diff + last));
-        outd.push_back(vec_t(top_data + first, top_data + last));
+  bn.set_context(net_phase::train);
+  bn.set_stddev(vec_t(stddev, stddev + 2));
+  bn.back_propagation(in_data, out_data, out_grad, in_grad);
+
+  for (int i = 0; i < num; i++) {
+    for (int j = 0; j < spatial_dim * channels; j++) {
+      EXPECT_NEAR(expected_gradients[i * spatial_dim * channels + j],
+                  (*in_grad[0])[i][j], 1e-4);
     }
-    in_grad.push_back(&ing);
-    out_grad.push_back(&outg);
-    out_data.push_back(&outd);
-
-    bn.set_context(net_phase::train);
-    bn.set_stddev(vec_t(stddev, stddev + 2));
-    bn.back_propagation(in_data, out_data, out_grad, in_grad);
-
-    for (int i = 0; i < num; i++) {
-        for (int j = 0; j < spatial_dim*channels; j++) {
-            EXPECT_NEAR(expected_gradients[i*spatial_dim*channels + j], (*in_grad[0])[i][j], 1e-4);
-        }
-    }
+  }
 }
 
 TEST(batchnorm, forward) {
-    batch_normalization_layer bn(/*spatial-size=*/4, /*channel=*/3);
+  batch_normalization_layer bn(/*spatial-size=*/4, /*channel=*/3);
 
-    /*
-          mean   var
-    ch0:  0.0    0.0
-    ch1: -1.0    6.0
-    ch2:  2.875 10.696
-    */
-    tensor_t in = {
-      {
-         0.0f,  0.0f,  0.0f,  0.0f, // ch-0 of data#0
-        -4.0f,  0.0f, -1.0f,  2.0f, // ch-1 of data#0
-         1.0f,  0.0f,  1.0f,  3.0f, // ch-2 of data#0
-      }, {
-         0.0f,  0.0f,  0.0f,  0.0f,  // ch-0 of data#1  
-         2.0f,  0.0f, -4.0f, -3.0f,  // ch-1 of data#1
-         2.0f,  5.0f,  1.0f, 10.0f   // ch-2 of data#1
-      }
-    };
+  /*
+        mean   var
+  ch0:  0.0    0.0
+  ch1: -1.0    6.0
+  ch2:  2.875 10.696
+  */
+  tensor_t in = {{
+                     0.0f, 0.0f, 0.0f, 0.0f,    // ch-0 of data#0
+                     -4.0f, 0.0f, -1.0f, 2.0f,  // ch-1 of data#0
+                     1.0f, 0.0f, 1.0f, 3.0f,    // ch-2 of data#0
+                 },
+                 {
+                     0.0f, 0.0f, 0.0f, 0.0f,    // ch-0 of data#1
+                     2.0f, 0.0f, -4.0f, -3.0f,  // ch-1 of data#1
+                     2.0f, 5.0f, 1.0f, 10.0f    // ch-2 of data#1
+                 }};
 
-    /* y = (x - mean) ./ sqrt(variance + eps) */
-    tensor_t expect = {
-        {
-            0.0f,    0.0f,    0.0f,   0.0f,   // ch-0 of data#0
-           -1.225f,  0.408f,  0.0f,   1.225f, // ch-1 of data#0
-           -0.573f, -0.879f, -0.573f, 0.038f, // ch-2 of data#0
-        },{
-            0.0f,   0.0f,    0.0f,    0.0f,  // ch-0 of data#1  
-            1.225f, 0.408f, -1.225f, -0.816f,  // ch-1 of data#1
-           -0.268f, 0.650f, -0.573f,  2.179f   // ch-2 of data#1
-        }
-    };
+  /* y = (x - mean) ./ sqrt(variance + eps) */
+  tensor_t expect = {{
+                         0.0f, 0.0f, 0.0f, 0.0f,             // ch-0 of data#0
+                         -1.225f, 0.408f, 0.0f, 1.225f,      // ch-1 of data#0
+                         -0.573f, -0.879f, -0.573f, 0.038f,  // ch-2 of data#0
+                     },
+                     {
+                         0.0f, 0.0f, 0.0f, 0.0f,            // ch-0 of data#1
+                         1.225f, 0.408f, -1.225f, -0.816f,  // ch-1 of data#1
+                         -0.268f, 0.650f, -0.573f, 2.179f   // ch-2 of data#1
+                     }};
 
-    auto result = bn.forward({ in });
+  auto result = bn.forward({in});
 
-    for (size_t i = 0; i < 2; i++) {
-        for (size_t j = 0; j < 3 * 4; j++) {
-            EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
-        }
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 3 * 4; j++) {
+      EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
     }
+  }
 
-    bn.post_update();
+  bn.post_update();
 
-    // confirming that calculating the moving average doesn't affect the result
-    // while we feed the same data
-    result = bn.forward({ in });
-    for (size_t i = 0; i < 2; i++) {
-        for (size_t j = 0; j < 3 * 4; j++) {
-            EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
-        }
+  // confirming that calculating the moving average doesn't affect the result
+  // while we feed the same data
+  result = bn.forward({in});
+  for (size_t i = 0; i < 2; i++) {
+    for (size_t j = 0; j < 3 * 4; j++) {
+      EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
     }
+  }
 }
 
 TEST(batchnorm, read_write) {
-    batch_normalization_layer l1(100, 100);
-    batch_normalization_layer l2(100, 100);
+  batch_normalization_layer l1(100, 100);
+  batch_normalization_layer l2(100, 100);
 
-    l1.setup(true);
-    l2.setup(true);
+  l1.setup(true);
+  l2.setup(true);
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_batch_norm_layer.h
+++ b/test/test_batch_norm_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_caffe_converter.h
+++ b/test/test_caffe_converter.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_caffe_converter.h
+++ b/test/test_caffe_converter.h
@@ -9,23 +9,23 @@
 
 namespace tiny_dnn {
 
-inline std::shared_ptr<network<sequential>>
-create_net_from_json(const std::string& caffemodeljson, const shape3d& shape = shape3d()) {
-    std::string tmp_file_path = unique_path();
+inline std::shared_ptr<network<sequential>> create_net_from_json(
+    const std::string& caffemodeljson, const shape3d& shape = shape3d()) {
+  std::string tmp_file_path = unique_path();
 
-    {
-        std::ofstream ofs(tmp_file_path.c_str());
-        ofs << caffemodeljson;
-    }
-    auto model = create_net_from_caffe_prototxt(tmp_file_path, shape);
+  {
+    std::ofstream ofs(tmp_file_path.c_str());
+    ofs << caffemodeljson;
+  }
+  auto model = create_net_from_caffe_prototxt(tmp_file_path, shape);
 
-    std::remove(tmp_file_path.c_str());
+  std::remove(tmp_file_path.c_str());
 
-    return model;
+  return model;
 }
 
 TEST(caffe_converter, rectangle_input) {
-    std::string json = R"(
+  std::string json = R"(
     name: "RectangleNet"
     input: "data"
     input_shape {
@@ -55,26 +55,23 @@ TEST(caffe_converter, rectangle_input) {
     }
     )";
 
+  auto model = create_net_from_json(json);
 
-    auto model = create_net_from_json(json);
+  // conv->pool->conv->pool->fc->relu->fc->softmax
+  ASSERT_EQ(model->depth(), 2);
 
-    // conv->pool->conv->pool->fc->relu->fc->softmax
-    ASSERT_EQ(model->depth(), 2);
+  EXPECT_EQ((*model)[0]->in_shape()[0], shape3d(24, 40, 1));
+  EXPECT_EQ((*model)[0]->out_shape()[0], shape3d(22, 38, 96));
 
-    EXPECT_EQ((*model)[0]->in_shape()[0], shape3d(24, 40, 1));
-    EXPECT_EQ((*model)[0]->out_shape()[0], shape3d(22, 38, 96));
-
-
-    EXPECT_EQ((*model)[1]->in_shape()[0], shape3d(22*38*96, 1, 1));
-    EXPECT_EQ((*model)[1]->out_shape()[0], shape3d(10, 1, 1));
-
+  EXPECT_EQ((*model)[1]->in_shape()[0], shape3d(22 * 38 * 96, 1, 1));
+  EXPECT_EQ((*model)[1]->out_shape()[0], shape3d(10, 1, 1));
 }
 
 /**
  * test if we can parse lenet-model, defined in caffe/examples/mnsit
  **/
 TEST(caffe_converter, lenet) {
-    std::string json = R"(
+  std::string json = R"(
     name: "LeNet"
     layer {
       name: "mnist"
@@ -245,58 +242,56 @@ TEST(caffe_converter, lenet) {
     }
     )";
 
-    auto model = create_net_from_json(json, shape3d(28, 28, 1));
+  auto model = create_net_from_json(json, shape3d(28, 28, 1));
 
-    // conv->pool->conv->pool->fc->relu->fc->softmax
-    ASSERT_EQ(model->depth(), 8);
+  // conv->pool->conv->pool->fc->relu->fc->softmax
+  ASSERT_EQ(model->depth(), 8);
 
-    // conv1 28x28x1 -> 24x24x20
-    EXPECT_EQ((*model)[0]->in_shape()[0], shape3d(28, 28, 1));   // in: 28x28x1
-    EXPECT_EQ((*model)[0]->in_shape()[1], shape3d(5, 5, 20));    // weight: 5x5x20
-    EXPECT_EQ((*model)[0]->in_shape()[2], shape3d(1, 1, 20));    // bias: 1x1x20
-    EXPECT_EQ((*model)[0]->out_shape()[0], shape3d(24, 24, 20)); // out:24x24x20
-    EXPECT_EQ((*model)[0]->layer_type(), "conv");
+  // conv1 28x28x1 -> 24x24x20
+  EXPECT_EQ((*model)[0]->in_shape()[0], shape3d(28, 28, 1));  // in: 28x28x1
+  EXPECT_EQ((*model)[0]->in_shape()[1], shape3d(5, 5, 20));   // weight: 5x5x20
+  EXPECT_EQ((*model)[0]->in_shape()[2], shape3d(1, 1, 20));   // bias: 1x1x20
+  EXPECT_EQ((*model)[0]->out_shape()[0], shape3d(24, 24, 20));  // out:24x24x20
+  EXPECT_EQ((*model)[0]->layer_type(), "conv");
 
-    // pool1 24x24x20 -> 12x12x20
-    EXPECT_EQ((*model)[1]->in_shape()[0], shape3d(24, 24, 20));
-    EXPECT_EQ((*model)[1]->out_shape()[0], shape3d(12, 12, 20));
-    EXPECT_EQ((*model)[1]->layer_type(), "max-pool");
+  // pool1 24x24x20 -> 12x12x20
+  EXPECT_EQ((*model)[1]->in_shape()[0], shape3d(24, 24, 20));
+  EXPECT_EQ((*model)[1]->out_shape()[0], shape3d(12, 12, 20));
+  EXPECT_EQ((*model)[1]->layer_type(), "max-pool");
 
-    // conv2 12x12x20 -> 8x8x50
-    EXPECT_EQ((*model)[2]->in_shape()[0], shape3d(12, 12, 20));
-    EXPECT_EQ((*model)[2]->in_shape()[1], shape3d(5, 5, 1000));
-    EXPECT_EQ((*model)[2]->in_shape()[2], shape3d(1, 1, 50));
-    EXPECT_EQ((*model)[2]->out_shape()[0], shape3d(8, 8, 50));
-    EXPECT_EQ((*model)[2]->layer_type(), "conv");
+  // conv2 12x12x20 -> 8x8x50
+  EXPECT_EQ((*model)[2]->in_shape()[0], shape3d(12, 12, 20));
+  EXPECT_EQ((*model)[2]->in_shape()[1], shape3d(5, 5, 1000));
+  EXPECT_EQ((*model)[2]->in_shape()[2], shape3d(1, 1, 50));
+  EXPECT_EQ((*model)[2]->out_shape()[0], shape3d(8, 8, 50));
+  EXPECT_EQ((*model)[2]->layer_type(), "conv");
 
-    // pool2 8x8x50 -> 4x4x50
-    EXPECT_EQ((*model)[3]->in_shape()[0], shape3d(8, 8, 50));
-    EXPECT_EQ((*model)[3]->out_shape()[0], shape3d(4, 4, 50));
-    EXPECT_EQ((*model)[3]->layer_type(), "max-pool");
+  // pool2 8x8x50 -> 4x4x50
+  EXPECT_EQ((*model)[3]->in_shape()[0], shape3d(8, 8, 50));
+  EXPECT_EQ((*model)[3]->out_shape()[0], shape3d(4, 4, 50));
+  EXPECT_EQ((*model)[3]->layer_type(), "max-pool");
 
-    // fc
-    EXPECT_EQ((*model)[4]->in_shape()[0], shape3d(4 * 4 * 50, 1, 1));
-    EXPECT_EQ((*model)[4]->out_shape()[0], shape3d(500, 1, 1));
-    EXPECT_EQ((*model)[4]->layer_type(), "fully-connected");
+  // fc
+  EXPECT_EQ((*model)[4]->in_shape()[0], shape3d(4 * 4 * 50, 1, 1));
+  EXPECT_EQ((*model)[4]->out_shape()[0], shape3d(500, 1, 1));
+  EXPECT_EQ((*model)[4]->layer_type(), "fully-connected");
 
-    // relu
-    EXPECT_EQ((*model)[5]->in_shape()[0], shape3d(500, 1, 1));
-    EXPECT_EQ((*model)[5]->out_shape()[0], shape3d(500, 1, 1));
-    EXPECT_EQ((*model)[5]->layer_type(), "linear");
+  // relu
+  EXPECT_EQ((*model)[5]->in_shape()[0], shape3d(500, 1, 1));
+  EXPECT_EQ((*model)[5]->out_shape()[0], shape3d(500, 1, 1));
+  EXPECT_EQ((*model)[5]->layer_type(), "linear");
 
-    // fc
-    EXPECT_EQ((*model)[6]->in_shape()[0], shape3d(500, 1, 1));
-    EXPECT_EQ((*model)[6]->out_shape()[0], shape3d(10, 1, 1));
-    EXPECT_EQ((*model)[6]->layer_type(), "fully-connected");
+  // fc
+  EXPECT_EQ((*model)[6]->in_shape()[0], shape3d(500, 1, 1));
+  EXPECT_EQ((*model)[6]->out_shape()[0], shape3d(10, 1, 1));
+  EXPECT_EQ((*model)[6]->layer_type(), "fully-connected");
 
-    // softmax
-    EXPECT_EQ((*model)[7]->in_shape()[0], shape3d(10, 1, 1));
-    EXPECT_EQ((*model)[7]->out_shape()[0], shape3d(10, 1, 1));
-    EXPECT_EQ((*model)[7]->layer_type(), "linear");
+  // softmax
+  EXPECT_EQ((*model)[7]->in_shape()[0], shape3d(10, 1, 1));
+  EXPECT_EQ((*model)[7]->out_shape()[0], shape3d(10, 1, 1));
+  EXPECT_EQ((*model)[7]->layer_type(), "linear");
 }
 
-TEST(caffe_converter, conv2) {
+TEST(caffe_converter, conv2) {}
 
-}
-
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_concat_layer.h
+++ b/test/test_concat_layer.h
@@ -10,58 +10,40 @@
 namespace tiny_dnn {
 
 TEST(concat, forward_data) {
-    std::vector<shape3d> in_shapes;
-    in_shapes.push_back(shape3d(1, 2, 1));
-    in_shapes.push_back(shape3d(1, 2, 1));
-    in_shapes.push_back(shape3d(1, 2, 1));
-    concat_layer cl(in_shapes);
-    
-    tensor_t in0 = {
-        { 0, 1 },
-        { 6, 7 },
-        { 12, 13 },
-        { 18, 19 }
-    };
+  std::vector<shape3d> in_shapes;
+  in_shapes.push_back(shape3d(1, 2, 1));
+  in_shapes.push_back(shape3d(1, 2, 1));
+  in_shapes.push_back(shape3d(1, 2, 1));
+  concat_layer cl(in_shapes);
 
-    tensor_t in1 = {
-        {  2, 3 },
-        {  8, 9 },
-        { 14, 15 },
-        { 20, 21 }
-    };
+  tensor_t in0 = {{0, 1}, {6, 7}, {12, 13}, {18, 19}};
 
-    tensor_t in2 = {
-        { 4, 5 },
-        { 10, 11 },
-        { 16, 17 },
-        { 22, 23 }
-    };
-    
-    tensor_t out_expected = {
-        { 0, 1, 2, 3, 4, 5 },
-        { 6, 7, 8, 9, 10, 11 },
-        { 12, 13, 14, 15, 16, 17 },
-        { 18, 19, 20, 21, 22, 23 }
-    };
-        
-    auto out = cl.forward({in0, in1, in2});
-    
-    for (cnn_size_t i = 0; i < 4; i++) {
-        for (cnn_size_t j = 0; j < 2; j++) {
-            EXPECT_FLOAT_EQ(out_expected[i][j], out[0][i][j]);
-        }
+  tensor_t in1 = {{2, 3}, {8, 9}, {14, 15}, {20, 21}};
+
+  tensor_t in2 = {{4, 5}, {10, 11}, {16, 17}, {22, 23}};
+
+  tensor_t out_expected = {{0, 1, 2, 3, 4, 5},
+                           {6, 7, 8, 9, 10, 11},
+                           {12, 13, 14, 15, 16, 17},
+                           {18, 19, 20, 21, 22, 23}};
+
+  auto out = cl.forward({in0, in1, in2});
+
+  for (cnn_size_t i = 0; i < 4; i++) {
+    for (cnn_size_t j = 0; j < 2; j++) {
+      EXPECT_FLOAT_EQ(out_expected[i][j], out[0][i][j]);
     }
+  }
 
-    
-    out = cl.backward({out_expected});
+  out = cl.backward({out_expected});
 
-    for (cnn_size_t i = 0; i < 4; i++) {
-        for (cnn_size_t j = 0; j < 2; j++) {
-            EXPECT_FLOAT_EQ(in0[i][j], out[0][i][j]);
-            EXPECT_FLOAT_EQ(in1[i][j], out[1][i][j]);
-            EXPECT_FLOAT_EQ(in2[i][j], out[2][i][j]);
-        }
+  for (cnn_size_t i = 0; i < 4; i++) {
+    for (cnn_size_t j = 0; j < 2; j++) {
+      EXPECT_FLOAT_EQ(in0[i][j], out[0][i][j]);
+      EXPECT_FLOAT_EQ(in1[i][j], out[1][i][j]);
+      EXPECT_FLOAT_EQ(in2[i][j], out[2][i][j]);
     }
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_concat_layer.h
+++ b/test/test_concat_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -10,834 +10,846 @@
 namespace tiny_dnn {
 
 TEST(convolutional, setup_tiny) {
+  convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
-
-    EXPECT_EQ(l.parallelize(),           true);           // if layer can be parallelized
-    EXPECT_EQ(l.in_channels(),           cnn_size_t(3));  // num of input tensors
-    EXPECT_EQ(l.out_channels(),          cnn_size_t(2));  // num of output tensors
-    EXPECT_EQ(l.in_data_size(),          cnn_size_t(25)); // size of input tensors
-    EXPECT_EQ(l.out_data_size(),         cnn_size_t(18)); // size of output tensors
-    EXPECT_EQ(l.in_data_shape().size(),  cnn_size_t(1));  // number of inputs shapes
-    EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
-    EXPECT_EQ(l.weights().size(),        cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.weights_grads().size(),  cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.inputs().size(),         cnn_size_t(3));  // num of input edges
-    EXPECT_EQ(l.outputs().size(),        cnn_size_t(2));  // num of outpus edges
-    EXPECT_EQ(l.in_types().size(),       cnn_size_t(3));  // num of input data types
-    EXPECT_EQ(l.out_types().size(),      cnn_size_t(2));  // num of output data types
-    EXPECT_EQ(l.fan_in_size(),           cnn_size_t(9));  // num of incoming connections
-    EXPECT_EQ(l.fan_out_size(),          cnn_size_t(18)); // num of outgoing connections
-    EXPECT_STREQ(l.layer_type().c_str(), "conv");         // string with layer type
+  EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));     // num of input tensors
+  EXPECT_EQ(l.out_channels(), cnn_size_t(2));    // num of output tensors
+  EXPECT_EQ(l.in_data_size(), cnn_size_t(25));   // size of input tensors
+  EXPECT_EQ(l.out_data_size(), cnn_size_t(18));  // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(),
+            cnn_size_t(1));  // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
+  EXPECT_EQ(l.weights().size(), cnn_size_t(2));  // the wieghts vector size
+  EXPECT_EQ(l.weights_grads().size(),
+            cnn_size_t(2));                        // the wieghts vector size
+  EXPECT_EQ(l.inputs().size(), cnn_size_t(3));     // num of input edges
+  EXPECT_EQ(l.outputs().size(), cnn_size_t(2));    // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), cnn_size_t(3));   // num of input data types
+  EXPECT_EQ(l.out_types().size(), cnn_size_t(2));  // num of output data types
+  EXPECT_EQ(l.fan_in_size(), cnn_size_t(9));     // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), cnn_size_t(18));   // num of outgoing connections
+  EXPECT_STREQ(l.layer_type().c_str(), "conv");  // string with layer type
 }
 
-inline void randomize_tensor(tensor_t& tensor)
-{
-    for (auto& vec : tensor) {
-        uniform_rand(vec.begin(), vec.end(), -1.0f, 1.0f);
-    }
+inline void randomize_tensor(tensor_t& tensor) {
+  for (auto& vec : tensor) {
+    uniform_rand(vec.begin(), vec.end(), -1.0f, 1.0f);
+  }
 }
 
 // prepare tensor buffers for unit test
 class tensor_buf {
-public:
-    tensor_buf(tensor_buf& other)
-        : in_data_(other.in_data_), out_data_(other.out_data_) {
-        for (auto& d : in_data_) in_ptr_.push_back(&d);
-        for (auto& d : out_data_) out_ptr_.push_back(&d);
+ public:
+  tensor_buf(tensor_buf& other)
+      : in_data_(other.in_data_), out_data_(other.out_data_) {
+    for (auto& d : in_data_) in_ptr_.push_back(&d);
+    for (auto& d : out_data_) out_ptr_.push_back(&d);
+  }
+
+  explicit tensor_buf(const layer& l, bool randomize = true)
+      : in_data_(l.in_channels()),
+        out_data_(l.out_channels()),
+        in_ptr_(l.in_channels()),
+        out_ptr_(l.out_channels()) {
+    for (size_t i = 0; i < l.in_channels(); i++) {
+      in_data_[i].resize(1, vec_t(l.in_shape()[i].size()));
+      in_ptr_[i] = &in_data_[i];
     }
 
-    explicit tensor_buf(const layer& l, bool randomize = true)
-    : in_data_(l.in_channels()), out_data_(l.out_channels()),
-      in_ptr_(l.in_channels()),  out_ptr_(l.out_channels()) {
-
-        for (size_t i = 0; i < l.in_channels(); i++) {
-            in_data_[i].resize(1, vec_t(l.in_shape()[i].size()));
-            in_ptr_[i] = &in_data_[i];
-        }
-
-        for (size_t i = 0; i < l.out_channels(); i++) {
-            out_data_[i].resize(1, vec_t(l.out_shape()[i].size()));
-            out_ptr_[i] = &out_data_[i];
-        }
-
-        if (randomize) {
-            for (auto& tensor : in_data_)  randomize_tensor(tensor);
-            for (auto& tensor : out_data_) randomize_tensor(tensor);
-        }
+    for (size_t i = 0; i < l.out_channels(); i++) {
+      out_data_[i].resize(1, vec_t(l.out_shape()[i].size()));
+      out_ptr_[i] = &out_data_[i];
     }
 
-    tensor_t& in_at(size_t i) { return in_data_[i]; }
-    tensor_t& out_at(size_t i) { return out_data_[i]; }
+    if (randomize) {
+      for (auto& tensor : in_data_) randomize_tensor(tensor);
+      for (auto& tensor : out_data_) randomize_tensor(tensor);
+    }
+  }
 
-    std::vector<tensor_t*>& in_buf()  { return in_ptr_; }
-    std::vector<tensor_t*>& out_buf() { return out_ptr_; }
+  tensor_t& in_at(size_t i) { return in_data_[i]; }
+  tensor_t& out_at(size_t i) { return out_data_[i]; }
 
-private:
-    std::vector<tensor_t> in_data_, out_data_;
-    std::vector<tensor_t*> in_ptr_, out_ptr_;
+  std::vector<tensor_t*>& in_buf() { return in_ptr_; }
+  std::vector<tensor_t*>& out_buf() { return out_ptr_; }
+
+ private:
+  std::vector<tensor_t> in_data_, out_data_;
+  std::vector<tensor_t*> in_ptr_, out_ptr_;
 };
 
 TEST(convolutional, fprop) {
+  convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
+  tensor_buf buf(l, false);
 
-    tensor_buf buf(l, false);
+  // short-hand references to the payload vectors
+  vec_t &in = buf.in_at(0)[0], &out = buf.out_at(0)[0],
+        &weight = buf.in_at(1)[0];
 
-    // short-hand references to the payload vectors
-    vec_t &in     = buf.in_at(0)[0]
-        , &out    = buf.out_at(0)[0]
-        , &weight = buf.in_at(1)[0];
+  ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18));  // weight
 
-    ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18)); // weight
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  l.setup(false);
+  {
+    l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.setup(false);
-    {
-        l.forward_propagation(buf.in_buf(), buf.out_buf());
+    for (auto o : out) EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
+  }
 
-        for (auto o: out)
-            EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
-    }
+  weight[0] = 0.3f;
+  weight[1] = 0.1f;
+  weight[2] = 0.2f;
+  weight[3] = 0.0f;
+  weight[4] = -0.1f;
+  weight[5] = -0.1f;
+  weight[6] = 0.05f;
+  weight[7] = -0.2f;
+  weight[8] = 0.05f;
 
-    weight[0] = 0.3f;  weight[1] = 0.1f; weight[2] = 0.2f;
-    weight[3] = 0.0f;  weight[4] =-0.1f; weight[5] =-0.1f;
-    weight[6] = 0.05f; weight[7] =-0.2f; weight[8] = 0.05f;
+  weight[9] = 0.0f;
+  weight[10] = -0.1f;
+  weight[11] = 0.1f;
+  weight[12] = 0.1f;
+  weight[13] = -0.2f;
+  weight[14] = 0.3f;
+  weight[15] = 0.2f;
+  weight[16] = -0.3f;
+  weight[17] = 0.2f;
 
-    weight[9]  = 0.0f; weight[10] =-0.1f; weight[11] = 0.1f;
-    weight[12] = 0.1f; weight[13] =-0.2f; weight[14] = 0.3f;
-    weight[15] = 0.2f; weight[16] =-0.3f; weight[17] = 0.2f;
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 1;
+  in[3] = 5;
+  in[4] = 2;
+  in[5] = 3;
+  in[6] = 0;
+  in[7] = 2;
+  in[8] = 0;
+  in[9] = 1;
+  in[10] = 0;
+  in[11] = 6;
+  in[12] = 1;
+  in[13] = 1;
+  in[14] = 10;
+  in[15] = 3;
+  in[16] = -1;
+  in[17] = 2;
+  in[18] = 9;
+  in[19] = 0;
+  in[20] = 1;
+  in[21] = 2;
+  in[22] = 1;
+  in[23] = 5;
+  in[24] = 5;
 
-    in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-    in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-    in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-    in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-    in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+  {
+    l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    {
-        l.forward_propagation(buf.in_buf(), buf.out_buf());
-
-        EXPECT_NEAR(0.4875026, out[0], 1E-5);
-        EXPECT_NEAR(0.8388910, out[1], 1E-5);
-        EXPECT_NEAR(0.8099984, out[2], 1E-5);
-        EXPECT_NEAR(0.7407749, out[3], 1E-5);
-        EXPECT_NEAR(0.5000000, out[4], 1E-5);
-        EXPECT_NEAR(0.1192029, out[5], 1E-5);
-        EXPECT_NEAR(0.5986877, out[6], 1E-5);
-        EXPECT_NEAR(0.7595109, out[7], 1E-5);
-        EXPECT_NEAR(0.6899745, out[8], 1E-5);
-    }
+    EXPECT_NEAR(0.4875026, out[0], 1E-5);
+    EXPECT_NEAR(0.8388910, out[1], 1E-5);
+    EXPECT_NEAR(0.8099984, out[2], 1E-5);
+    EXPECT_NEAR(0.7407749, out[3], 1E-5);
+    EXPECT_NEAR(0.5000000, out[4], 1E-5);
+    EXPECT_NEAR(0.1192029, out[5], 1E-5);
+    EXPECT_NEAR(0.5986877, out[6], 1E-5);
+    EXPECT_NEAR(0.7595109, out[7], 1E-5);
+    EXPECT_NEAR(0.6899745, out[8], 1E-5);
+  }
 }
 
 TEST(convolutional, with_stride) {
-    /*
-      forward - pass:
+  /*
+    forward - pass:
 
-      [0,1,2,3,4, 
-       1,2,3,4,5,          [1,1,1,           [ 9.5,    18.5,      
-       2,3,4,5,6,  *  0.5*  1,1,1,  + 0.5 = 
-       3,4,5,6,7,           1,1,1]            18.5,    27.5]
-       4,5,6,7,8]
-    
-    */
+    [0,1,2,3,4,
+     1,2,3,4,5,          [1,1,1,           [ 9.5,    18.5,
+     2,3,4,5,6,  *  0.5*  1,1,1,  + 0.5 =
+     3,4,5,6,7,           1,1,1]            18.5,    27.5]
+     4,5,6,7,8]
 
-    float_t in[] = {
-        0.0f, 1.0f, 2.0f, 3.0f, 4.0f,
-        1.0f, 2.0f, 3.0f, 4.0f, 5.0f,
-        2.0f, 3.0f, 4.0f, 5.0f, 6.0f,
-        3.0f, 4.0f, 5.0f, 6.0f, 7.0f,
-        4.0f, 5.0f, 6.0f, 7.0f, 8.0f
-    };
+  */
 
-    float_t w[] = {
-        0.5f, 0.5f, 0.5f,
-        0.5f, 0.5f, 0.5f,
-        0.5f, 0.5f, 0.5f
-    };
+  float_t in[] = {0.0f, 1.0f, 2.0f, 3.0f, 4.0f, 1.0f, 2.0f, 3.0f, 4.0f,
+                  5.0f, 2.0f, 3.0f, 4.0f, 5.0f, 6.0f, 3.0f, 4.0f, 5.0f,
+                  6.0f, 7.0f, 4.0f, 5.0f, 6.0f, 7.0f, 8.0f};
 
-    float_t b[] = {
-        0.5f
-    };
+  float_t w[] = {0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f, 0.5f};
 
-    float_t expected_out[] = {
-         9.5f, 18.5f,
-        18.5f, 27.5f
-    };
+  float_t b[] = {0.5f};
 
-    convolutional_layer<identity> l(5, 5, 3, 1, 1, padding::valid, true, 2, 2);
-    tensor_buf data(l, false), grad(l, false);
+  float_t expected_out[] = {9.5f, 18.5f, 18.5f, 27.5f};
 
-    data.in_at(0)[0] = vec_t(in, in + 25);
-    data.in_at(1)[0] = vec_t(w, w + 9);
-    data.in_at(2)[0] = vec_t(b, b + 1);
+  convolutional_layer<identity> l(5, 5, 3, 1, 1, padding::valid, true, 2, 2);
+  tensor_buf data(l, false), grad(l, false);
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
+  data.in_at(0)[0] = vec_t(in, in + 25);
+  data.in_at(1)[0] = vec_t(w, w + 9);
+  data.in_at(2)[0] = vec_t(b, b + 1);
 
-    vec_t& actual = data.out_at(0)[0];
+  l.forward_propagation(data.in_buf(), data.out_buf());
 
-    for (size_t i = 0; i < 4; i++) {
-        ASSERT_DOUBLE_EQ(expected_out[i], actual[i]);
-    }
+  vec_t& actual = data.out_at(0)[0];
 
+  for (size_t i = 0; i < 4; i++) {
+    ASSERT_DOUBLE_EQ(expected_out[i], actual[i]);
+  }
 
-    float_t curr_delta[] = {
-        -1.0f, 2.0f,
-        3.0f, 0.0f,
-    };
+  float_t curr_delta[] = {
+      -1.0f, 2.0f, 3.0f, 0.0f,
+  };
 
-    float_t expected_prev_delta[] = {
-        -0.5f, -0.5f, 0.5f, 1.0f, 1.0f,
-        -0.5f, -0.5f, 0.5f, 1.0f, 1.0f,
-         1.0f,  1.0f, 2.0f, 1.0f, 1.0f,
-         1.5f,  1.5f, 1.5f, 0.0f, 0.0f,
-         1.5f,  1.5f, 1.5f, 0.0f, 0.0f
-    };
+  float_t expected_prev_delta[] = {-0.5f, -0.5f, 0.5f, 1.0f, 1.0f, -0.5f, -0.5f,
+                                   0.5f,  1.0f,  1.0f, 1.0f, 1.0f, 2.0f,  1.0f,
+                                   1.0f,  1.5f,  1.5f, 1.5f, 0.0f, 0.0f,  1.5f,
+                                   1.5f,  1.5f,  0.0f, 0.0f};
 
-    float_t expected_dw[] = {
-        10.0f, 14.0f, 18.0f,
-        14.0f, 18.0f, 22.0f,
-        18.0f, 22.0f, 26.0f
-    };
+  float_t expected_dw[] = {10.0f, 14.0f, 18.0f, 14.0f, 18.0f,
+                           22.0f, 18.0f, 22.0f, 26.0f};
 
-    float_t expected_db[] = {
-        4.0f
-    };
+  float_t expected_db[] = {4.0f};
 
-    grad.out_at(0)[0] = vec_t(curr_delta, curr_delta + 4);
+  grad.out_at(0)[0] = vec_t(curr_delta, curr_delta + 4);
 
-    l.back_propagation(data.in_buf(), data.out_buf(), grad.out_buf(), grad.in_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad.out_buf(),
+                     grad.in_buf());
 
-    const vec_t& actual_delta = grad.in_at(0)[0];
-    const vec_t& actual_dw = grad.in_at(1)[0];
-    const vec_t& actual_db = grad.in_at(2)[0];
+  const vec_t& actual_delta = grad.in_at(0)[0];
+  const vec_t& actual_dw = grad.in_at(1)[0];
+  const vec_t& actual_db = grad.in_at(2)[0];
 
-    for (size_t i = 0; i < 25; i++) {
-        ASSERT_DOUBLE_EQ(actual_delta[i], expected_prev_delta[i]);
-    }
-    for (size_t i = 0; i < 9; i++) {
-        ASSERT_DOUBLE_EQ(actual_dw[i], expected_dw[i]);
-    }
-    ASSERT_DOUBLE_EQ(actual_db[0], expected_db[0]);
-
+  for (size_t i = 0; i < 25; i++) {
+    ASSERT_DOUBLE_EQ(actual_delta[i], expected_prev_delta[i]);
+  }
+  for (size_t i = 0; i < 9; i++) {
+    ASSERT_DOUBLE_EQ(actual_dw[i], expected_dw[i]);
+  }
+  ASSERT_DOUBLE_EQ(actual_db[0], expected_db[0]);
 }
 
 // test for AVX backends
 
 #ifdef CNN_USE_AVX
 TEST(convolutional, fprop_avx) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2);
+  tensor_buf buf(l), buf2(l);
 
-    tensor_buf buf(l), buf2(l);
+  l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf.out_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(buf.in_buf(), buf2.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf2.out_buf());
+  vec_t& out_avx = buf2.out_at(0)[0];
+  vec_t& out_noavx = buf.out_at(0)[0];
 
-    vec_t& out_avx = buf2.out_at(0)[0];
-    vec_t& out_noavx = buf.out_at(0)[0];
-
-    for (size_t i = 0; i < out_avx.size(); i++) {
-        // check if all outputs between default backend and avx backend are the same
-        EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-    }
+  for (size_t i = 0; i < out_avx.size(); i++) {
+    // check if all outputs between default backend and avx backend are the same
+    EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
+  }
 }
 
 TEST(convolutional, bprop_avx) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2);
+  tensor_buf data(l), grad1(l);
+  tensor_buf grad2(grad1);
 
-    tensor_buf data(l), grad1(l);
-    tensor_buf grad2(grad1);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(),
+                     grad1.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(), grad1.in_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(),
+                     grad2.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(), grad2.in_buf());
-
-    for (size_t ch = 0; ch < l.out_channels(); ch++) {
-        vec_t& out_noavx = grad1.in_at(ch)[0];
-        vec_t& out_avx = grad2.in_at(ch)[0];
-        for (size_t i = 0; i < out_avx.size(); i++) {
-            EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-        }
+  for (size_t ch = 0; ch < l.out_channels(); ch++) {
+    vec_t& out_noavx = grad1.in_at(ch)[0];
+    vec_t& out_avx = grad2.in_at(ch)[0];
+    for (size_t i = 0; i < out_avx.size(); i++) {
+      EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
     }
+  }
 }
 
 TEST(convolutional, fprop_avx_1x1out) {
+  convolutional_layer<sigmoid> l(5, 5, 5, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 5, 1, 2);
+  tensor_buf buf(l), buf2(l);
 
-    tensor_buf buf(l), buf2(l);
+  l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf.out_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(buf.in_buf(), buf2.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf2.out_buf());
+  vec_t& out_avx = buf2.out_at(0)[0];
+  vec_t& out_noavx = buf.out_at(0)[0];
 
-    vec_t& out_avx = buf2.out_at(0)[0];
-    vec_t& out_noavx = buf.out_at(0)[0];
-
-    for (size_t i = 0; i < out_avx.size(); i++) {
-        EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-    }
+  for (size_t i = 0; i < out_avx.size(); i++) {
+    EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
+  }
 }
 
 TEST(convolutional, bprop_avx_1x1out) {
+  convolutional_layer<sigmoid> l(5, 5, 5, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 5, 1, 2);
+  tensor_buf data(l), grad1(l);
+  tensor_buf grad2(grad1);
 
-    tensor_buf data(l), grad1(l);
-    tensor_buf grad2(grad1);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(),
+                     grad1.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(), grad1.in_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(),
+                     grad2.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(), grad2.in_buf());
-
-    for (size_t ch = 0; ch < l.out_channels(); ch++) {
-        vec_t& out_noavx = grad1.in_at(ch)[0];
-        vec_t& out_avx = grad2.in_at(ch)[0];
-        for (size_t i = 0; i < out_avx.size(); i++) {
-            EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-        }
+  for (size_t ch = 0; ch < l.out_channels(); ch++) {
+    vec_t& out_noavx = grad1.in_at(ch)[0];
+    vec_t& out_avx = grad2.in_at(ch)[0];
+    for (size_t i = 0; i < out_avx.size(); i++) {
+      EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
     }
+  }
 }
 
 TEST(convolutional, fprop_avx_hstride) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 1, 2);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 1, 2);
+  tensor_buf buf(l), buf2(l);
 
-    tensor_buf buf(l), buf2(l);
+  l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf.out_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(buf.in_buf(), buf2.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf2.out_buf());
+  vec_t& out_avx = buf2.out_at(0)[0];
+  vec_t& out_noavx = buf.out_at(0)[0];
 
-    vec_t& out_avx = buf2.out_at(0)[0];
-    vec_t& out_noavx = buf.out_at(0)[0];
-
-    for (size_t i = 0; i < out_avx.size(); i++) {
-        EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-    }
+  for (size_t i = 0; i < out_avx.size(); i++) {
+    EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
+  }
 }
 
 TEST(convolutional, bprop_avx_hstride) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 1, 2);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 1, 2);
+  tensor_buf data(l), grad1(l);
+  tensor_buf grad2(grad1);
 
-    tensor_buf data(l), grad1(l);
-    tensor_buf grad2(grad1);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(),
+                     grad1.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(), grad1.in_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(),
+                     grad2.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(), grad2.in_buf());
-
-    for (size_t ch = 0; ch < l.out_channels(); ch++) {
-        vec_t& out_noavx = grad1.in_at(ch)[0];
-        vec_t& out_avx = grad2.in_at(ch)[0];
-        for (size_t i = 0; i < out_avx.size(); i++) {
-            EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-        }
+  for (size_t ch = 0; ch < l.out_channels(); ch++) {
+    vec_t& out_noavx = grad1.in_at(ch)[0];
+    vec_t& out_avx = grad2.in_at(ch)[0];
+    for (size_t i = 0; i < out_avx.size(); i++) {
+      EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
     }
+  }
 }
 
 TEST(convolutional, fprop_avx_hstride_1x1out) {
+  convolutional_layer<sigmoid> l(5, 5, 5, 1, 2, padding::valid, true, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 5, 1, 2, padding::valid, true, 1, 2);
+  tensor_buf buf(l), buf2(l);
 
-    tensor_buf buf(l), buf2(l);
+  l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf.out_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(buf.in_buf(), buf2.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf2.out_buf());
+  vec_t& out_avx = buf2.out_at(0)[0];
+  vec_t& out_noavx = buf.out_at(0)[0];
 
-    vec_t& out_avx = buf2.out_at(0)[0];
-    vec_t& out_noavx = buf.out_at(0)[0];
-
-    for (size_t i = 0; i < out_avx.size(); i++) {
-        EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-    }
+  for (size_t i = 0; i < out_avx.size(); i++) {
+    EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
+  }
 }
 
 TEST(convolutional, bprop_avx_hstride_1x1out) {
+  convolutional_layer<sigmoid> l(5, 5, 5, 1, 2, padding::valid, true, 1, 2);
 
-    convolutional_layer<sigmoid> l(5, 5, 5, 1, 2, padding::valid, true, 1, 2);
+  tensor_buf data(l), grad1(l);
+  tensor_buf grad2(grad1);
 
-    tensor_buf data(l), grad1(l);
-    tensor_buf grad2(grad1);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(),
+                     grad1.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(), grad1.in_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(),
+                     grad2.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(), grad2.in_buf());
-
-    for (size_t ch = 0; ch < l.out_channels(); ch++) {
-        vec_t& out_noavx = grad1.in_at(ch)[0];
-        vec_t& out_avx = grad2.in_at(ch)[0];
-        for (size_t i = 0; i < out_avx.size(); i++) {
-            EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-        }
+  for (size_t ch = 0; ch < l.out_channels(); ch++) {
+    vec_t& out_noavx = grad1.in_at(ch)[0];
+    vec_t& out_avx = grad2.in_at(ch)[0];
+    for (size_t i = 0; i < out_avx.size(); i++) {
+      EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
     }
+  }
 }
 
 TEST(convolutional, fprop_avx_wstride) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 2, 1);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 2, 1);
+  tensor_buf buf(l), buf2(l);
 
-    tensor_buf buf(l), buf2(l);
+  l.forward_propagation(buf.in_buf(), buf.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf.out_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(buf.in_buf(), buf2.out_buf());
 
-    l.forward_propagation(buf.in_buf(), buf2.out_buf());
+  vec_t& out_avx = buf2.out_at(0)[0];
+  vec_t& out_noavx = buf.out_at(0)[0];
 
-    vec_t& out_avx = buf2.out_at(0)[0];
-    vec_t& out_noavx = buf.out_at(0)[0];
-
-    for (size_t i = 0; i < out_avx.size(); i++) {
-        EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-    }
+  for (size_t i = 0; i < out_avx.size(); i++) {
+    EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
+  }
 }
 
 TEST(convolutional, bprop_avx_wstride) {
+  convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 2, 1);
 
-    convolutional_layer<sigmoid> l(7, 7, 5, 1, 2, padding::valid, true, 2, 1);
+  tensor_buf data(l), grad1(l);
+  tensor_buf grad2(grad1);
 
-    tensor_buf data(l), grad1(l);
-    tensor_buf grad2(grad1);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(),
+                     grad1.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad1.out_buf(), grad1.in_buf());
+  l.set_backend_type(tiny_dnn::core::backend_t::avx);
 
-    l.set_backend_type(tiny_dnn::core::backend_t::avx);
+  l.forward_propagation(data.in_buf(), data.out_buf());
+  l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(),
+                     grad2.in_buf());
 
-    l.forward_propagation(data.in_buf(), data.out_buf());
-    l.back_propagation(data.in_buf(), data.out_buf(), grad2.out_buf(), grad2.in_buf());
-
-    for (size_t ch = 0; ch < l.out_channels(); ch++) {
-        vec_t& out_noavx = grad1.in_at(ch)[0];
-        vec_t& out_avx = grad2.in_at(ch)[0];
-        for (size_t i = 0; i < out_avx.size(); i++) {
-            EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
-        }
+  for (size_t ch = 0; ch < l.out_channels(); ch++) {
+    vec_t& out_noavx = grad1.in_at(ch)[0];
+    vec_t& out_avx = grad2.in_at(ch)[0];
+    for (size_t i = 0; i < out_avx.size(); i++) {
+      EXPECT_NEAR(out_avx[i], out_noavx[i], 1E-5);
     }
+  }
 }
 
-#endif // CNN_USE_AVX
+#endif  // CNN_USE_AVX
 
 #ifdef CNN_USE_NNPACK
 TEST(convolutional, fprop_nnp) {
+  convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                 core::backend_t::nnpack);
 
-    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-        padding::valid, true, 1, 1, core::backend_t::nnpack);
+  // layer::forward_propagation expects tensors, even if we feed only one input
+  // at a time
+  auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    // layer::forward_propagation expects tensors, even if we feed only one input at a time
-    auto create_simple_tensor = [](size_t vector_size) {
-        return tensor_t(1, vec_t(vector_size));
-    };
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor = create_simple_tensor(25),
+           out_tensor = create_simple_tensor(18),
+           a_tensor = create_simple_tensor(18),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor = create_simple_tensor(2);
 
-    // create simple tensors that wrap the payload vectors of the correct size
-    tensor_t in_tensor     = create_simple_tensor(25)
-           , out_tensor    = create_simple_tensor(18)
-           , a_tensor      = create_simple_tensor(18)
-           , weight_tensor = create_simple_tensor(18)
-           , bias_tensor   = create_simple_tensor(2);
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    // short-hand references to the payload vectors
-    vec_t &in     = in_tensor[0]
-        , &out    = out_tensor[0]
-        , &weight = weight_tensor[0];
+  ASSERT_EQ(l.in_shape()[1].size(), 18);  // weight
 
-    ASSERT_EQ(l.in_shape()[1].size(), 18); // weight
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  std::vector<tensor_t*> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
+  out_data.push_back(&a_tensor);
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-    std::vector<tensor_t*> in_data, out_data;
-    in_data.push_back(&in_tensor);
-    in_data.push_back(&weight_tensor);
-    in_data.push_back(&bias_tensor);
-    out_data.push_back(&out_tensor);
-    out_data.push_back(&a_tensor);
-    l.setup(false);
-    {
-        l.forward_propagation(in_data, out_data);
+    for (auto o : out) EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
+  }
 
-        for (auto o: out)
-            EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
-    }
+  weight[0] = 0.3;
+  weight[1] = 0.1;
+  weight[2] = 0.2;
+  weight[3] = 0.0;
+  weight[4] = -0.1;
+  weight[5] = -0.1;
+  weight[6] = 0.05;
+  weight[7] = -0.2;
+  weight[8] = 0.05;
 
-    weight[0] = 0.3;  weight[1] = 0.1; weight[2] = 0.2;
-    weight[3] = 0.0;  weight[4] =-0.1; weight[5] =-0.1;
-    weight[6] = 0.05; weight[7] =-0.2; weight[8] = 0.05;
+  weight[9] = 0.0;
+  weight[10] = -0.1;
+  weight[11] = 0.1;
+  weight[12] = 0.1;
+  weight[13] = -0.2;
+  weight[14] = 0.3;
+  weight[15] = 0.2;
+  weight[16] = -0.3;
+  weight[17] = 0.2;
 
-    weight[9]  = 0.0; weight[10] =-0.1; weight[11] = 0.1;
-    weight[12] = 0.1; weight[13] =-0.2; weight[14] = 0.3;
-    weight[15] = 0.2; weight[16] =-0.3; weight[17] = 0.2;
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 1;
+  in[3] = 5;
+  in[4] = 2;
+  in[5] = 3;
+  in[6] = 0;
+  in[7] = 2;
+  in[8] = 0;
+  in[9] = 1;
+  in[10] = 0;
+  in[11] = 6;
+  in[12] = 1;
+  in[13] = 1;
+  in[14] = 10;
+  in[15] = 3;
+  in[16] = -1;
+  in[17] = 2;
+  in[18] = 9;
+  in[19] = 0;
+  in[20] = 1;
+  in[21] = 2;
+  in[22] = 1;
+  in[23] = 5;
+  in[24] = 5;
 
-    in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-    in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-    in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-    in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-    in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+  {
+    l.forward_propagation(in_data, out_data);
 
-    {
-        l.forward_propagation(in_data, out_data);
-
-        EXPECT_NEAR(0.4875026, out[0], 1E-5);
-        EXPECT_NEAR(0.8388910, out[1], 1E-5);
-        EXPECT_NEAR(0.8099984, out[2], 1E-5);
-        EXPECT_NEAR(0.7407749, out[3], 1E-5);
-        EXPECT_NEAR(0.5000000, out[4], 1E-5);
-        EXPECT_NEAR(0.1192029, out[5], 1E-5);
-        EXPECT_NEAR(0.5986877, out[6], 1E-5);
-        EXPECT_NEAR(0.7595109, out[7], 1E-5);
-        EXPECT_NEAR(0.6899745, out[8], 1E-5);
-    }
-
+    EXPECT_NEAR(0.4875026, out[0], 1E-5);
+    EXPECT_NEAR(0.8388910, out[1], 1E-5);
+    EXPECT_NEAR(0.8099984, out[2], 1E-5);
+    EXPECT_NEAR(0.7407749, out[3], 1E-5);
+    EXPECT_NEAR(0.5000000, out[4], 1E-5);
+    EXPECT_NEAR(0.1192029, out[5], 1E-5);
+    EXPECT_NEAR(0.5986877, out[6], 1E-5);
+    EXPECT_NEAR(0.7595109, out[7], 1E-5);
+    EXPECT_NEAR(0.6899745, out[8], 1E-5);
+  }
 }
 #endif
 
-TEST(convolutional, gradient_check) { // tanh - mse
-    network<sequential> nn;
-    nn << convolutional_layer<tan_h>(5, 5, 3, 1, 1);
+TEST(convolutional, gradient_check) {  // tanh - mse
+  network<sequential> nn;
+  nn << convolutional_layer<tan_h>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-                                       test_data.second,
-                                       epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check2) { // sigmoid - mse
-    network<sequential> nn;
-    nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+TEST(convolutional, gradient_check2) {  // sigmoid - mse
+  network<sequential> nn;
+  nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-                                       test_data.second,
-                                       epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check3) { // rectified - mse
-    network<sequential> nn;
+TEST(convolutional, gradient_check3) {  // rectified - mse
+  network<sequential> nn;
 
-    nn << convolutional_layer<rectified_linear>(5, 5, 3, 1, 1);
+  nn << convolutional_layer<rectified_linear>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-                                       test_data.second,
-                                       epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check4) { // identity - mse
-    network<sequential> nn;
+TEST(convolutional, gradient_check4) {  // identity - mse
+  network<sequential> nn;
 
-    nn << convolutional_layer<identity>(5, 5, 3, 1, 1);
+  nn << convolutional_layer<identity>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-                                       test_data.second,
-                                       epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check5) { // sigmoid - cross-entropy
-    network<sequential> nn;
+TEST(convolutional, gradient_check5) {  // sigmoid - cross-entropy
+  network<sequential> nn;
 
-    nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+  nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<cross_entropy>(test_data.first,
-                                                 test_data.second,
-                                                 epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<cross_entropy>(
+      test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check6) { // sigmoid - absolute
-    network<sequential> nn;
+TEST(convolutional, gradient_check6) {  // sigmoid - absolute
+  network<sequential> nn;
 
-    nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+  nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<absolute>(test_data.first,
-                                            test_data.second,
-                                            epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<absolute>(test_data.first, test_data.second,
+                                          epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check7) { // sigmoid - absolute eps
-    network<sequential> nn;
+TEST(convolutional, gradient_check7) {  // sigmoid - absolute eps
+  network<sequential> nn;
 
-    nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+  nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<absolute_eps<100>>(test_data.first,
-                                                     test_data.second,
-                                                     epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<absolute_eps<100>>(
+      test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check8_pad_same) { // sigmoid - mse - padding same
-    network<sequential> nn;
+TEST(convolutional, gradient_check8_pad_same) {  // sigmoid - mse - padding same
+  network<sequential> nn;
 
-    nn << convolutional_layer<sigmoid> (5, 5, 3, 1, 1, padding::same,
-                                        true, 1, 1, core::backend_t::tiny_dnn);
+  nn << convolutional_layer<sigmoid>(5, 5, 3, 1, 1, padding::same, true, 1, 1,
+                                     core::backend_t::tiny_dnn);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-                                       test_data.second,
-                                       epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check9_w_stride) { // sigmoid - mse - w_stride > 1
-    network<sequential> nn;
+TEST(convolutional, gradient_check9_w_stride) {  // sigmoid - mse - w_stride > 1
+  network<sequential> nn;
 
-    nn << convolutional_layer<identity>(3, 3, 1, 1, 1, padding::valid,
-        true, 2, 1, core::backend_t::tiny_dnn);
+  nn << convolutional_layer<identity>(3, 3, 1, 1, 1, padding::valid, true, 2, 1,
+                                      core::backend_t::tiny_dnn);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-        test_data.second,
-        epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check10_h_stride) { // sigmoid - mse - h_stride > 1
-    network<sequential> nn;
+TEST(convolutional,
+     gradient_check10_h_stride) {  // sigmoid - mse - h_stride > 1
+  network<sequential> nn;
 
-    nn << convolutional_layer<identity>(3, 3, 1, 1, 1, padding::valid,
-        true, 1, 2, core::backend_t::tiny_dnn);
+  nn << convolutional_layer<identity>(3, 3, 1, 1, 1, padding::valid, true, 1, 2,
+                                      core::backend_t::tiny_dnn);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-        test_data.second,
-        epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, gradient_check11_connection_tbl) { // sigmoid - mse - has connection-tbl
-    network<sequential> nn;
-    bool tbl[3 * 3] = {
-        true, false, true,
-        false, true, false,
-        true, true, false };
+TEST(convolutional,
+     gradient_check11_connection_tbl) {  // sigmoid - mse - has connection-tbl
+  network<sequential> nn;
+  bool tbl[3 * 3] = {true, false, true, false, true, false, true, true, false};
 
-    connection_table connections(tbl, 3, 3);
+  connection_table connections(tbl, 3, 3);
 
-    nn << convolutional_layer<sigmoid>(7, 7, 3, 3, 1, connections, padding::valid,
-        true, 1, 1, core::backend_t::tiny_dnn);
+  nn << convolutional_layer<sigmoid>(7, 7, 3, 3, 1, connections, padding::valid,
+                                     true, 1, 1, core::backend_t::tiny_dnn);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
-        test_data.second,
-        epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(convolutional, read_write)
-{
-    convolutional_layer<tan_h> l1(5, 5, 3, 1, 1);
-    convolutional_layer<tan_h> l2(5, 5, 3, 1, 1);
+TEST(convolutional, read_write) {
+  convolutional_layer<tan_h> l1(5, 5, 3, 1, 1);
+  convolutional_layer<tan_h> l2(5, 5, 3, 1, 1);
 
-    l1.init_weight();
-    l2.init_weight();
+  l1.init_weight();
+  l2.init_weight();
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
 TEST(convolutional, read_write2) {
 #define O true
 #define X false
-    static const bool connection[] = {
-        O, X, X, X, O, O,
-        O, O, X, X, X, O,
-        O, O, O, X, X, X
-    };
+  static const bool connection[] = {O, X, X, X, O, O, O, O, X,
+                                    X, X, O, O, O, O, X, X, X};
 #undef O
 #undef X
-    convolutional_layer<tan_h> layer1(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
-    convolutional_layer<tan_h> layer2(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
-    layer1.init_weight();
-    layer2.init_weight();
+  convolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+                                    connection_table(connection, 3, 6));
+  convolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+                                    connection_table(connection, 3, 6));
+  layer1.init_weight();
+  layer2.init_weight();
 
-    serialization_test(layer1, layer2);
+  serialization_test(layer1, layer2);
 }
 
-
 TEST(convolutional, copy_and_pad_input_valid) {
+  conv_params params;
+  params.in = shape3d(5, 5, 1);
+  params.weight = shape3d(3, 3, 2);
+  params.in_padded = shape3d(5, 5, 1);
+  params.out = shape3d(3, 3, 1);
+  params.pad_type = padding::valid;  // test target
+  params.w_stride = 1;
+  params.h_stride = 1;
 
-    conv_params params;
-    params.in        = shape3d(5,5,1);
-    params.weight    = shape3d(3,3,2);
-    params.in_padded = shape3d(5,5,1);
-    params.out       = shape3d(3,3,1);
-    params.pad_type  = padding::valid; // test target
-    params.w_stride  = 1;
-    params.h_stride  = 1;
+  Conv2d conv2d_op;
+  conv2d_op.setParams(&params);
 
-    Conv2d conv2d_op;
-           conv2d_op.setParams(&params);
+  auto create_tensor = [](cnn_size_t batch_size, cnn_size_t vector_size) {
+    return tensor_t(batch_size, vec_t(vector_size));
+  };
 
-    auto create_tensor = [](cnn_size_t batch_size,
-                            cnn_size_t vector_size) {
-        return tensor_t(batch_size, vec_t(vector_size));
-    };
+  tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
 
-    tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
+  fill_tensor(in_tensor, float_t(1));
 
-    fill_tensor(in_tensor, float_t(1));
+  conv2d_op.copy_and_pad_input(in_tensor, out_tensor);
 
-    conv2d_op.copy_and_pad_input(in_tensor, out_tensor);
-
-    for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
-        EXPECT_EQ(out_tensor[0][i], float_t(1));
-    }
+  for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
+    EXPECT_EQ(out_tensor[0][i], float_t(1));
+  }
 }
 
 TEST(convolutional, copy_and_pad_input_same) {
+  conv_params params;
+  params.in = shape3d(5, 5, 1);
+  params.weight = shape3d(3, 3, 2);
+  params.in_padded = shape3d(7, 7, 1);
+  params.out = shape3d(3, 3, 1);
+  params.pad_type = padding::same;  // test target
+  params.w_stride = 1;
+  params.h_stride = 1;
 
-    conv_params params;
-    params.in        = shape3d(5,5,1);
-    params.weight    = shape3d(3,3,2);
-    params.in_padded = shape3d(7,7,1);
-    params.out       = shape3d(3,3,1);
-    params.pad_type  = padding::same; // test target
-    params.w_stride  = 1;
-    params.h_stride  = 1;
+  Conv2d conv2d_op;
+  conv2d_op.setParams(&params);
 
-    Conv2d conv2d_op;
-           conv2d_op.setParams(&params);
+  auto create_tensor = [](cnn_size_t batch_size, cnn_size_t vector_size) {
+    return tensor_t(batch_size, vec_t(vector_size));
+  };
 
-    auto create_tensor = [](cnn_size_t batch_size,
-                            cnn_size_t vector_size) {
-        return tensor_t(batch_size, vec_t(vector_size));
-    };
+  tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
 
-    tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
+  fill_tensor(in_tensor, float_t(1));
 
-    fill_tensor(in_tensor, float_t(1));
+  /* @in_tensor   --->   @out_tensor
+   *
+   *    1 1 1             0 0 0 0 0
+   *    1 1 1             0 1 1 1 0
+   *    1 1 1             0 1 1 1 0
+   *                      0 1 1 1 0
+   *                      0 0 0 0 0
+   */
 
-    /* @in_tensor   --->   @out_tensor
-     *
-     *    1 1 1             0 0 0 0 0
-     *    1 1 1             0 1 1 1 0
-     *    1 1 1             0 1 1 1 0
-     *                      0 1 1 1 0
-     *                      0 0 0 0 0
-     */
+  conv2d_op.copy_and_pad_input(in_tensor, out_tensor);
 
-    conv2d_op.copy_and_pad_input(in_tensor, out_tensor);
-
-    EXPECT_EQ(out_tensor[0][7],  float_t(0));
-    EXPECT_EQ(out_tensor[0][8],  float_t(1));
-    EXPECT_EQ(out_tensor[0][9],  float_t(1));
-    EXPECT_EQ(out_tensor[0][10], float_t(1));
-    EXPECT_EQ(out_tensor[0][11], float_t(1));
-    EXPECT_EQ(out_tensor[0][12], float_t(1));
-    EXPECT_EQ(out_tensor[0][13], float_t(0));
+  EXPECT_EQ(out_tensor[0][7], float_t(0));
+  EXPECT_EQ(out_tensor[0][8], float_t(1));
+  EXPECT_EQ(out_tensor[0][9], float_t(1));
+  EXPECT_EQ(out_tensor[0][10], float_t(1));
+  EXPECT_EQ(out_tensor[0][11], float_t(1));
+  EXPECT_EQ(out_tensor[0][12], float_t(1));
+  EXPECT_EQ(out_tensor[0][13], float_t(0));
 }
 
 TEST(convolutional, copy_and_unpad_valid) {
+  conv_params params;
+  params.in = shape3d(5, 5, 1);
+  params.weight = shape3d(3, 3, 2);
+  params.in_padded = shape3d(5, 5, 1);
+  params.out = shape3d(3, 3, 1);
+  params.pad_type = padding::valid;  // test target
+  params.w_stride = 1;
+  params.h_stride = 1;
 
-    conv_params params;
-    params.in        = shape3d(5,5,1);
-    params.weight    = shape3d(3,3,2);
-    params.in_padded = shape3d(5,5,1);
-    params.out       = shape3d(3,3,1);
-    params.pad_type  = padding::valid; // test target
-    params.w_stride  = 1;
-    params.h_stride  = 1;
+  Conv2d conv2d_op;
+  conv2d_op.setParams(&params);
 
-    Conv2d conv2d_op;
-           conv2d_op.setParams(&params);
+  auto create_tensor = [](cnn_size_t batch_size, cnn_size_t vector_size) {
+    return tensor_t(batch_size, vec_t(vector_size));
+  };
 
-    auto create_tensor = [](cnn_size_t batch_size,
-                            cnn_size_t vector_size) {
-        return tensor_t(batch_size, vec_t(vector_size));
-    };
+  tensor_t in_tensor = create_tensor(1, 1 * 7 * 7), out_tensor;
 
-    tensor_t in_tensor = create_tensor(1, 1 * 7 * 7), out_tensor;
+  fill_tensor(in_tensor, float_t(1));
 
-    fill_tensor(in_tensor, float_t(1));
+  conv2d_op.copy_and_unpad_delta(in_tensor, out_tensor);
 
-    conv2d_op.copy_and_unpad_delta(in_tensor, out_tensor);
-
-    for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
-        EXPECT_EQ(out_tensor[0][i], float_t(1));
-    }
+  for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
+    EXPECT_EQ(out_tensor[0][i], float_t(1));
+  }
 }
 
 TEST(convolutional, copy_and_unpad_delta_same) {
+  conv_params params;
+  params.in = shape3d(3, 3, 1);
+  params.weight = shape3d(2, 2, 1);
+  params.in_padded = shape3d(5, 5, 1);
+  params.out = shape3d(2, 2, 1);
+  params.pad_type = padding::same;  // test target
+  params.w_stride = 1;
+  params.h_stride = 1;
 
-    conv_params params;
-    params.in        = shape3d(3,3,1);
-    params.weight    = shape3d(2,2,1);
-    params.in_padded = shape3d(5,5,1);
-    params.out       = shape3d(2,2,1);
-    params.pad_type  = padding::same; // test target
-    params.w_stride  = 1;
-    params.h_stride  = 1;
+  Conv2d conv2d_op;
+  conv2d_op.setParams(&params);
 
-    Conv2d conv2d_op;
-           conv2d_op.setParams(&params);
+  auto create_tensor = [](cnn_size_t batch_size, cnn_size_t vector_size) {
+    return tensor_t(batch_size, vec_t(vector_size));
+  };
 
-    auto create_tensor = [](cnn_size_t batch_size,
-                            cnn_size_t vector_size) {
-        return tensor_t(batch_size, vec_t(vector_size));
-    };
+  tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
 
-    tensor_t in_tensor = create_tensor(1, 1 * 5 * 5), out_tensor;
+  fill_tensor(in_tensor, float_t(0));
 
-    fill_tensor(in_tensor, float_t(0));
+  /*
+   * @in_tensor   --->   @out_tensor
+   *
+   * 0 0 0 0 0             1 1 1
+   * 0 1 1 1 0             1 1 1
+   * 0 1 1 1 0             1 1 1
+   * 0 1 1 1 0
+   * 0 0 0 0 0
+   *
+   */
 
-    /*
-     * @in_tensor   --->   @out_tensor
-     *
-     * 0 0 0 0 0             1 1 1
-     * 0 1 1 1 0             1 1 1
-     * 0 1 1 1 0             1 1 1
-     * 0 1 1 1 0
-     * 0 0 0 0 0
-     *
-     */
-
-    for (int i = 0; i < 3; ++i) {
-        for (int j = 0; j < 3; ++j) {
-            in_tensor[0][6 + 5*i + j] = float_t(1);
-        }
+  for (int i = 0; i < 3; ++i) {
+    for (int j = 0; j < 3; ++j) {
+      in_tensor[0][6 + 5 * i + j] = float_t(1);
     }
+  }
 
-    conv2d_op.copy_and_unpad_delta(in_tensor, out_tensor);
+  conv2d_op.copy_and_unpad_delta(in_tensor, out_tensor);
 
-    for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
-        EXPECT_EQ(out_tensor[0][i], float_t(1));
-    }
+  for (cnn_size_t i = 0; i < out_tensor[0].size(); ++i) {
+    EXPECT_EQ(out_tensor[0][i], float_t(1));
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_core.h
+++ b/test/test_core.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_core.h
+++ b/test/test_core.h
@@ -8,49 +8,50 @@
 #include "tiny_dnn/tiny_dnn.h"
 #if defined(USE_OPENCL) || defined(USE_CUDA)
 #include "third_party/CLCudaAPI/clpp11.h"
-#endif //defined(USE_OPENCL) || defined(USE_CUDA)
+#endif  // defined(USE_OPENCL) || defined(USE_CUDA)
 using namespace tiny_dnn;
 
 namespace tiny_dnn {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
 device_t device_type(size_t &platform, size_t &device) {
-    //check which platforms are available
-    auto platforms = CLCudaAPI::GetAllPlatforms();
+  // check which platforms are available
+  auto platforms = CLCudaAPI::GetAllPlatforms();
 
-    // if no platforms - return -1
-    if (platforms.size() == 0)
-        return device_t::NONE;
+  // if no platforms - return -1
+  if (platforms.size() == 0) return device_t::NONE;
 
-    for (auto p = platforms.begin(); p != platforms.end(); ++p)
-        for (size_t d = 0; d < p->NumDevices(); ++d) {
-            auto dev = CLCudaAPI::Device(*p, d);
-            if (dev.Type()=="GPU") {
-                platform = p - platforms.begin();
-                device = d;
-                return device_t::GPU;
-            }
-        }
+  for (auto p = platforms.begin(); p != platforms.end(); ++p)
+    for (size_t d = 0; d < p->NumDevices(); ++d) {
+      auto dev = CLCudaAPI::Device(*p, d);
+      if (dev.Type() == "GPU") {
+        platform = p - platforms.begin();
+        device = d;
+        return device_t::GPU;
+      }
+    }
 
-    for (auto p = platforms.begin(); p != platforms.end(); ++p)
-        for (size_t d = 0; d < p->NumDevices(); ++d) {
-            auto dev = CLCudaAPI::Device(*p, d);
-            if (dev.Type()=="CPU") {
-                platform = p - platforms.begin();
-                device = d;
-                return device_t::CPU;
-            }
-        }
+  for (auto p = platforms.begin(); p != platforms.end(); ++p)
+    for (size_t d = 0; d < p->NumDevices(); ++d) {
+      auto dev = CLCudaAPI::Device(*p, d);
+      if (dev.Type() == "CPU") {
+        platform = p - platforms.begin();
+        device = d;
+        return device_t::CPU;
+      }
+    }
 
-    //no CPUs or GPUs
-    return device_t::NONE;
+  // no CPUs or GPUs
+  return device_t::NONE;
 }
 
-#define TINY_DNN_GET_DEVICE_AND_PLATFORM size_t cl_platform, cl_device; \
-                                         device_t device = device_type(cl_platform, cl_device);
+#define TINY_DNN_GET_DEVICE_AND_PLATFORM \
+  size_t cl_platform, cl_device;         \
+  device_t device = device_type(cl_platform, cl_device);
 #else
-#define TINY_DNN_GET_DEVICE_AND_PLATFORM size_t cl_platform, cl_device; \
-                                         device_t device = device_t::NONE;
-#endif //defined(USE_OPENCL) || defined(USE_CUDA)
+#define TINY_DNN_GET_DEVICE_AND_PLATFORM \
+  size_t cl_platform, cl_device;         \
+  device_t device = device_t::NONE;
+#endif  // defined(USE_OPENCL) || defined(USE_CUDA)
 /*
 TEST(core, platforms_and_devices) {
     // Since Singleton has a general state,
@@ -70,189 +71,216 @@ TEST(core, platforms_and_devices) {
 }*/
 
 TEST(core, device) {
-    // Since Singleton has a general state,
-    // in each test we reset program register
-    ProgramManager::getInstance().reset();
+  // Since Singleton has a general state,
+  // in each test we reset program register
+  ProgramManager::getInstance().reset();
 
-    // CPU and GPU devices are instantiated
-    Device my_cpu_device(device_t::CPU);
+  // CPU and GPU devices are instantiated
+  Device my_cpu_device(device_t::CPU);
 
-    TINY_DNN_GET_DEVICE_AND_PLATFORM;
-    if (device != device_t::NONE)
-        Device my_gpu_device(device, cl_platform, cl_device);
+  TINY_DNN_GET_DEVICE_AND_PLATFORM;
+  if (device != device_t::NONE)
+    Device my_gpu_device(device, cl_platform, cl_device);
 }
 
 TEST(core, add_bad_device) {
-    // A simple CPU device cannot register an op.
-    // A warning is expected telling the user to use
-    // more parameters when device is created.
+  // A simple CPU device cannot register an op.
+  // A warning is expected telling the user to use
+  // more parameters when device is created.
 
-    // Since Singleton has a general state,
-    // in each test we reset program register
-    ProgramManager::getInstance().reset();
+  // Since Singleton has a general state,
+  // in each test we reset program register
+  ProgramManager::getInstance().reset();
 
-    Device my_gpu_device(device_t::CPU);
+  Device my_gpu_device(device_t::CPU);
 
-    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-        padding::valid, true, 1, 1, backend_t::opencl);
-    try {
-        my_gpu_device.registerOp(l);
-        EXPECT_TRUE(false);
-    }
-    catch (const nn_error& e) {
-        std::string err_mess = "Cannot register layer: " + l.layer_type() +
-                               ". Device has disabled OpenCL support. Please specify platform and device "
-                                       "in Device constructor";
-        EXPECT_STREQ(err_mess.c_str(), e.what());
-    }
-    catch(...) {
-        EXPECT_TRUE(false);
-    }
+  convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                 backend_t::opencl);
+  try {
+    my_gpu_device.registerOp(l);
+    EXPECT_TRUE(false);
+  } catch (const nn_error &e) {
+    std::string err_mess = "Cannot register layer: " + l.layer_type() +
+                           ". Device has disabled OpenCL support. Please "
+                           "specify platform and device "
+                           "in Device constructor";
+    EXPECT_STREQ(err_mess.c_str(), e.what());
+  } catch (...) {
+    EXPECT_TRUE(false);
+  }
 }
 
 TEST(core, add_bad_layer) {
-    // A GPU device cannot register an op with non-OpenCL engine.
-    // A warning is expected telling the user to redefine the op engine.
+  // A GPU device cannot register an op with non-OpenCL engine.
+  // A warning is expected telling the user to redefine the op engine.
 
-    // Since Singleton has a general state,
-    // in each test we reset program register
-    ProgramManager::getInstance().reset();
+  // Since Singleton has a general state,
+  // in each test we reset program register
+  ProgramManager::getInstance().reset();
 
-    TINY_DNN_GET_DEVICE_AND_PLATFORM;
-    if (device != device_t::NONE) {
-        Device my_gpu_device(device, cl_platform, cl_device);
+  TINY_DNN_GET_DEVICE_AND_PLATFORM;
+  if (device != device_t::NONE) {
+    Device my_gpu_device(device, cl_platform, cl_device);
 
-        convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-                                       padding::valid, true, 1, 1, backend_t::tiny_dnn);
+    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                   backend_t::tiny_dnn);
 
-        try {
-            my_gpu_device.registerOp(l);
-            EXPECT_TRUE(false);
-        }
-        catch (const nn_error &e) {
-            std::string err_mess = "Cannot register layer: " + l.layer_type() +
-                                   ". Enabled engine: " + to_string(l.engine()) + ". OpenCL engine (backend_t::opencl) "
-                                           "should be used.";
-            EXPECT_STREQ(err_mess.c_str(), e.what());
-        }
-        catch (...) {
-            EXPECT_TRUE(false);
-        }
+    try {
+      my_gpu_device.registerOp(l);
+      EXPECT_TRUE(false);
+    } catch (const nn_error &e) {
+      std::string err_mess = "Cannot register layer: " + l.layer_type() +
+                             ". Enabled engine: " + to_string(l.engine()) +
+                             ". OpenCL engine (backend_t::opencl) "
+                             "should be used.";
+      EXPECT_STREQ(err_mess.c_str(), e.what());
+    } catch (...) {
+      EXPECT_TRUE(false);
     }
+  }
 }
 
 TEST(core, device_add_op) {
-    // An Op with OpenCL engine is registered to
-    // a GPU device which will compile its program, and
-    // will place it to the general register.
+  // An Op with OpenCL engine is registered to
+  // a GPU device which will compile its program, and
+  // will place it to the general register.
 
-    // Since Singleton has a general state,
-    // in each test we reset program register
-    ProgramManager::getInstance().reset();
+  // Since Singleton has a general state,
+  // in each test we reset program register
+  ProgramManager::getInstance().reset();
 
-    TINY_DNN_GET_DEVICE_AND_PLATFORM;
-    if (device != device_t::NONE) {
-        Device my_gpu_device(device, cl_platform, cl_device);
+  TINY_DNN_GET_DEVICE_AND_PLATFORM;
+  if (device != device_t::NONE) {
+    Device my_gpu_device(device, cl_platform, cl_device);
 
-        convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-                                       padding::valid, true, 1, 1, backend_t::opencl);
+    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                   backend_t::opencl);
 
-        //max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::opencl);
+    // max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::opencl);
 
-        ASSERT_EQ(ProgramManager::getInstance().num_programs(), 0);
+    ASSERT_EQ(ProgramManager::getInstance().num_programs(), 0);
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-        // first time op registration: OK
-        my_gpu_device.registerOp(l);
+    // first time op registration: OK
+    my_gpu_device.registerOp(l);
 
-        ASSERT_EQ(ProgramManager::getInstance().num_programs(), 1);
+    ASSERT_EQ(ProgramManager::getInstance().num_programs(), 1);
 
-        // second time op registraion: we expect that Op it's not
-        // registrated since it's already there.
-        my_gpu_device.registerOp(l);
+    // second time op registraion: we expect that Op it's not
+    // registrated since it's already there.
+    my_gpu_device.registerOp(l);
 
-        ASSERT_EQ(ProgramManager::getInstance().num_programs(), 1);
+    ASSERT_EQ(ProgramManager::getInstance().num_programs(), 1);
 #endif
-    }
+  }
 }
 
 TEST(core, ocl_conv) {
-    // Since Singleton has a general state,
-    // in each test we reset program register
-    ProgramManager::getInstance().reset();
+  // Since Singleton has a general state,
+  // in each test we reset program register
+  ProgramManager::getInstance().reset();
 
-    TINY_DNN_GET_DEVICE_AND_PLATFORM;
-    if (device != device_t::NONE) {
-        Device my_gpu_device(device, cl_platform, cl_device);
+  TINY_DNN_GET_DEVICE_AND_PLATFORM;
+  if (device != device_t::NONE) {
+    Device my_gpu_device(device, cl_platform, cl_device);
 
-        convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-                                       padding::valid, true, 1, 1, backend_t::libdnn);
+    convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                   backend_t::libdnn);
 
-        // first time op registration: OK
-        my_gpu_device.registerOp(l);
+    // first time op registration: OK
+    my_gpu_device.registerOp(l);
 
-        auto create_simple_tensor = [](size_t vector_size) {
-            return tensor_t(1, vec_t(vector_size));
-        };
+    auto create_simple_tensor = [](size_t vector_size) {
+      return tensor_t(1, vec_t(vector_size));
+    };
 
-        // create simple tensors that wrap the payload vectors of the correct size
-        tensor_t in_tensor = create_simple_tensor(25)
-        , out_tensor = create_simple_tensor(18)
-        , a_tensor = create_simple_tensor(18)
-        , weight_tensor = create_simple_tensor(18)
-        , bias_tensor = create_simple_tensor(2);
+    // create simple tensors that wrap the payload vectors of the correct size
+    tensor_t in_tensor = create_simple_tensor(25),
+             out_tensor = create_simple_tensor(18),
+             a_tensor = create_simple_tensor(18),
+             weight_tensor = create_simple_tensor(18),
+             bias_tensor = create_simple_tensor(2);
 
-        // short-hand references to the payload vectors
-        vec_t &in = in_tensor[0]
-        , &out = out_tensor[0]
-        , &weight = weight_tensor[0];
+    // short-hand references to the payload vectors
+    vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-        ASSERT_EQ(l.in_shape()[1].size(), 18); // weight
+    ASSERT_EQ(l.in_shape()[1].size(), 18);  // weight
 
-        uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-        std::vector<tensor_t *> in_data, out_data;
-        in_data.push_back(&in_tensor);
-        in_data.push_back(&weight_tensor);
-        in_data.push_back(&bias_tensor);
-        out_data.push_back(&out_tensor);
-        out_data.push_back(&a_tensor);
-        l.setup(false);
-        {
-            l.forward_propagation(in_data, out_data);
+    std::vector<tensor_t *> in_data, out_data;
+    in_data.push_back(&in_tensor);
+    in_data.push_back(&weight_tensor);
+    in_data.push_back(&bias_tensor);
+    out_data.push_back(&out_tensor);
+    out_data.push_back(&a_tensor);
+    l.setup(false);
+    {
+      l.forward_propagation(in_data, out_data);
 
-            for (auto o: out)
-                EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
-        }
-    
-		weight[0] = 0.3;  weight[1] = 0.1; weight[2] = 0.2;
-		weight[3] = 0.0;  weight[4] =-0.1; weight[5] =-0.1;
-		weight[6] = 0.05; weight[7] =-0.2; weight[8] = 0.05;
+      for (auto o : out) EXPECT_DOUBLE_EQ(o, tiny_dnn::float_t(0.5));
+    }
 
-		weight[9]  = 0.0; weight[10] =-0.1; weight[11] = 0.1;
-		weight[12] = 0.1; weight[13] =-0.2; weight[14] = 0.3;
-		weight[15] = 0.2; weight[16] =-0.3; weight[17] = 0.2;
+    weight[0] = 0.3;
+    weight[1] = 0.1;
+    weight[2] = 0.2;
+    weight[3] = 0.0;
+    weight[4] = -0.1;
+    weight[5] = -0.1;
+    weight[6] = 0.05;
+    weight[7] = -0.2;
+    weight[8] = 0.05;
 
-		in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-		in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-		in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-		in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-		in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+    weight[9] = 0.0;
+    weight[10] = -0.1;
+    weight[11] = 0.1;
+    weight[12] = 0.1;
+    weight[13] = -0.2;
+    weight[14] = 0.3;
+    weight[15] = 0.2;
+    weight[16] = -0.3;
+    weight[17] = 0.2;
 
-		{
-			l.forward_propagation(in_data, out_data);
+    in[0] = 3;
+    in[1] = 2;
+    in[2] = 1;
+    in[3] = 5;
+    in[4] = 2;
+    in[5] = 3;
+    in[6] = 0;
+    in[7] = 2;
+    in[8] = 0;
+    in[9] = 1;
+    in[10] = 0;
+    in[11] = 6;
+    in[12] = 1;
+    in[13] = 1;
+    in[14] = 10;
+    in[15] = 3;
+    in[16] = -1;
+    in[17] = 2;
+    in[18] = 9;
+    in[19] = 0;
+    in[20] = 1;
+    in[21] = 2;
+    in[22] = 1;
+    in[23] = 5;
+    in[24] = 5;
 
-			EXPECT_NEAR(0.4875026, out[0], 1E-5);
-			EXPECT_NEAR(0.8388910, out[1], 1E-5);
-			EXPECT_NEAR(0.8099984, out[2], 1E-5);
-			EXPECT_NEAR(0.7407749, out[3], 1E-5);
-			EXPECT_NEAR(0.5000000, out[4], 1E-5);
-			EXPECT_NEAR(0.1192029, out[5], 1E-5);
-			EXPECT_NEAR(0.5986877, out[6], 1E-5);
-			EXPECT_NEAR(0.7595109, out[7], 1E-5);
-			EXPECT_NEAR(0.6899745, out[8], 1E-5);
-		}
-	}
+    {
+      l.forward_propagation(in_data, out_data);
+
+      EXPECT_NEAR(0.4875026, out[0], 1E-5);
+      EXPECT_NEAR(0.8388910, out[1], 1E-5);
+      EXPECT_NEAR(0.8099984, out[2], 1E-5);
+      EXPECT_NEAR(0.7407749, out[3], 1E-5);
+      EXPECT_NEAR(0.5000000, out[4], 1E-5);
+      EXPECT_NEAR(0.1192029, out[5], 1E-5);
+      EXPECT_NEAR(0.5986877, out[6], 1E-5);
+      EXPECT_NEAR(0.7595109, out[7], 1E-5);
+      EXPECT_NEAR(0.6899745, out[8], 1E-5);
+    }
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_deconvolutional_layer.h
+++ b/test/test_deconvolutional_layer.h
@@ -63,7 +63,8 @@ TEST(deconvolutional, fprop) {
 
     deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2);
 
-    // layer::forward_propagation expects tensors, even if we feed only one input at a time
+    // layer::forward_propagation expects tensors, even if we feed only one
+input at a time
     auto create_simple_tensor = [](size_t vector_size) {
         return tensor_t(1, vec_t(vector_size));
     };
@@ -197,7 +198,8 @@ TEST(deconvolutional, gradient_check) { // tanh - mse
 
     const auto test_data = generate_gradient_check_data(nn.in_data_size());
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(deconvolutional, gradient_check2) { // sigmoid - mse
@@ -206,7 +208,8 @@ TEST(deconvolutional, gradient_check2) { // sigmoid - mse
 
     const auto test_data = generate_gradient_check_data(nn.in_data_size());
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(deconvolutional, gradient_check3) { // rectified - mse
@@ -216,7 +219,8 @@ TEST(deconvolutional, gradient_check3) { // rectified - mse
 
     const auto test_data = generate_gradient_check_data(nn.in_data_size());
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(deconvolutional, gradient_check4) { // identity - mse
@@ -226,7 +230,8 @@ TEST(deconvolutional, gradient_check4) { // identity - mse
 
     const auto test_data = generate_gradient_check_data(nn.in_data_size());
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(deconvolutional, gradient_check5) { // sigmoid - cross-entropy
@@ -236,7 +241,8 @@ TEST(deconvolutional, gradient_check5) { // sigmoid - cross-entropy
 
     const auto test_data = generate_gradient_check_data(nn.in_data_size());
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<cross_entropy>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<cross_entropy>(test_data.first,
+test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
 TEST(deconvolutional, read_write)
@@ -260,12 +266,14 @@ TEST(deconvolutional, read_write2) {
     };
 #undef O
 #undef X
-    deconvolutional_layer<tan_h> layer1(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
-    deconvolutional_layer<tan_h> layer2(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
+    deconvolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
+    deconvolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
     layer1.init_weight();
     layer2.init_weight();
 
     serialization_test(layer1, layer2);
 }
 */
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_deconvolutional_layer.h
+++ b/test/test_deconvolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_dropout_layer.h
+++ b/test/test_dropout_layer.h
@@ -3,47 +3,47 @@
 // found in the LICENSE file.
 
 #pragma once
+#include <deque>
 #include "picotest/picotest.h"
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
-#include <deque>
 
 namespace tiny_dnn {
 
 TEST(dropout, randomized) {
-    int num_units = 10000;
-    tiny_dnn::float_t dropout_rate = 0.1f;
-    dropout_layer l(num_units, dropout_rate, net_phase::train);
-    vec_t v(num_units, 1.0);
+  int num_units = 10000;
+  tiny_dnn::float_t dropout_rate = 0.1f;
+  dropout_layer l(num_units, dropout_rate, net_phase::train);
+  vec_t v(num_units, 1.0);
 
-    l.forward({ {v} });
-    const auto mask1 = l.get_mask(0);
+  l.forward({{v}});
+  const auto mask1 = l.get_mask(0);
 
-    l.forward({ {v} });
-    const auto mask2 = l.get_mask(0);
+  l.forward({{v}});
+  const auto mask2 = l.get_mask(0);
 
-    // mask should change for each fprop
-    EXPECT_TRUE(is_different_container(mask1, mask2));
+  // mask should change for each fprop
+  EXPECT_TRUE(is_different_container(mask1, mask2));
 
-    // dropout-rate should be around 0.1
-    double margin_factor = 0.9;
-    int64_t num_on1 = std::count(mask1.begin(), mask1.end(), 1);
-    int64_t num_on2 = std::count(mask2.begin(), mask2.end(), 1);
+  // dropout-rate should be around 0.1
+  double margin_factor = 0.9;
+  int64_t num_on1 = std::count(mask1.begin(), mask1.end(), 1);
+  int64_t num_on2 = std::count(mask2.begin(), mask2.end(), 1);
 
-    EXPECT_LE(num_units * dropout_rate * margin_factor, num_on1);
-    EXPECT_GE(num_units * dropout_rate / margin_factor, num_on1);
-    EXPECT_LE(num_units * dropout_rate * margin_factor, num_on2);
-    EXPECT_GE(num_units * dropout_rate / margin_factor, num_on2);
+  EXPECT_LE(num_units * dropout_rate * margin_factor, num_on1);
+  EXPECT_GE(num_units * dropout_rate / margin_factor, num_on1);
+  EXPECT_LE(num_units * dropout_rate * margin_factor, num_on2);
+  EXPECT_GE(num_units * dropout_rate / margin_factor, num_on2);
 }
 
 TEST(dropout, read_write) {
-    dropout_layer l1(1024, 0.5, net_phase::test);
-    dropout_layer l2(1024, 0.5, net_phase::test);
+  dropout_layer l1(1024, 0.5, net_phase::test);
+  dropout_layer l2(1024, 0.5, net_phase::test);
 
-    l1.init_weight();
-    l2.init_weight();
+  l1.init_weight();
+  l2.init_weight();
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_dropout_layer.h
+++ b/test/test_dropout_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -10,148 +10,161 @@
 namespace tiny_dnn {
 
 TEST(fully_connected, train) {
-    network<sequential> nn;
-    adagrad optimizer;
+  network<sequential> nn;
+  adagrad optimizer;
 
-    nn << fully_connected_layer<sigmoid>(3, 2);
+  nn << fully_connected_layer<sigmoid>(3, 2);
 
-    vec_t a(3), t(2), a2(3), t2(2);
+  vec_t a(3), t(2), a2(3), t2(2);
 
-    a[0] = 3.0f; a[1] = 0.0f; a[2] = -1.0f;
-    t[0] = 0.3f; t[1] = 0.7f;
+  a[0] = 3.0f;
+  a[1] = 0.0f;
+  a[2] = -1.0f;
+  t[0] = 0.3f;
+  t[1] = 0.7f;
 
-    a2[0] = 0.2f; a2[1] = 0.5f; a2[2] = 4.0f;
-    t2[0] = 0.5f; t2[1] = 0.1f;
+  a2[0] = 0.2f;
+  a2[1] = 0.5f;
+  a2[2] = 4.0f;
+  t2[0] = 0.5f;
+  t2[1] = 0.1f;
 
-    std::vector<vec_t> data, train;
+  std::vector<vec_t> data, train;
 
-    for (int i = 0; i < 100; i++) {
-        data.push_back(a);
-        data.push_back(a2);
-        train.push_back(t);
-        train.push_back(t2);
-    }
-    optimizer.alpha = 0.1f;
-    nn.train<mse>(optimizer, data, train, 1, 10);
+  for (int i = 0; i < 100; i++) {
+    data.push_back(a);
+    data.push_back(a2);
+    train.push_back(t);
+    train.push_back(t2);
+  }
+  optimizer.alpha = 0.1f;
+  nn.train<mse>(optimizer, data, train, 1, 10);
 
-    vec_t predicted = nn.predict(a);
+  vec_t predicted = nn.predict(a);
 
-    EXPECT_NEAR(predicted[0], t[0], 1E-5);
-    EXPECT_NEAR(predicted[1], t[1], 1E-5);
+  EXPECT_NEAR(predicted[0], t[0], 1E-5);
+  EXPECT_NEAR(predicted[1], t[1], 1E-5);
 
-    predicted = nn.predict(a2);
+  predicted = nn.predict(a2);
 
-    EXPECT_NEAR(predicted[0], t2[0], 1E-5);
-    EXPECT_NEAR(predicted[1], t2[1], 1E-5);
+  EXPECT_NEAR(predicted[0], t2[0], 1E-5);
+  EXPECT_NEAR(predicted[1], t2[1], 1E-5);
 }
 
 TEST(fully_connected, train2) {
-    network<sequential> nn;
-    gradient_descent optimizer;
+  network<sequential> nn;
+  gradient_descent optimizer;
 
-    nn << fully_connected_layer<tan_h>(4, 6)
-       << fully_connected_layer<tan_h>(6, 3);
+  nn << fully_connected_layer<tan_h>(4, 6)
+     << fully_connected_layer<tan_h>(6, 3);
 
-    vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
+  vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
 
-    a[0] = 3.0f; a[1] = 1.0f; a[2] = -1.0f; a[3] = 4.0f;
-    t[0] = 0.3f; t[1] = 0.7f; t[2] = 0.3f;
+  a[0] = 3.0f;
+  a[1] = 1.0f;
+  a[2] = -1.0f;
+  a[3] = 4.0f;
+  t[0] = 0.3f;
+  t[1] = 0.7f;
+  t[2] = 0.3f;
 
-    a2[0] = 1.0f; a2[1] = 0.0f; a2[2] = 4.0f; a2[3] = 2.0f;
-    t2[0] = 0.6f; t2[1] = 0.0f; t2[2] = 0.1f;
+  a2[0] = 1.0f;
+  a2[1] = 0.0f;
+  a2[2] = 4.0f;
+  a2[3] = 2.0f;
+  t2[0] = 0.6f;
+  t2[1] = 0.0f;
+  t2[2] = 0.1f;
 
-    std::vector<vec_t> data, train;
+  std::vector<vec_t> data, train;
 
-    for (int i = 0; i < 100; i++) {
-        data.push_back(a);
-        data.push_back(a2);
-        train.push_back(t);
-        train.push_back(t2);
-    }
-    optimizer.alpha = 0.1f;
-    nn.train<mse>(optimizer, data, train, 1, 10);
+  for (int i = 0; i < 100; i++) {
+    data.push_back(a);
+    data.push_back(a2);
+    train.push_back(t);
+    train.push_back(t2);
+  }
+  optimizer.alpha = 0.1f;
+  nn.train<mse>(optimizer, data, train, 1, 10);
 
-    vec_t predicted = nn.predict(a);
+  vec_t predicted = nn.predict(a);
 
-    EXPECT_NEAR(predicted[0], t[0], 1E-4);
-    EXPECT_NEAR(predicted[1], t[1], 1E-4);
+  EXPECT_NEAR(predicted[0], t[0], 1E-4);
+  EXPECT_NEAR(predicted[1], t[1], 1E-4);
 
-    predicted = nn.predict(a2);
+  predicted = nn.predict(a2);
 
-    EXPECT_NEAR(predicted[0], t2[0], 1E-4);
-    EXPECT_NEAR(predicted[1], t2[1], 1E-4);
+  EXPECT_NEAR(predicted[0], t2[0], 1E-4);
+  EXPECT_NEAR(predicted[1], t2[1], 1E-4);
 }
 
 TEST(fully_connected, gradient_check) {
-    network<sequential> nn;
-    nn << fully_connected_layer<tan_h>(50, 10);
+  network<sequential> nn;
+  nn << fully_connected_layer<tan_h>(50, 10);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(fully_connected, read_write)
-{
-    fully_connected_layer<tan_h> l1(100, 100);
-    fully_connected_layer<tan_h> l2(100, 100);
+TEST(fully_connected, read_write) {
+  fully_connected_layer<tan_h> l1(100, 100);
+  fully_connected_layer<tan_h> l2(100, 100);
 
-    l1.setup(true);
-    l2.setup(true);
+  l1.setup(true);
+  l2.setup(true);
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-TEST(fully_connected, forward)
-{
-    fully_connected_layer<identity> l(4, 2);
-    EXPECT_EQ(l.in_channels(), cnn_size_t(3)); // in, W and b
+TEST(fully_connected, forward) {
+  fully_connected_layer<identity> l(4, 2);
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));  // in, W and b
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.5));
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.5));
 
-    vec_t in = {0,1,2,3};
-    vec_t out = l.forward({ {in} })[0][0];
-    vec_t out_expected = {6.5, 6.5}; // 0+1+2+3+0.5
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_FLOAT_EQ(out_expected[i], out[i]);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(out_expected[i], out[i]);
+  }
 }
 
 #ifdef CNN_USE_NNPACK
-TEST(fully_connected, forward_nnp)
-{
-    fully_connected_layer<identity> l(4, 2, true, core::backend_t::nnpack);
-    EXPECT_EQ(l.in_channels(), 3); // in, W and b
+TEST(fully_connected, forward_nnp) {
+  fully_connected_layer<identity> l(4, 2, true, core::backend_t::nnpack);
+  EXPECT_EQ(l.in_channels(), 3);  // in, W and b
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.5));
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.5));
 
-    vec_t in = {0,1,2,3};
-    vec_t out = l.forward({ {in} })[0][0];
-    vec_t out_expected = {6.5, 6.5}; // 0+1+2+3+0.5
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_FLOAT_EQ(out_expected[i], out[i]);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(out_expected[i], out[i]);
+  }
 }
 #endif
 
-TEST(fully_connected, forward_nobias)
-{
-    fully_connected_layer<identity> l(4, 2, false);
-    EXPECT_EQ(l.in_channels(), cnn_size_t(2));// in and W
+TEST(fully_connected, forward_nobias) {
+  fully_connected_layer<identity> l(4, 2, false);
+  EXPECT_EQ(l.in_channels(), cnn_size_t(2));  // in and W
 
-    l.weight_init(weight_init::constant(1.0));
+  l.weight_init(weight_init::constant(1.0));
 
-    vec_t in = { 0,1,2,3 };
-    vec_t out = l.forward({ { in } })[0][0];
-    vec_t out_expected = { 6.0, 6.0 }; // 0+1+2+3
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.0, 6.0};  // 0+1+2+3
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_FLOAT_EQ(out_expected[i], out[i]);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(out_expected[i], out[i]);
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_image.h
+++ b/test/test_image.h
@@ -12,414 +12,404 @@ using namespace tiny_dnn;
 namespace tiny_dnn {
 
 TEST(image, default_ctor_uint8) {
-    image<uint8_t> img;
+  image<uint8_t> img;
 
-    EXPECT_TRUE(img.empty());
+  EXPECT_TRUE(img.empty());
 }
 
 TEST(image, default_ctor_float) {
-    image<float> img;
+  image<float> img;
 
-    EXPECT_TRUE(img.empty());
+  EXPECT_TRUE(img.empty());
 }
 
 TEST(image, copy_ctor) {
-    uint8_t a[] = { 0,127,255 };
+  uint8_t a[] = {0, 127, 255};
 
-    image<uint8_t> src(a, 3, 1, image_type::grayscale);
-    image<float> dst(src);
+  image<uint8_t> src(a, 3, 1, image_type::grayscale);
+  image<float> dst(src);
 
-    EXPECT_FLOAT_EQ(0.0f, dst.at(0, 0));
-    EXPECT_FLOAT_EQ(127.0f, dst.at(1, 0));
-    EXPECT_FLOAT_EQ(255.0f, dst.at(2, 0));
+  EXPECT_FLOAT_EQ(0.0f, dst.at(0, 0));
+  EXPECT_FLOAT_EQ(127.0f, dst.at(1, 0));
+  EXPECT_FLOAT_EQ(255.0f, dst.at(2, 0));
 }
 
 TEST(image, create_from_array_uint8) {
-    uint8_t src[] = { 1,2,3,4,5,6 };
+  uint8_t src[] = {1, 2, 3, 4, 5, 6};
 
-    {
-        image<uint8_t> img(src, 3, 2, image_type::grayscale);
+  {
+    image<uint8_t> img(src, 3, 2, image_type::grayscale);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.width());
-        EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
-        EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
-        EXPECT_EQ((int)image_type::grayscale, (int)img.type());
-        EXPECT_EQ(5, img.at(1, 1));
-    }
+    EXPECT_EQ(static_cast<cnn_size_t>(3), img.width());
+    EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
+    EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+    EXPECT_EQ((int)image_type::grayscale, (int)img.type());
+    EXPECT_EQ(5, img.at(1, 1));
+  }
 
-    {
-        image<uint8_t> img(src, 1, 2, image_type::rgb);
+  {
+    image<uint8_t> img(src, 1, 2, image_type::rgb);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(1), img.width());
-        EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
-        EXPECT_EQ((int)image_type::rgb, (int)img.type());
-        EXPECT_EQ(static_cast<cnn_size_t>(4), img.at(0, 1, 1));
-    }
+    EXPECT_EQ(static_cast<cnn_size_t>(1), img.width());
+    EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
+    EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
+    EXPECT_EQ((int)image_type::rgb, (int)img.type());
+    EXPECT_EQ(static_cast<cnn_size_t>(4), img.at(0, 1, 1));
+  }
 }
 
-
 TEST(image, create_from_array_float) {
-    float src[] = { 1,2,3,4,5,6 };
+  float src[] = {1, 2, 3, 4, 5, 6};
 
-    {
-        image<float> img(src, 3, 2, image_type::grayscale);
+  {
+    image<float> img(src, 3, 2, image_type::grayscale);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.width());
-        EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
-        EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
-        EXPECT_EQ((int)image_type::grayscale, (int)img.type());
-        EXPECT_FLOAT_EQ(5.0f, img.at(1, 1));
-    }
+    EXPECT_EQ(static_cast<cnn_size_t>(3), img.width());
+    EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
+    EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+    EXPECT_EQ((int)image_type::grayscale, (int)img.type());
+    EXPECT_FLOAT_EQ(5.0f, img.at(1, 1));
+  }
 
-    {
-        image<float> img(src, 1, 2, image_type::rgb);
+  {
+    image<float> img(src, 1, 2, image_type::rgb);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(1), img.width());
-        EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
-        EXPECT_EQ((int)image_type::rgb, (int)img.type());
-        EXPECT_FLOAT_EQ(4.0f, img.at(0, 1, 1));
-    }
+    EXPECT_EQ(static_cast<cnn_size_t>(1), img.width());
+    EXPECT_EQ(static_cast<cnn_size_t>(2), img.height());
+    EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
+    EXPECT_EQ((int)image_type::rgb, (int)img.type());
+    EXPECT_FLOAT_EQ(4.0f, img.at(0, 1, 1));
+  }
 }
 
 TEST(image, create_zero_filled_uint8) {
-    image<uint8_t> img(shape3d(3, 2, 1), image_type::grayscale);
+  image<uint8_t> img(shape3d(3, 2, 1), image_type::grayscale);
 
-    EXPECT_EQ(0, img.at(0, 0));
-    EXPECT_EQ(0, img.at(2, 1));
+  EXPECT_EQ(0, img.at(0, 0));
+  EXPECT_EQ(0, img.at(2, 1));
 }
 
 TEST(image, create_zero_filled_float) {
-    image<float> img(shape3d(3, 2, 1), image_type::grayscale);
+  image<float> img(shape3d(3, 2, 1), image_type::grayscale);
 
-    EXPECT_FLOAT_EQ(0.0f, img.at(0, 0));
-    EXPECT_FLOAT_EQ(0.0f, img.at(2, 1));
+  EXPECT_FLOAT_EQ(0.0f, img.at(0, 0));
+  EXPECT_FLOAT_EQ(0.0f, img.at(2, 1));
 }
 
 TEST(image, copy) {
-    uint8_t base[] = { 1,2,3,4,5,6 };
-    image<uint8_t> src(base, 3, 2, image_type::grayscale);
-    image<float> dst(src);
+  uint8_t base[] = {1, 2, 3, 4, 5, 6};
+  image<uint8_t> src(base, 3, 2, image_type::grayscale);
+  image<float> dst(src);
 
-    EXPECT_FLOAT_EQ(1.0f, dst.at(0, 0));
-    EXPECT_FLOAT_EQ(6.0f, dst.at(2, 1));
+  EXPECT_FLOAT_EQ(1.0f, dst.at(0, 0));
+  EXPECT_FLOAT_EQ(6.0f, dst.at(2, 1));
 }
 
 TEST(image, read_png_1bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basi0g01.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basi0g01.png", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> img(path, image_type::grayscale);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
-    EXPECT_EQ(255, img.at(0, 0));
-    EXPECT_EQ(255, img.at(15, 15));
-    EXPECT_EQ(0, img.at(31, 0));
-    EXPECT_EQ(0, img.at(16, 15));
-    EXPECT_EQ(0, img.at(31, 31));
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+  EXPECT_EQ(255, img.at(0, 0));
+  EXPECT_EQ(255, img.at(15, 15));
+  EXPECT_EQ(0, img.at(31, 0));
+  EXPECT_EQ(0, img.at(16, 15));
+  EXPECT_EQ(0, img.at(31, 31));
 }
 
 TEST(image, read_png_2bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basi0g02.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basi0g02.png", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> img(path, image_type::grayscale);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
-    EXPECT_EQ(0,  img.at(0, 0));
-    EXPECT_EQ(85, img.at(4, 0));
-    EXPECT_EQ(170, img.at(8, 0));
-    EXPECT_EQ(255, img.at(12, 0));
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+  EXPECT_EQ(0, img.at(0, 0));
+  EXPECT_EQ(85, img.at(4, 0));
+  EXPECT_EQ(170, img.at(8, 0));
+  EXPECT_EQ(255, img.at(12, 0));
 }
 
 TEST(image, read_png_4bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g04.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g04.png", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> img(path, image_type::grayscale);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
-    EXPECT_EQ(0, img.at(0, 0));
-    EXPECT_EQ(17, img.at(4, 0));
-    EXPECT_EQ(34, img.at(8, 0));
-    EXPECT_EQ(51, img.at(12, 0));
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+  EXPECT_EQ(0, img.at(0, 0));
+  EXPECT_EQ(17, img.at(4, 0));
+  EXPECT_EQ(34, img.at(8, 0));
+  EXPECT_EQ(51, img.at(12, 0));
 }
 
 TEST(image, read_png_8bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g08.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g08.png", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> img(path, image_type::grayscale);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
-    EXPECT_EQ(0, img.at(0, 0));
-    EXPECT_EQ(32, img.at(0, 1));
-    EXPECT_EQ(64, img.at(0, 2));
-    EXPECT_EQ(96, img.at(0, 3));
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
+  EXPECT_EQ(0, img.at(0, 0));
+  EXPECT_EQ(32, img.at(0, 1));
+  EXPECT_EQ(64, img.at(0, 2));
+  EXPECT_EQ(96, img.at(0, 3));
 }
 
 TEST(image, read_png_8bit_gray2bgr) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g08.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn0g08.png", path));
 
-    image<uint8_t> img(path, image_type::bgr);
+  image<uint8_t> img(path, image_type::bgr);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(3),  img.depth());
-    EXPECT_EQ(0, img.at(0, 0));
-    EXPECT_EQ(0, img.at(0, 0, 0));
-    EXPECT_EQ(0, img.at(0, 0, 1));
-    EXPECT_EQ(0, img.at(0, 0, 2));
-    EXPECT_EQ(32, img.at(0, 1));
-    EXPECT_EQ(32, img.at(0, 1, 0));
-    EXPECT_EQ(32, img.at(0, 1, 1));
-    EXPECT_EQ(32, img.at(0, 1, 2));
-    EXPECT_EQ(64, img.at(0, 2));
-    EXPECT_EQ(64, img.at(0, 2, 0));
-    EXPECT_EQ(64, img.at(0, 2, 1));
-    EXPECT_EQ(64, img.at(0, 2, 2));
-    EXPECT_EQ(96, img.at(0, 3));
-    EXPECT_EQ(96, img.at(0, 3, 0));
-    EXPECT_EQ(96, img.at(0, 3, 1));
-    EXPECT_EQ(96, img.at(0, 3, 2));
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
+  EXPECT_EQ(0, img.at(0, 0));
+  EXPECT_EQ(0, img.at(0, 0, 0));
+  EXPECT_EQ(0, img.at(0, 0, 1));
+  EXPECT_EQ(0, img.at(0, 0, 2));
+  EXPECT_EQ(32, img.at(0, 1));
+  EXPECT_EQ(32, img.at(0, 1, 0));
+  EXPECT_EQ(32, img.at(0, 1, 1));
+  EXPECT_EQ(32, img.at(0, 1, 2));
+  EXPECT_EQ(64, img.at(0, 2));
+  EXPECT_EQ(64, img.at(0, 2, 0));
+  EXPECT_EQ(64, img.at(0, 2, 1));
+  EXPECT_EQ(64, img.at(0, 2, 2));
+  EXPECT_EQ(96, img.at(0, 3));
+  EXPECT_EQ(96, img.at(0, 3, 0));
+  EXPECT_EQ(96, img.at(0, 3, 1));
+  EXPECT_EQ(96, img.at(0, 3, 2));
 }
 
 TEST(image, read_png_8bit_rgba) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn6a08.png", path));
-    {
-        image<uint8_t> img(path, image_type::bgr);
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn6a08.png", path));
+  {
+    image<uint8_t> img(path, image_type::bgr);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth()); // alpha channel is just ignored
+    EXPECT_EQ(static_cast<cnn_size_t>(3),
+              img.depth());  // alpha channel is just ignored
 
-        // bgr order
-        EXPECT_EQ(255, img.at(31, 31, 0));
-        EXPECT_EQ(32,  img.at(31, 31, 1));
-        EXPECT_EQ(0,   img.at(31, 31, 2));
-    }
-    {
-        image<uint8_t> img(path, image_type::rgb);
+    // bgr order
+    EXPECT_EQ(255, img.at(31, 31, 0));
+    EXPECT_EQ(32, img.at(31, 31, 1));
+    EXPECT_EQ(0, img.at(31, 31, 2));
+  }
+  {
+    image<uint8_t> img(path, image_type::rgb);
 
-        // rgb order
-        EXPECT_EQ(0,   img.at(31, 31, 0));
-        EXPECT_EQ(32,  img.at(31, 31, 1));
-        EXPECT_EQ(255, img.at(31, 31, 2));
-    }
+    // rgb order
+    EXPECT_EQ(0, img.at(31, 31, 0));
+    EXPECT_EQ(32, img.at(31, 31, 1));
+    EXPECT_EQ(255, img.at(31, 31, 2));
+  }
 }
 
 TEST(image, read_png_8bit_rgba2gray) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn6a08.png", path));
+  ASSERT_TRUE(resolve_path("testimage/pngsuite/primary/basn6a08.png", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
-    image<uint8_t> rgb(path, image_type::rgb);
+  image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> rgb(path, image_type::rgb);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
 
-    for (size_t y = 0; y < 32; y++) {
-        for (size_t x = 0; x < 32; x++) {
-            uint8_t r = rgb.at(x, y, 0);
-            uint8_t g = rgb.at(x, y, 1);
-            uint8_t b = rgb.at(x, y, 2);
+  for (size_t y = 0; y < 32; y++) {
+    for (size_t x = 0; x < 32; x++) {
+      uint8_t r = rgb.at(x, y, 0);
+      uint8_t g = rgb.at(x, y, 1);
+      uint8_t b = rgb.at(x, y, 2);
 
-            // RGB2GRAY conversion in tiny-dnn (inherited from stbi__compute_y function in stb_image.h)
-            // note that weights slightly differ from opencv/matlab
-            //
-            //  tiny-dnn: 0.300r + 0.586g + 0.113b
-            //  opencv:   0.299r + 0.587g + 0.114b
-            uint8_t expected_y = (((r * 77) + (g * 150) + (b * 29)) >> 8);
+      // RGB2GRAY conversion in tiny-dnn (inherited from stbi__compute_y
+      // function in stb_image.h)
+      // note that weights slightly differ from opencv/matlab
+      //
+      //  tiny-dnn: 0.300r + 0.586g + 0.113b
+      //  opencv:   0.299r + 0.587g + 0.114b
+      uint8_t expected_y = (((r * 77) + (g * 150) + (b * 29)) >> 8);
 
-            EXPECT_EQ(expected_y, img.at(x, y));
-        }
+      EXPECT_EQ(expected_y, img.at(x, y));
     }
+  }
 }
 
 TEST(image, read_bmp_8bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/bmp/8bit.bmp", path));
+  ASSERT_TRUE(resolve_path("testimage/bmp/8bit.bmp", path));
 
-    image<uint8_t> img(path, image_type::rgb);
+  image<uint8_t> img(path, image_type::rgb);
 
-    EXPECT_EQ(255, img.at(0, 0, 0));
-    EXPECT_EQ(255, img.at(0, 0, 1));
-    EXPECT_EQ(255, img.at(0, 0, 2));
+  EXPECT_EQ(255, img.at(0, 0, 0));
+  EXPECT_EQ(255, img.at(0, 0, 1));
+  EXPECT_EQ(255, img.at(0, 0, 2));
 
-    EXPECT_EQ(0, img.at(31, 31, 0));
-    EXPECT_EQ(0, img.at(31, 31, 1));
-    EXPECT_EQ(255, img.at(31, 31, 2));
+  EXPECT_EQ(0, img.at(31, 31, 0));
+  EXPECT_EQ(0, img.at(31, 31, 1));
+  EXPECT_EQ(255, img.at(31, 31, 2));
 }
 
 TEST(image, read_bmp_8bit_rgb2gray) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/bmp/8bit.bmp", path));
+  ASSERT_TRUE(resolve_path("testimage/bmp/8bit.bmp", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> img(path, image_type::grayscale);
 
-    uint8_t expected_y = (255 * 29) >> 8;
+  uint8_t expected_y = (255 * 29) >> 8;
 
-    EXPECT_EQ(255, img.at(0, 0));
-    EXPECT_EQ(expected_y, img.at(31, 31));
+  EXPECT_EQ(255, img.at(0, 0));
+  EXPECT_EQ(expected_y, img.at(31, 31));
 }
 
 TEST(image, read_bmp_24bit) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/bmp/24bit.bmp", path));
+  ASSERT_TRUE(resolve_path("testimage/bmp/24bit.bmp", path));
 
+  image<uint8_t> img(path, image_type::rgb);
+  {
+    image<uint8_t> img(path, image_type::bgr);
+
+    EXPECT_EQ(static_cast<cnn_size_t>(3),
+              img.depth());  // alpha channel is just ignored
+
+    // bgr order
+    EXPECT_EQ(255, img.at(31, 31, 0));
+    EXPECT_EQ(32, img.at(31, 31, 1));
+    EXPECT_EQ(0, img.at(31, 31, 2));
+  }
+  {
     image<uint8_t> img(path, image_type::rgb);
-    {
-        image<uint8_t> img(path, image_type::bgr);
 
-        EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth()); // alpha channel is just ignored
-
-                                   // bgr order
-        EXPECT_EQ(255, img.at(31, 31, 0));
-        EXPECT_EQ(32, img.at(31, 31, 1));
-        EXPECT_EQ(0, img.at(31, 31, 2));
-    }
-    {
-        image<uint8_t> img(path, image_type::rgb);
-
-        // rgb order
-        EXPECT_EQ(0, img.at(31, 31, 0));
-        EXPECT_EQ(32, img.at(31, 31, 1));
-        EXPECT_EQ(255, img.at(31, 31, 2));
-    }
+    // rgb order
+    EXPECT_EQ(0, img.at(31, 31, 0));
+    EXPECT_EQ(32, img.at(31, 31, 1));
+    EXPECT_EQ(255, img.at(31, 31, 2));
+  }
 }
 
 TEST(image, read_bmp_24bit_rgb2gray) {
-    std::string path;
+  std::string path;
 
-    ASSERT_TRUE(resolve_path("testimage/bmp/24bit.bmp", path));
+  ASSERT_TRUE(resolve_path("testimage/bmp/24bit.bmp", path));
 
-    image<uint8_t> img(path, image_type::grayscale);
-    image<uint8_t> rgb(path, image_type::rgb);
+  image<uint8_t> img(path, image_type::grayscale);
+  image<uint8_t> rgb(path, image_type::rgb);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(1),  img.depth());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(1), img.depth());
 
-    for (size_t y = 0; y < 32; y++) {
-        for (size_t x = 0; x < 32; x++) {
-            uint8_t r = rgb.at(x, y, 0);
-            uint8_t g = rgb.at(x, y, 1);
-            uint8_t b = rgb.at(x, y, 2);
+  for (size_t y = 0; y < 32; y++) {
+    for (size_t x = 0; x < 32; x++) {
+      uint8_t r = rgb.at(x, y, 0);
+      uint8_t g = rgb.at(x, y, 1);
+      uint8_t b = rgb.at(x, y, 2);
 
-            // RGB2GRAY conversion in tiny-dnn (inherited from stbi__compute_y function in stb_image.h)
-            // note that weights slightly differ from opencv/matlab
-            //
-            //  tiny-dnn: 0.300r + 0.586g + 0.113b
-            //  opencv:   0.299r + 0.587g + 0.114b
-            uint8_t expected_y = (((r * 77) + (g * 150) + (b * 29)) >> 8);
+      // RGB2GRAY conversion in tiny-dnn (inherited from stbi__compute_y
+      // function in stb_image.h)
+      // note that weights slightly differ from opencv/matlab
+      //
+      //  tiny-dnn: 0.300r + 0.586g + 0.113b
+      //  opencv:   0.299r + 0.587g + 0.114b
+      uint8_t expected_y = (((r * 77) + (g * 150) + (b * 29)) >> 8);
 
-            EXPECT_EQ(expected_y, img.at(x, y));
-        }
+      EXPECT_EQ(expected_y, img.at(x, y));
     }
+  }
 }
 
-TEST(image, resize)
-{
-    image<> img(shape3d(10, 10, 3), image_type::rgb);
+TEST(image, resize) {
+  image<> img(shape3d(10, 10, 3), image_type::rgb);
 
-    img.resize(32, 32);
+  img.resize(32, 32);
 
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
-    EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
-    EXPECT_EQ(static_cast<cnn_size_t>(3),  img.depth());
-    EXPECT_EQ((int)image_type::rgb, (int)img.type());
-    EXPECT_EQ(static_cast<cnn_size_t>(32 * 32 * 3), img.data().size());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.width());
+  EXPECT_EQ(static_cast<cnn_size_t>(32), img.height());
+  EXPECT_EQ(static_cast<cnn_size_t>(3), img.depth());
+  EXPECT_EQ((int)image_type::rgb, (int)img.type());
+  EXPECT_EQ(static_cast<cnn_size_t>(32 * 32 * 3), img.data().size());
 }
 
-TEST(image, empty)
-{
-    image<> img;
-    image<> img2(shape3d(1,1,1), image_type::grayscale);
+TEST(image, empty) {
+  image<> img;
+  image<> img2(shape3d(1, 1, 1), image_type::grayscale);
 
-    EXPECT_TRUE(img.empty());
-    EXPECT_FALSE(img2.empty());
+  EXPECT_TRUE(img.empty());
+  EXPECT_FALSE(img2.empty());
 }
 
-TEST(image, fill)
-{
-    image<> img(shape3d(3, 3, 3), image_type::rgb);
-    img.fill(127);
+TEST(image, fill) {
+  image<> img(shape3d(3, 3, 3), image_type::rgb);
+  img.fill(127);
 
-    for (auto i : img) {
-        EXPECT_EQ(i, 127);
-    }
+  for (auto i : img) {
+    EXPECT_EQ(i, 127);
+  }
 }
 
-TEST(image, fromrgb)
-{
-    std::vector<uint8_t> rgb = {
-    //  r    g    b
-        0, 127, 255,
-        1, 126, 254,
-        2, 125, 253,
-        3, 124, 252
-    };
+TEST(image, fromrgb) {
+  std::vector<uint8_t> rgb = {
+      //  r    g    b
+      0, 127, 255, 1, 126, 254, 2, 125, 253, 3, 124, 252};
 
-    image<uint8_t> img(shape3d(2, 2, 3), image_type::rgb);
+  image<uint8_t> img(shape3d(2, 2, 3), image_type::rgb);
 
-    img.from_rgb(rgb.begin(), rgb.end());
+  img.from_rgb(rgb.begin(), rgb.end());
 
-    EXPECT_EQ(0,   img.at(0, 0, 0));
-    EXPECT_EQ(127, img.at(0, 0, 1));
-    EXPECT_EQ(255, img.at(0, 0, 2));
+  EXPECT_EQ(0, img.at(0, 0, 0));
+  EXPECT_EQ(127, img.at(0, 0, 1));
+  EXPECT_EQ(255, img.at(0, 0, 2));
 
-    EXPECT_EQ(1,   img.at(1, 0, 0));
-    EXPECT_EQ(126, img.at(1, 0, 1));
-    EXPECT_EQ(254, img.at(1, 0, 2));
+  EXPECT_EQ(1, img.at(1, 0, 0));
+  EXPECT_EQ(126, img.at(1, 0, 1));
+  EXPECT_EQ(254, img.at(1, 0, 2));
 
-    EXPECT_EQ(2,   img.at(0, 1, 0));
-    EXPECT_EQ(125, img.at(0, 1, 1));
-    EXPECT_EQ(253, img.at(0, 1, 2));
+  EXPECT_EQ(2, img.at(0, 1, 0));
+  EXPECT_EQ(125, img.at(0, 1, 1));
+  EXPECT_EQ(253, img.at(0, 1, 2));
 
-    EXPECT_EQ(3,   img.at(1, 1, 0));
-    EXPECT_EQ(124, img.at(1, 1, 1));
-    EXPECT_EQ(252, img.at(1, 1, 2));
+  EXPECT_EQ(3, img.at(1, 1, 0));
+  EXPECT_EQ(124, img.at(1, 1, 1));
+  EXPECT_EQ(252, img.at(1, 1, 2));
 }
 
-TEST(image, torgb)
-{
-    std::vector<uint8_t> rgb = {
-        //  r    g    b
-        0, 127, 255,
-        1, 126, 254,
-        2, 125, 253,
-        3, 124, 252
-    };
+TEST(image, torgb) {
+  std::vector<uint8_t> rgb = {
+      //  r    g    b
+      0, 127, 255, 1, 126, 254, 2, 125, 253, 3, 124, 252};
 
-    image<uint8_t> img(shape3d(2, 2, 3), image_type::rgb);
+  image<uint8_t> img(shape3d(2, 2, 3), image_type::rgb);
 
-    img.from_rgb(rgb.begin(), rgb.end());
-    
-    auto dst = img.to_rgb<uint8_t>();
+  img.from_rgb(rgb.begin(), rgb.end());
 
-    for (size_t i = 0; i < rgb.size(); i++) {
-        EXPECT_EQ(dst[i], rgb[i]);
-    }
+  auto dst = img.to_rgb<uint8_t>();
+
+  for (size_t i = 0; i < rgb.size(); i++) {
+    EXPECT_EQ(dst[i], rgb[i]);
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_image.h
+++ b/test/test_image.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_large_thread_count.h
+++ b/test/test_large_thread_count.h
@@ -10,31 +10,30 @@
 namespace tiny_dnn {
 
 TEST(test_large_thread_count, test_large_thread_count) {
+  network<sequential> net;
+  net << fully_connected_layer<tan_h>(1, 2);
+  adagrad optimizer;
 
-    network<sequential> net;
-    net << fully_connected_layer<tan_h>(1, 2);
-    adagrad optimizer;
+  std::vector<vec_t> data;
+  std::vector<label_t> labels;
 
-    std::vector<vec_t> data;
-    std::vector<label_t> labels;
+  const size_t tnum = 100;
 
-    const size_t tnum = 100;
+  for (size_t i = 0; i < tnum; i++) {
+    bool in = bernoulli(0.5);
+    bool label = bernoulli(0.5);
 
-    for (size_t i = 0; i < tnum; i++) {
-        bool in = bernoulli(0.5);
-        bool label = bernoulli(0.5);
+    data.push_back({static_cast<float_t>(in)});
+    labels.push_back(label ? 1 : 0);
+  }
 
-        data.push_back({ static_cast<float_t>(in) });
-        labels.push_back(label ? 1 : 0);
-    }
+  const int n_threads = 200;
 
-    const int n_threads = 200;
-
-    // test different batch sizes
-    net.train<mse>(optimizer, data, labels, 1, 1, nop, nop, true, n_threads);
-    net.train<mse>(optimizer, data, labels, 100, 1, nop, nop, true, n_threads);
-    net.train<mse>(optimizer, data, labels, 200, 1, nop, nop, true, n_threads);
-    net.train<mse>(optimizer, data, labels, 300, 1, nop, nop, true, n_threads);
+  // test different batch sizes
+  net.train<mse>(optimizer, data, labels, 1, 1, nop, nop, true, n_threads);
+  net.train<mse>(optimizer, data, labels, 100, 1, nop, nop, true, n_threads);
+  net.train<mse>(optimizer, data, labels, 200, 1, nop, nop, true, n_threads);
+  net.train<mse>(optimizer, data, labels, 300, 1, nop, nop, true, n_threads);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_large_thread_count.h
+++ b/test/test_large_thread_count.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_lrn_layer.h
+++ b/test/test_lrn_layer.h
@@ -10,33 +10,35 @@
 namespace tiny_dnn {
 
 TEST(lrn, cross) {
-    lrn_layer<identity> lrn(1, 1, 3, 4, /*alpha=*/1.5, /*beta=*/2.0, norm_region::across_channels);
+  lrn_layer<identity> lrn(1, 1, 3, 4, /*alpha=*/1.5, /*beta=*/2.0,
+                          norm_region::across_channels);
 
-    tiny_dnn::float_t in[4] = { -1.0, 3.0, 2.0, 5.0 };
-    tiny_dnn::float_t expected[4] =
-    {
-        -1.0f/36.0f,    // -1.0 / (1+0.5*(1*1+3*3))^2
-        3.0f/64.0f,     //  3.0 / (1+0.5*(1*1+3*3+2*2))^2
-        2.0f/400.0f,    //  2.0 / (1+0.5*(3*3+2*2+5*5))^2
-        5.0f/15.5f/15.5f // 5.0 / (1+0.5*(2*2+5*5))^2
-    };
+  tiny_dnn::float_t in[4] = {-1.0, 3.0, 2.0, 5.0};
+  tiny_dnn::float_t expected[4] = {
+      -1.0f / 36.0f,        // -1.0 / (1+0.5*(1*1+3*3))^2
+      3.0f / 64.0f,         //  3.0 / (1+0.5*(1*1+3*3+2*2))^2
+      2.0f / 400.0f,        //  2.0 / (1+0.5*(3*3+2*2+5*5))^2
+      5.0f / 15.5f / 15.5f  // 5.0 / (1+0.5*(2*2+5*5))^2
+  };
 
-    auto out = lrn.forward({ {vec_t(in, in + 4)} })[0][0];
+  auto out = lrn.forward({{vec_t(in, in + 4)}})[0][0];
 
-    EXPECT_FLOAT_EQ(expected[0], out[0]);
-    EXPECT_FLOAT_EQ(expected[1], out[1]);
-    EXPECT_FLOAT_EQ(expected[2], out[2]);
-    EXPECT_FLOAT_EQ(expected[3], out[3]);
+  EXPECT_FLOAT_EQ(expected[0], out[0]);
+  EXPECT_FLOAT_EQ(expected[1], out[1]);
+  EXPECT_FLOAT_EQ(expected[2], out[2]);
+  EXPECT_FLOAT_EQ(expected[3], out[3]);
 }
 
 TEST(lrn, read_write) {
-    lrn_layer<identity> l1(10, 10, 3, 4, 1.5f, 2.0f, norm_region::across_channels);
-    lrn_layer<identity> l2(10, 10, 3, 4, 1.5f, 2.0f, norm_region::across_channels);
+  lrn_layer<identity> l1(10, 10, 3, 4, 1.5f, 2.0f,
+                         norm_region::across_channels);
+  lrn_layer<identity> l2(10, 10, 3, 4, 1.5f, 2.0f,
+                         norm_region::across_channels);
 
-    l1.init_weight();
-    l2.init_weight();
+  l1.init_weight();
+  l2.init_weight();
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_lrn_layer.h
+++ b/test/test_lrn_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_max_pooling_layer.h
+++ b/test/test_max_pooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <string>

--- a/test/test_max_pooling_layer.h
+++ b/test/test_max_pooling_layer.h
@@ -13,150 +13,105 @@
 namespace tiny_dnn {
 
 TEST(max_pool, read_write) {
-    max_pooling_layer<tan_h> l1(100, 100, 5, 2);
-    max_pooling_layer<tan_h> l2(100, 100, 5, 2);
+  max_pooling_layer<tan_h> l1(100, 100, 5, 2);
+  max_pooling_layer<tan_h> l2(100, 100, 5, 2);
 
-    l1.init_weight();
-    l2.init_weight();
+  l1.init_weight();
+  l2.init_weight();
 
-    serialization_test(l1, l2);
+  serialization_test(l1, l2);
 }
 
 TEST(max_pool, forward) {
-    max_pooling_layer<identity> l(4, 4, 1, 2);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  max_pooling_layer<identity> l(4, 4, 1, 2);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        8, 6,
-        4, 2
-    };
+  vec_t expected = {8, 6, 4, 2};
 
-    vec_t res = l.forward({ { in } })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(max_pool, setup_tiny) {
-    max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::tiny_dnn);
+  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::tiny_dnn);
 
-    EXPECT_EQ(l.parallelize(),           true);           // if layer can be parallelized
-    EXPECT_EQ(l.in_channels(),           cnn_size_t(1));  // num of input tensors
-    EXPECT_EQ(l.out_channels(),          cnn_size_t(2));  // num of output tensors
-    EXPECT_EQ(l.in_data_size(),          cnn_size_t(16)); // size of input tensors
-    EXPECT_EQ(l.out_data_size(),         cnn_size_t(4));  // size of output tensors
-    EXPECT_EQ(l.in_data_shape().size(),  cnn_size_t(1));  // num of inputs shapes
-    EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
-    EXPECT_EQ(l.weights().size(),        cnn_size_t(0));  // the wieghts vector size
-    EXPECT_EQ(l.weights_grads().size(),  cnn_size_t(0));  // the wieghts vector size
-    EXPECT_EQ(l.inputs().size(),         cnn_size_t(1));  // num of input edges
-    EXPECT_EQ(l.outputs().size(),        cnn_size_t(2));  // num of outpus edges
-    EXPECT_EQ(l.in_types().size(),       cnn_size_t(1));  // num of input data types
-    EXPECT_EQ(l.out_types().size(),      cnn_size_t(2));  // num of output data types
-    EXPECT_EQ(l.fan_in_size(),           cnn_size_t(4));  // num of incoming connections
-    EXPECT_EQ(l.fan_out_size(),          cnn_size_t(1));  // num of outgoing connections
-    EXPECT_STREQ(l.layer_type().c_str(), "max-pool");     // string with layer type
+  EXPECT_EQ(l.parallelize(), true);             // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), cnn_size_t(1));    // num of input tensors
+  EXPECT_EQ(l.out_channels(), cnn_size_t(2));   // num of output tensors
+  EXPECT_EQ(l.in_data_size(), cnn_size_t(16));  // size of input tensors
+  EXPECT_EQ(l.out_data_size(), cnn_size_t(4));  // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(), cnn_size_t(1));   // num of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
+  EXPECT_EQ(l.weights().size(), cnn_size_t(0));  // the wieghts vector size
+  EXPECT_EQ(l.weights_grads().size(),
+            cnn_size_t(0));                        // the wieghts vector size
+  EXPECT_EQ(l.inputs().size(), cnn_size_t(1));     // num of input edges
+  EXPECT_EQ(l.outputs().size(), cnn_size_t(2));    // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), cnn_size_t(1));   // num of input data types
+  EXPECT_EQ(l.out_types().size(), cnn_size_t(2));  // num of output data types
+  EXPECT_EQ(l.fan_in_size(), cnn_size_t(4));   // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), cnn_size_t(1));  // num of outgoing connections
+  EXPECT_STREQ(l.layer_type().c_str(), "max-pool");  // string with layer type
 }
 
 TEST(max_pool, forward_stride_tiny) {
-    max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::tiny_dnn);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::tiny_dnn);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        8, 6,
-        4, 2
-    };
+  vec_t expected = {8, 6, 4, 2};
 
-    vec_t res = l.forward({ {in} })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 #ifdef CNN_USE_NNPACK
 TEST(max_pool, forward_stride_nnp) {
-    max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::nnpack);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::nnpack);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        8, 6,
-        4, 2
-    };
+  vec_t expected = {8, 6, 4, 2};
 
-    vec_t res = l.forward({ {in} })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 #endif
 
 TEST(max_pool, forward_stride) {
-    max_pooling_layer<identity> l(4, 4, 1, 2, 1);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  max_pooling_layer<identity> l(4, 4, 1, 2, 1);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t expected = {
-        8, 7, 6,
-        8, 7, 6,
-        4, 3, 2
-    };
+  vec_t expected = {8, 7, 6, 8, 7, 6, 4, 3, 2};
 
-    vec_t res = l.forward({ { in } })[0][0];
+  vec_t res = l.forward({{in}})[0][0];
 
-    for (size_t i = 0; i < expected.size(); i++) {
-        EXPECT_FLOAT_EQ(expected[i], res[i]);
-    }
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
 }
 
 TEST(max_pool, backward) {
-    max_pooling_layer<identity> l(4, 4, 1, 2);
-    vec_t in = {
-        0, 1, 2, 3,
-        8, 7, 5, 6,
-        4, 3, 1, 2,
-        0,-1,-2,-3
-    };
+  max_pooling_layer<identity> l(4, 4, 1, 2);
+  vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
-    vec_t out_grad = {
-        1, 2,
-        3, 4
-    };
+  vec_t out_grad = {1, 2, 3, 4};
 
-    vec_t in_grad_expected = {
-        0, 0, 0, 0,
-        1, 0, 0, 2,
-        3, 0, 0, 4,
-        0, 0, 0, 0
-    };
+  vec_t in_grad_expected = {0, 0, 0, 0, 1, 0, 0, 2, 3, 0, 0, 4, 0, 0, 0, 0};
 
-    l.forward({ {in} })[0];
-    vec_t in_grad = l.backward(std::vector<tensor_t>{ {out_grad}})[0][0];
+  l.forward({{in}})[0];
+  vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
 
-    for (size_t i = 0; i < in_grad.size(); i++) {
-        EXPECT_FLOAT_EQ(in_grad_expected[i], in_grad[i]);
-    }
+  for (size_t i = 0; i < in_grad.size(); i++) {
+    EXPECT_FLOAT_EQ(in_grad_expected[i], in_grad[i]);
+  }
 }
 
 }  // namespace tiny_dnn

--- a/test/test_models.h
+++ b/test/test_models.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_models.h
+++ b/test/test_models.h
@@ -12,23 +12,23 @@ using namespace tiny_dnn;
 namespace tiny_dnn {
 
 TEST(models, alexnet) {
-    models::alexnet nn("alexnet");
- 
-    ASSERT_EQ(nn.name(), "alexnet");
-    EXPECT_EQ(nn.in_data_size(), cnn_size_t(224 * 224 * 3));
+  models::alexnet nn("alexnet");
 
-    vec_t in(nn.in_data_size());
+  ASSERT_EQ(nn.name(), "alexnet");
+  EXPECT_EQ(nn.in_data_size(), cnn_size_t(224 * 224 * 3));
 
-    // generate random variables
-    uniform_rand(in.begin(), in.end(), 0, 1);
+  vec_t in(nn.in_data_size());
 
-    // init wieghts and biases
-    nn.weight_init(weight_init::constant(2.0));
-    nn.bias_init(weight_init::constant(2.0));
-    nn.init_weight();
+  // generate random variables
+  uniform_rand(in.begin(), in.end(), 0, 1);
 
-    // predict
-    auto res = nn.predict(in);
+  // init wieghts and biases
+  nn.weight_init(weight_init::constant(2.0));
+  nn.bias_init(weight_init::constant(2.0));
+  nn.init_weight();
+
+  // predict
+  auto res = nn.predict(in);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -13,139 +13,132 @@ using namespace tiny_dnn::activation;
 using namespace tiny_dnn::layers;
 
 class test_fc_layer : public fully_connected_layer<tan_h> {
-public:
-    typedef fully_connected_layer<tan_h> base;
+ public:
+  typedef fully_connected_layer<tan_h> base;
 
-    test_fc_layer() : base(10, 10) {
-        ++counter();
-    }
+  test_fc_layer() : base(10, 10) { ++counter(); }
 
-    test_fc_layer(const test_fc_layer& fc) : base(10, 10) {
-        ++counter();
-    }
+  test_fc_layer(const test_fc_layer& fc) : base(10, 10) { ++counter(); }
 
-    virtual ~test_fc_layer() {
-        --counter();
-    }
+  virtual ~test_fc_layer() { --counter(); }
 
-    test_fc_layer(test_fc_layer&& r) : base(std::move(r)){
-        ++counter();
-    }
+  test_fc_layer(test_fc_layer&& r) : base(std::move(r)) { ++counter(); }
 
-    static int& counter() { static int i = 0; return i; }
+  static int& counter() {
+    static int i = 0;
+    return i;
+  }
 };
 
 TEST(network, construct_sequential_by_local_variables) {
-    {
-        network<sequential> net;
-        test_fc_layer fc1, fc2;
-        net << fc1 << fc2;
-        ASSERT_EQ(test_fc_layer::counter(), 2);
-    }
-    ASSERT_EQ(test_fc_layer::counter(), 0);
+  {
+    network<sequential> net;
+    test_fc_layer fc1, fc2;
+    net << fc1 << fc2;
+    ASSERT_EQ(test_fc_layer::counter(), 2);
+  }
+  ASSERT_EQ(test_fc_layer::counter(), 0);
 }
 
 TEST(network, construct_sequential_by_temporary_variables) {
-    {
-        network<sequential> net;
-        net << test_fc_layer() << test_fc_layer();
-        ASSERT_EQ(test_fc_layer::counter(), 2);
-    }
-    ASSERT_EQ(test_fc_layer::counter(), 0);
+  {
+    network<sequential> net;
+    net << test_fc_layer() << test_fc_layer();
+    ASSERT_EQ(test_fc_layer::counter(), 2);
+  }
+  ASSERT_EQ(test_fc_layer::counter(), 0);
 }
 
 TEST(network, construct_sequential_by_shared_ptr) {
-    {
-        network<sequential> net;
-        auto fc1 = std::make_shared<test_fc_layer>();
-        auto fc2 = std::make_shared<test_fc_layer>();
-        net << fc1 << fc2;
-        ASSERT_EQ(test_fc_layer::counter(), 2);
-    }
-    ASSERT_EQ(test_fc_layer::counter(), 0);
+  {
+    network<sequential> net;
+    auto fc1 = std::make_shared<test_fc_layer>();
+    auto fc2 = std::make_shared<test_fc_layer>();
+    net << fc1 << fc2;
+    ASSERT_EQ(test_fc_layer::counter(), 2);
+  }
+  ASSERT_EQ(test_fc_layer::counter(), 0);
 }
 
 TEST(network, construct_multi_by_local_variables) {
-    network<sequential> net;
-    conv<tan_h> conv1(32, 32, 5, 1, 6, padding::same);
-    conv<sigmoid> conv2(32, 32, 7, 6, 12, padding::same);
-    max_pool<relu> pool1(32, 32, 12, 2);
-    lrn_layer<identity> lrn(16, 16, 4, 12);
-    dropout dp(16*16*12, 0.5);
-    fc<softmax> full(16*16*12, 1);
+  network<sequential> net;
+  conv<tan_h> conv1(32, 32, 5, 1, 6, padding::same);
+  conv<sigmoid> conv2(32, 32, 7, 6, 12, padding::same);
+  max_pool<relu> pool1(32, 32, 12, 2);
+  lrn_layer<identity> lrn(16, 16, 4, 12);
+  dropout dp(16 * 16 * 12, 0.5);
+  fc<softmax> full(16 * 16 * 12, 1);
 
-    net << conv1 << conv2 << pool1 << lrn << dp << full;
+  net << conv1 << conv2 << pool1 << lrn << dp << full;
 }
 
 TEST(network, construct_multi_by_temporary_variables) {
-    network<sequential> net;
-    net << conv<tan_h>(32, 32, 5, 1, 6, padding::same)
-        << conv<sigmoid>(32, 32, 7, 6, 12, padding::same)
-        << max_pool<relu>(32, 32, 12, 2)
-        << lrn_layer<identity>(16, 16, 4, 12)
-        << dropout(16 * 16 * 12, 0.5)
-        << fc<softmax>(16 * 16 * 12, 1);
+  network<sequential> net;
+  net << conv<tan_h>(32, 32, 5, 1, 6, padding::same)
+      << conv<sigmoid>(32, 32, 7, 6, 12, padding::same)
+      << max_pool<relu>(32, 32, 12, 2) << lrn_layer<identity>(16, 16, 4, 12)
+      << dropout(16 * 16 * 12, 0.5) << fc<softmax>(16 * 16 * 12, 1);
 }
 
 TEST(network, in_dim) {
-    network<sequential> net;
-    convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
-    max_pooling_layer<identity> p1(32, 32, 6, 2);
-    net << c1 << p1;
+  network<sequential> net;
+  convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
+  max_pooling_layer<identity> p1(32, 32, 6, 2);
+  net << c1 << p1;
 
-    EXPECT_EQ(c1.in_data_size(), net.in_data_size());
+  EXPECT_EQ(c1.in_data_size(), net.in_data_size());
 }
 
 TEST(network, out_dim) {
-    network<sequential> net;
-    convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
-    max_pooling_layer<identity> p1(32, 32, 6, 2);
-    net << c1 << p1;
+  network<sequential> net;
+  convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
+  max_pooling_layer<identity> p1(32, 32, 6, 2);
+  net << c1 << p1;
 
-    EXPECT_EQ(p1.out_data_size(), net.out_data_size());
+  EXPECT_EQ(p1.out_data_size(), net.out_data_size());
 }
 
 TEST(network, name) {
+  network<sequential> net1;
+  network<sequential> net2("foo");
 
-    network<sequential> net1;
-    network<sequential> net2("foo");
-
-    EXPECT_EQ(net1.name(), "");
-    EXPECT_EQ(net2.name(), "foo");
+  EXPECT_EQ(net1.name(), "");
+  EXPECT_EQ(net2.name(), "foo");
 }
 
 TEST(network, add) {
-    network<sequential> net;
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same);
+  network<sequential> net;
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same);
 
-    EXPECT_EQ(net.depth(), static_cast<cnn_size_t>(1));
+  EXPECT_EQ(net.depth(), static_cast<cnn_size_t>(1));
 }
 
 TEST(network, manual_init) {
-    // initializing weights directly
-    network<sequential> net;
-    net << convolutional_layer<identity>(3, 3, 3, 1, 1)
-        << fully_connected_layer<softmax>(1, 2, false);
+  // initializing weights directly
+  network<sequential> net;
+  net << convolutional_layer<identity>(3, 3, 3, 1, 1)
+      << fully_connected_layer<softmax>(1, 2, false);
 
-    adagrad opt;
+  adagrad opt;
 
-    vec_t* c1_w = net[0]->weights()[0];
-    vec_t* c1_b = net[0]->weights()[1];
-    vec_t* f1_w = net[1]->weights()[0];
+  vec_t* c1_w = net[0]->weights()[0];
+  vec_t* c1_b = net[0]->weights()[1];
+  vec_t* f1_w = net[1]->weights()[0];
 
-    EXPECT_EQ(c1_w->size(), static_cast<cnn_size_t>(9));
-    EXPECT_EQ(c1_b->size(), static_cast<cnn_size_t>(1));
-    EXPECT_EQ(f1_w->size(), static_cast<cnn_size_t>(2));
+  EXPECT_EQ(c1_w->size(), static_cast<cnn_size_t>(9));
+  EXPECT_EQ(c1_b->size(), static_cast<cnn_size_t>(1));
+  EXPECT_EQ(f1_w->size(), static_cast<cnn_size_t>(2));
 
-    *c1_w = { 0,1,2,3,4,5,6,7,8 };
-    *c1_b = { 1 };
-    *f1_w = { 1,2 };
+  *c1_w = {0, 1, 2, 3, 4, 5, 6, 7, 8};
+  *c1_b = {1};
+  *f1_w = {1, 2};
 
-    // check if the training and predicting works
-    // https://github.com/tiny-dnn/tiny-dnn/issues/330
-    net.predict({ 1,1,1,1,1,1,1,1,1 });
+  // check if the training and predicting works
+  // https://github.com/tiny-dnn/tiny-dnn/issues/330
+  net.predict({1, 1, 1, 1, 1, 1, 1, 1, 1});
 
-    net.train<mse, adagrad>(opt, tensor_t{ {1,1,1,1,1,1,1,1,1} }, tensor_t{ {1,2} }, 1, 1);
+  net.train<mse, adagrad>(opt, tensor_t{{1, 1, 1, 1, 1, 1, 1, 1, 1}},
+                          tensor_t{{1, 2}}, 1, 1);
 }
 
 // TODO(nyanp): check out values again since the routine it's a bit sensitive
@@ -175,9 +168,11 @@ TEST(network, manual_init) {
 
         out.emplace_back(std::vector<vec_t>{
             { static_cast<float_t>(in[0] && in[1]),
-              static_cast<float_t>(in[0] || in[1]) }, // 1st output train and/or function
+              static_cast<float_t>(in[0] || in[1]) }, // 1st output train and/or
+function
             { static_cast<float_t>(in[0] ^  in[1]),
-              static_cast<float_t>(in[0] == in[1]) } // 2nd output train xor/eq function
+              static_cast<float_t>(in[0] == in[1]) } // 2nd output train xor/eq
+function
         });
     }
 
@@ -186,7 +181,8 @@ TEST(network, manual_init) {
 
     optimizer.alpha *= 10;
 
-    //net.fit<mse>(optimizer, data, out, 10, 10, nop, [&](){ std::cout << net.get_loss<mse>(data,out) << std::endl;});
+    //net.fit<mse>(optimizer, data, out, 10, 10, nop, [&](){ std::cout <<
+net.get_loss<mse>(data,out) << std::endl;});
     net.fit<mse>(optimizer, data, out, 10, 10);
 
     for (size_t i = 0; i < tnum; i++) {
@@ -205,365 +201,361 @@ TEST(network, manual_init) {
 }*/
 
 TEST(network, train_predict) {
-    // train xor function
-    network<sequential> net;
-    adagrad optimizer;
+  // train xor function
+  network<sequential> net;
+  adagrad optimizer;
 
-    std::vector<vec_t> data;
-    std::vector<label_t> label;
-    size_t tnum = 300;
+  std::vector<vec_t> data;
+  std::vector<label_t> label;
+  size_t tnum = 300;
 
-    optimizer.alpha *= 10;
+  optimizer.alpha *= 10;
 
-    for (size_t i = 0; i < tnum; i++) {
-        bool in[2] = { bernoulli(0.5), bernoulli(0.5) };
-        data.push_back({ static_cast<float_t>(in[0]),
-                         static_cast<float_t>(in[1]) });
-        label.push_back((in[0] ^ in[1]) ? 1 : 0);
-    }
+  for (size_t i = 0; i < tnum; i++) {
+    bool in[2] = {bernoulli(0.5), bernoulli(0.5)};
+    data.push_back({static_cast<float_t>(in[0]), static_cast<float_t>(in[1])});
+    label.push_back((in[0] ^ in[1]) ? 1 : 0);
+  }
 
-    net << fully_connected_layer<tan_h>(2, 10)
-        << fully_connected_layer<tan_h>(10, 2);
+  net << fully_connected_layer<tan_h>(2, 10)
+      << fully_connected_layer<tan_h>(10, 2);
 
-    net.train<mse>(optimizer, data, label, 10, 10);
+  net.train<mse>(optimizer, data, label, 10, 10);
 
-
-    for (size_t i = 0; i < tnum; i++) {
-        bool in[2] = { bernoulli(0.5), bernoulli(0.5) };
-        label_t expected = (in[0] ^ in[1]) ? 1 : 0;
-        label_t actual = net.predict_label({ static_cast<float_t>(in[0]),
-                                             static_cast<float_t>(in[1]) });
-        EXPECT_EQ(expected, actual);
-    }
+  for (size_t i = 0; i < tnum; i++) {
+    bool in[2] = {bernoulli(0.5), bernoulli(0.5)};
+    label_t expected = (in[0] ^ in[1]) ? 1 : 0;
+    label_t actual = net.predict_label(
+        {static_cast<float_t>(in[0]), static_cast<float_t>(in[1])});
+    EXPECT_EQ(expected, actual);
+  }
 }
 
 TEST(network, set_netphase) {
-    // TODO: add unit-test for public api
+  // TODO: add unit-test for public api
 }
 
 TEST(network, test) {
-    network<sequential> net;
-    fully_connected_layer<identity> fc(30, 1);
-    int data_num = 300;
+  network<sequential> net;
+  fully_connected_layer<identity> fc(30, 1);
+  int data_num = 300;
 
-    net << fc;
-    net.weight_init(weight_init::constant(1.0));
-    net.init_weight();
+  net << fc;
+  net.weight_init(weight_init::constant(1.0));
+  net.init_weight();
 
-    std::vector<vec_t> in, expected;
+  std::vector<vec_t> in, expected;
 
-    for (int i = 0; i < data_num; i++) {
-        vec_t v(30);
-        uniform_rand(v.begin(), v.end(), -1.0, 1.0);
-        float_t sum = std::accumulate(v.begin(), v.end(), (float_t)0.0);
+  for (int i = 0; i < data_num; i++) {
+    vec_t v(30);
+    uniform_rand(v.begin(), v.end(), -1.0, 1.0);
+    float_t sum = std::accumulate(v.begin(), v.end(), (float_t)0.0);
 
-        in.emplace_back(v);
-        expected.emplace_back(vec_t{sum});
-    }
+    in.emplace_back(v);
+    expected.emplace_back(vec_t{sum});
+  }
 
-    auto out = net.test(in);
-    for (int i = 0; i < data_num; i++) { 
-        for (size_t j = 0; j < out[i].size(); j++)
-            EXPECT_FLOAT_EQ(out[i][j], expected[i][0]);
-    }
+  auto out = net.test(in);
+  for (int i = 0; i < data_num; i++) {
+    for (size_t j = 0; j < out[i].size(); j++)
+      EXPECT_FLOAT_EQ(out[i][j], expected[i][0]);
+  }
 }
 
 TEST(network, get_loss) {
-    // TODO: add unit-test for public api
+  // TODO: add unit-test for public api
 }
 
 TEST(network, at) {
-    network<sequential> net;
-    convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
-    average_pooling_layer<identity> p1(32, 32, 6, 2);
+  network<sequential> net;
+  convolutional_layer<identity> c1(32, 32, 5, 3, 6, padding::same);
+  average_pooling_layer<identity> p1(32, 32, 6, 2);
 
-    net << c1 << p1;
-    net.init_weight();
+  net << c1 << p1;
+  net.init_weight();
 
-    // auto& c = net.at<convolutional_layer<identity>>(0);
-    // auto& p = net.at<average_pooling_layer<identity>>(1);
+  // auto& c = net.at<convolutional_layer<identity>>(0);
+  // auto& p = net.at<average_pooling_layer<identity>>(1);
 }
 
 TEST(network, bracket_operator) {
-    network<sequential> net;
+  network<sequential> net;
 
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
-        << average_pooling_layer<identity>(32, 32, 6, 2);
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
+      << average_pooling_layer<identity>(32, 32, 6, 2);
 
-    EXPECT_EQ(net[0]->layer_type(), "conv");
-    EXPECT_EQ(net[1]->layer_type(), "ave-pool");
+  EXPECT_EQ(net[0]->layer_type(), "conv");
+  EXPECT_EQ(net[1]->layer_type(), "ave-pool");
 }
 
-
 TEST(network, weight_init) {
-    network<sequential> net;
+  network<sequential> net;
 
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
-        << average_pooling_layer<identity>(32, 32, 6, 2);
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
+      << average_pooling_layer<identity>(32, 32, 6, 2);
 
-    // change all layers at once
-    net.weight_init(weight_init::constant(2.0));
-    net.init_weight();
+  // change all layers at once
+  net.weight_init(weight_init::constant(2.0));
+  net.init_weight();
 
-    vec_t& w1 = *net[0]->weights()[0];
-    vec_t& w2 = *net[1]->weights()[0];
+  vec_t& w1 = *net[0]->weights()[0];
+  vec_t& w2 = *net[1]->weights()[0];
 
-    for (size_t i = 0; i < w1.size(); i++)
-        EXPECT_NEAR(w1[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w1.size(); i++) EXPECT_NEAR(w1[i], 2.0, 1e-10);
 
-    for (size_t i = 0; i < w2.size(); i++)
-        EXPECT_NEAR(w2[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w2.size(); i++) EXPECT_NEAR(w2[i], 2.0, 1e-10);
 }
 
 TEST(network, weight_init_per_layer) {
-    network<sequential> net;
+  network<sequential> net;
 
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
-        << average_pooling_layer<identity>(32, 32, 6, 2);
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
+      << average_pooling_layer<identity>(32, 32, 6, 2);
 
-    // change specific layer
-    net[0]->weight_init(weight_init::constant(2.0));
-    net[1]->weight_init(weight_init::constant(1.0));
-    net.init_weight();
+  // change specific layer
+  net[0]->weight_init(weight_init::constant(2.0));
+  net[1]->weight_init(weight_init::constant(1.0));
+  net.init_weight();
 
-    vec_t& w1 = *net[0]->weights()[0];
-    vec_t& w2 = *net[1]->weights()[0];
+  vec_t& w1 = *net[0]->weights()[0];
+  vec_t& w2 = *net[1]->weights()[0];
 
-    for (size_t i = 0; i < w1.size(); i++)
-        EXPECT_NEAR(w1[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w1.size(); i++) EXPECT_NEAR(w1[i], 2.0, 1e-10);
 
-    for (size_t i = 0; i < w2.size(); i++)
-        EXPECT_NEAR(w2[i], 1.0, 1e-10);
+  for (size_t i = 0; i < w2.size(); i++) EXPECT_NEAR(w2[i], 1.0, 1e-10);
 }
 
 TEST(network, bias_init) {
-    network<sequential> net;
+  network<sequential> net;
 
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
-        << average_pooling_layer<identity>(32, 32, 6, 2);
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
+      << average_pooling_layer<identity>(32, 32, 6, 2);
 
-    net.bias_init(weight_init::constant(2.0));
-    net.init_weight();
+  net.bias_init(weight_init::constant(2.0));
+  net.init_weight();
 
-    vec_t& w1 = *net[0]->weights()[1];
-    vec_t& w2 = *net[1]->weights()[1];
+  vec_t& w1 = *net[0]->weights()[1];
+  vec_t& w2 = *net[1]->weights()[1];
 
-    for (size_t i = 0; i < w1.size(); i++)
-        EXPECT_NEAR(w1[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w1.size(); i++) EXPECT_NEAR(w1[i], 2.0, 1e-10);
 
-    for (size_t i = 0; i < w2.size(); i++)
-        EXPECT_NEAR(w2[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w2.size(); i++) EXPECT_NEAR(w2[i], 2.0, 1e-10);
 }
 
 TEST(network, bias_init_per_layer) {
-    network<sequential> net;
+  network<sequential> net;
 
-    net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
-        << average_pooling_layer<identity>(32, 32, 6, 2);
+  net << convolutional_layer<identity>(32, 32, 5, 3, 6, padding::same)
+      << average_pooling_layer<identity>(32, 32, 6, 2);
 
-    net[0]->bias_init(weight_init::constant(2.0));
-    net[1]->bias_init(weight_init::constant(1.0));
-    net.init_weight();
+  net[0]->bias_init(weight_init::constant(2.0));
+  net[1]->bias_init(weight_init::constant(1.0));
+  net.init_weight();
 
-    vec_t& w1 = *net[0]->weights()[1];
-    vec_t& w2 = *net[1]->weights()[1];
+  vec_t& w1 = *net[0]->weights()[1];
+  vec_t& w2 = *net[1]->weights()[1];
 
-    for (size_t i = 0; i < w1.size(); i++)
-        EXPECT_NEAR(w1[i], 2.0, 1e-10);
+  for (size_t i = 0; i < w1.size(); i++) EXPECT_NEAR(w1[i], 2.0, 1e-10);
 
-    for (size_t i = 0; i < w2.size(); i++)
-        EXPECT_NEAR(w2[i], 1.0, 1e-10);
+  for (size_t i = 0; i < w2.size(); i++) EXPECT_NEAR(w2[i], 1.0, 1e-10);
 }
 
-TEST(network, gradient_check) { // sigmoid - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef sigmoid activation;
-    typedef network<sequential> network;
+TEST(network, gradient_check) {  // sigmoid - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef sigmoid activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(10, 14*14*3)
-       << convolutional_layer<activation>(14, 14, 5, 3, 6)
-       << average_pooling_layer<activation>(10, 10, 6, 2)
-       << fully_connected_layer<activation>(5*5*6, 3);
+  network nn;
+  nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
+     << convolutional_layer<activation>(14, 14, 5, 3, 6)
+     << average_pooling_layer<activation>(10, 10, 6, 2)
+     << fully_connected_layer<activation>(5 * 5 * 6, 3);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             epsilon<float_t>(), GRAD_CHECK_RANDOM));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(),
+                                           GRAD_CHECK_RANDOM));
 }
 
-TEST(network, gradient_check2) { // tan_h - mse
-    typedef mse loss_func;
-    typedef tan_h activation;
-    typedef network<sequential> network;
+TEST(network, gradient_check2) {  // tan_h - mse
+  typedef mse loss_func;
+  typedef tan_h activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
-       << convolutional_layer<activation>(14, 14, 5, 3, 6)
-       << average_pooling_layer<activation>(10, 10, 6, 2)
-       << fully_connected_layer<activation>(5 * 5 * 6, 3);
+  network nn;
+  nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
+     << convolutional_layer<activation>(14, 14, 5, 3, 6)
+     << average_pooling_layer<activation>(10, 10, 6, 2)
+     << fully_connected_layer<activation>(5 * 5 * 6, 3);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             epsilon<float_t>(), GRAD_CHECK_RANDOM));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(),
+                                           GRAD_CHECK_RANDOM));
 }
 
-TEST(network, gradient_check3) { // mixture - mse
-    typedef mse loss_func;
-    typedef network<sequential> network;
+TEST(network, gradient_check3) {  // mixture - mse
+  typedef mse loss_func;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<tan_h>(10, 14 * 14 * 3)
-       << convolutional_layer<sigmoid>(14, 14, 5, 3, 6)
-       << average_pooling_layer<rectified_linear>(10, 10, 6, 2)
-       << fully_connected_layer<identity>(5 * 5 * 6, 3);
+  network nn;
+  nn << fully_connected_layer<tan_h>(10, 14 * 14 * 3)
+     << convolutional_layer<sigmoid>(14, 14, 5, 3, 6)
+     << average_pooling_layer<rectified_linear>(10, 10, 6, 2)
+     << fully_connected_layer<identity>(5 * 5 * 6, 3);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             epsilon<float_t>(), GRAD_CHECK_RANDOM));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(),
+                                           GRAD_CHECK_RANDOM));
 }
 
-TEST(network, gradient_check4) { // sigmoid - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef sigmoid activation;
-    typedef network<sequential> network;
+TEST(network, gradient_check4) {  // sigmoid - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef sigmoid activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
-       << convolutional_layer<activation>(14, 14, 5, 3, 6)
-       << average_pooling_layer<activation>(10, 10, 6, 2)
-       << fully_connected_layer<activation>(5 * 5 * 6, 3);
+  network nn;
+  nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
+     << convolutional_layer<activation>(14, 14, 5, 3, 6)
+     << average_pooling_layer<activation>(10, 10, 6, 2)
+     << fully_connected_layer<activation>(5 * 5 * 6, 3);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             epsilon<float_t>(), GRAD_CHECK_RANDOM));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(),
+                                           GRAD_CHECK_RANDOM));
 }
 
-TEST(network, gradient_check5) { // softmax - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef softmax activation;
-    typedef network<sequential> network;
+TEST(network, gradient_check5) {  // softmax - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef softmax activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
-       << convolutional_layer<activation>(14, 14, 5, 3, 6)
-       << average_pooling_layer<activation>(10, 10, 6, 2)
-       << fully_connected_layer<activation>(5 * 5 * 6, 3);
+  network nn;
+  nn << fully_connected_layer<activation>(10, 14 * 14 * 3)
+     << convolutional_layer<activation>(14, 14, 5, 3, 6)
+     << average_pooling_layer<activation>(10, 10, 6, 2)
+     << fully_connected_layer<activation>(5 * 5 * 6, 3);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             1e-1f, GRAD_CHECK_RANDOM));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           1e-1f, GRAD_CHECK_RANDOM));
 }
 
-TEST(network, gradient_check6) { // sigmoid - cross-entropy
-    typedef cross_entropy loss_func;
-    typedef sigmoid activation;
-    typedef network<sequential> network;
+TEST(network, gradient_check6) {  // sigmoid - cross-entropy
+  typedef cross_entropy loss_func;
+  typedef sigmoid activation;
+  typedef network<sequential> network;
 
-    network nn;
-    nn << fully_connected_layer<activation>(3, 201)
-       << fully_connected_layer<activation>(201, 2);
+  network nn;
+  nn << fully_connected_layer<activation>(3, 201)
+     << fully_connected_layer<activation>(201, 2);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first,
-                                             test_data.second,
-                                             epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<loss_func>(test_data.first, test_data.second,
+                                           epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(network, read_write)
-{
-    typedef mse loss_func;
-    typedef network<sequential> network;
+TEST(network, read_write) {
+  typedef mse loss_func;
+  typedef network<sequential> network;
 
-    network n1, n2;
+  network n1, n2;
 
-    n1 << convolutional_layer<tan_h>(32, 32, 5, 1, 6) // C1, 1@32x32-in, 6@28x28-out
-       << average_pooling_layer<tan_h>(28, 28, 6, 2) // S2, 6@28x28-in, 6@14x14-out
-       << convolutional_layer<tan_h>(14, 14, 5, 6, 16) // C3, 6@14x14-in, 16@10x10-in
-       << average_pooling_layer<tan_h>(10, 10, 16, 2) // S4, 16@10x10-in, 16@5x5-out
-       << convolutional_layer<tan_h>(5, 5, 5, 16, 120) // C5, 16@5x5-in, 120@1x1-out
-       << fully_connected_layer<tan_h>(120, 10); // F6, 120-in, 10-out
+  n1 << convolutional_layer<tan_h>(32, 32, 5, 1,
+                                   6)  // C1, 1@32x32-in, 6@28x28-out
+     << average_pooling_layer<tan_h>(28, 28, 6,
+                                     2)  // S2, 6@28x28-in, 6@14x14-out
+     << convolutional_layer<tan_h>(14, 14, 5, 6,
+                                   16)  // C3, 6@14x14-in, 16@10x10-in
+     << average_pooling_layer<tan_h>(10, 10, 16,
+                                     2)  // S4, 16@10x10-in, 16@5x5-out
+     << convolutional_layer<tan_h>(5, 5, 5, 16,
+                                   120)         // C5, 16@5x5-in, 120@1x1-out
+     << fully_connected_layer<tan_h>(120, 10);  // F6, 120-in, 10-out
 
-    n2 << convolutional_layer<tan_h>(32, 32, 5, 1, 6) // C1, 1@32x32-in, 6@28x28-out
-       << average_pooling_layer<tan_h>(28, 28, 6, 2) // S2, 6@28x28-in, 6@14x14-out
-       << convolutional_layer<tan_h>(14, 14, 5, 6, 16) // C3, 6@14x14-in, 16@10x10-in
-       << average_pooling_layer<tan_h>(10, 10, 16, 2) // S4, 16@10x10-in, 16@5x5-out
-       << convolutional_layer<tan_h>(5, 5, 5, 16, 120) // C5, 16@5x5-in, 120@1x1-out
-       << fully_connected_layer<tan_h>(120, 10); // F6, 120-in, 10-out
+  n2 << convolutional_layer<tan_h>(32, 32, 5, 1,
+                                   6)  // C1, 1@32x32-in, 6@28x28-out
+     << average_pooling_layer<tan_h>(28, 28, 6,
+                                     2)  // S2, 6@28x28-in, 6@14x14-out
+     << convolutional_layer<tan_h>(14, 14, 5, 6,
+                                   16)  // C3, 6@14x14-in, 16@10x10-in
+     << average_pooling_layer<tan_h>(10, 10, 16,
+                                     2)  // S4, 16@10x10-in, 16@5x5-out
+     << convolutional_layer<tan_h>(5, 5, 5, 16,
+                                   120)         // C5, 16@5x5-in, 120@1x1-out
+     << fully_connected_layer<tan_h>(120, 10);  // F6, 120-in, 10-out
 
-    n1.init_weight();
-    n2.init_weight();
+  n1.init_weight();
+  n2.init_weight();
 
-    std::vector<vec_t> t;
-    std::vector<label_t> l;
-    t.push_back(vec_t(32*32, 0.0));
-    l.push_back(3);
-    adagrad optimizer;
-    n1.train<loss_func>(optimizer, t, l, 1, 1);
+  std::vector<vec_t> t;
+  std::vector<label_t> l;
+  t.push_back(vec_t(32 * 32, 0.0));
+  l.push_back(3);
+  adagrad optimizer;
+  n1.train<loss_func>(optimizer, t, l, 1, 1);
 
-    serialization_test(n1, n2);
+  serialization_test(n1, n2);
 
-    vec_t in(32*32, 0.0);
+  vec_t in(32 * 32, 0.0);
 
-    auto res1 = n1.predict(in);
-    auto res2 = n2.predict(in);
+  auto res1 = n1.predict(in);
+  auto res2 = n2.predict(in);
 
-    ASSERT_TRUE(n1.has_same_weights(n2, epsilon<float_t>()));
+  ASSERT_TRUE(n1.has_same_weights(n2, epsilon<float_t>()));
 
-    for (int i = 0; i < 10; i++) {
-        tiny_dnn::float_t eps = std::abs(res1[i]) * 1e-5f;
-        ASSERT_TRUE(std::abs(res1[i] - res2[i]) < eps);
-    }
+  for (int i = 0; i < 10; i++) {
+    tiny_dnn::float_t eps = std::abs(res1[i]) * 1e-5f;
+    ASSERT_TRUE(std::abs(res1[i] - res2[i]) < eps);
+  }
 }
 
 TEST(network, trainable) {
-    auto net = make_mlp<sigmoid>({ 2,3,2,1 }); // fc(2,3) - fc(3,2) - fc(2,1)
+  auto net = make_mlp<sigmoid>({2, 3, 2, 1});  // fc(2,3) - fc(3,2) - fc(2,1)
 
-    // trainable=false, or "freeze" 2nd layer fc(3,2)
-    net[1]->set_trainable(false);
+  // trainable=false, or "freeze" 2nd layer fc(3,2)
+  net[1]->set_trainable(false);
 
-    vec_t w0 = { 0,1,2,3,4,5 };
-    vec_t w1 = { 6,7,8,9,8,7 };
-    vec_t w2 = { 6,5 };
+  vec_t w0 = {0, 1, 2, 3, 4, 5};
+  vec_t w1 = {6, 7, 8, 9, 8, 7};
+  vec_t w2 = {6, 5};
 
-    *net[0]->weights()[0] = { 0,1,2,3,4,5 };
-    *net[1]->weights()[0] = { 6,7,8,9,8,7 };
-    *net[2]->weights()[0] = { 6,5 };
+  *net[0]->weights()[0] = {0, 1, 2, 3, 4, 5};
+  *net[1]->weights()[0] = {6, 7, 8, 9, 8, 7};
+  *net[2]->weights()[0] = {6, 5};
 
-    adam a;
+  adam a;
 
-    net.init_weight();
+  net.init_weight();
 
-    auto w0_standby = *net[0]->weights()[0];
-    auto w1_standby = *net[1]->weights()[0];
-    auto w2_standby = *net[2]->weights()[0];
+  auto w0_standby = *net[0]->weights()[0];
+  auto w1_standby = *net[1]->weights()[0];
+  auto w2_standby = *net[2]->weights()[0];
 
-    EXPECT_NE(w0, w0_standby);
-    EXPECT_EQ(w1, w1_standby);
-    EXPECT_NE(w2, w2_standby);
+  EXPECT_NE(w0, w0_standby);
+  EXPECT_EQ(w1, w1_standby);
+  EXPECT_NE(w2, w2_standby);
 
-    std::vector<vec_t> data{ {1,0}, {0,2} };
-    std::vector<vec_t> out{ {2}, {1} };
+  std::vector<vec_t> data{{1, 0}, {0, 2}};
+  std::vector<vec_t> out{{2}, {1}};
 
-    net.fit<mse>(a, data, out, 1, 1);
+  net.fit<mse>(a, data, out, 1, 1);
 
-    auto w0_after_update = *net[0]->weights()[0];
-    auto w1_after_update = *net[1]->weights()[0];
-    auto w2_after_update = *net[2]->weights()[0];
+  auto w0_after_update = *net[0]->weights()[0];
+  auto w1_after_update = *net[1]->weights()[0];
+  auto w2_after_update = *net[2]->weights()[0];
 
-    EXPECT_NE(w0, w0_after_update);
-    EXPECT_EQ(w1, w1_after_update);
-    EXPECT_NE(w2, w2_after_update);
+  EXPECT_NE(w0, w0_after_update);
+  EXPECT_EQ(w1, w1_after_update);
+  EXPECT_NE(w2, w2_after_update);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_no_duplicate_symbols.cpp
+++ b/test/test_no_duplicate_symbols.cpp
@@ -6,9 +6,10 @@
 #include "picotest/picotest.h"
 #include "tiny_dnn/tiny_dnn.h"
 
-TEST(no_duplicate_symbols, no_duplicate_symbols) { 
-    // The real test is that the tests link without errors due to duplicate symbols
-    // typically caused by missing inline keywords in headers.
-    // This is why this test is placed in a separate .cpp file.
-    EXPECT_TRUE(true);
+TEST(no_duplicate_symbols, no_duplicate_symbols) {
+  // The real test is that the tests link without errors due to duplicate
+  // symbols
+  // typically caused by missing inline keywords in headers.
+  // This is why this test is placed in a separate .cpp file.
+  EXPECT_TRUE(true);
 }

--- a/test/test_no_duplicate_symbols.cpp
+++ b/test/test_no_duplicate_symbols.cpp
@@ -1,29 +1,6 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 #define _CRT_SECURE_NO_WARNINGS
 #include "picotest/picotest.h"

--- a/test/test_nodes.h
+++ b/test/test_nodes.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_nodes.h
+++ b/test/test_nodes.h
@@ -12,73 +12,70 @@ using namespace tiny_dnn::layers;
 namespace tiny_dnn {
 
 TEST(nodes, sequential) {
-    network<sequential> nn;
+  network<sequential> nn;
 
-    nn << fc<tan_h>(10, 100)
-       << fc<softmax>(100, 10);
+  nn << fc<tan_h>(10, 100) << fc<softmax>(100, 10);
 }
 
 TEST(nodes, graph_no_branch) {
-    // declare nodes
-    auto in = std::make_shared<input_layer>(shape3d(8, 8, 1));
+  // declare nodes
+  auto in = std::make_shared<input_layer>(shape3d(8, 8, 1));
 
-    auto cnn = std::make_shared<
-        convolutional_layer<tan_h> >(8, 8, 3, 1, 4);
+  auto cnn = std::make_shared<convolutional_layer<tan_h>>(8, 8, 3, 1, 4);
 
-    auto pool = std::make_shared<
-        average_pooling_layer<tan_h> >(6, 6, 4, 2);
+  auto pool = std::make_shared<average_pooling_layer<tan_h>>(6, 6, 4, 2);
 
-    auto out = std::make_shared<linear_layer<relu> >(3 * 3 * 4);
+  auto out = std::make_shared<linear_layer<relu>>(3 * 3 * 4);
 
-    // connect
-    in << cnn << pool << out;
+  // connect
+  in << cnn << pool << out;
 
-    network<graph> net;
-    construct_graph(net, { in }, { out });
+  network<graph> net;
+  construct_graph(net, {in}, {out});
 }
 
 TEST(nodes, graph_branch) {
-    // declare nodes
-    auto in1 = std::make_shared<input_layer>(shape3d(3, 1, 1));
-    auto in2 = std::make_shared<input_layer>(shape3d(3, 1, 1));
-    auto added = std::make_shared<add>(2, 3);
-    auto out = std::make_shared<linear_layer<relu>>(3);
+  // declare nodes
+  auto in1 = std::make_shared<input_layer>(shape3d(3, 1, 1));
+  auto in2 = std::make_shared<input_layer>(shape3d(3, 1, 1));
+  auto added = std::make_shared<add>(2, 3);
+  auto out = std::make_shared<linear_layer<relu>>(3);
 
-    // connect
-    (in1, in2) << added;
-    added << out;
+  // connect
+  (in1, in2) << added;
+  added << out;
 
-    network<graph> net;
-    construct_graph(net, { in1, in2 }, { out });
+  network<graph> net;
+  construct_graph(net, {in1, in2}, {out});
 
-    auto res = net.predict({ { 2,4,3 },{ -1,2,-5 } })[0];
+  auto res = net.predict({{2, 4, 3}, {-1, 2, -5}})[0];
 
-    // relu({2,4,3} + {-1,2,-5}) = {1,6,0}
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[0]), static_cast<float_t>(1.0));
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[1]), static_cast<float_t>(6.0));
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[2]), static_cast<float_t>(0.0));
+  // relu({2,4,3} + {-1,2,-5}) = {1,6,0}
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[0]), static_cast<float_t>(1.0));
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[1]), static_cast<float_t>(6.0));
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[2]), static_cast<float_t>(0.0));
 }
 
 TEST(nodes, graph_branch2) {
-    // declare nodes
-    input_layer in1(shape3d(3, 1, 1));
-    input_layer in2(shape3d(3, 1, 1));
-    add added(2, 3);
-    linear_layer<relu> out(3);
+  // declare nodes
+  input_layer in1(shape3d(3, 1, 1));
+  input_layer in2(shape3d(3, 1, 1));
+  add added(2, 3);
+  linear_layer<relu> out(3);
 
-    // connect
-    (in1, in2) << added;
-    added << out;
+  // connect
+  (in1, in2) << added;
+  added << out;
 
-    network<graph> net;
-    construct_graph(net, { &in1, &in2 }, { &out });
+  network<graph> net;
+  construct_graph(net, {&in1, &in2}, {&out});
 
-    auto res = net.predict({ { 2,4,3 },{ -1,2,-5 } })[0];
+  auto res = net.predict({{2, 4, 3}, {-1, 2, -5}})[0];
 
-    // relu({2,4,3} + {-1,2,-5}) = {1,6,0}
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[0]), static_cast<float_t>(1.0));
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[1]), static_cast<float_t>(6.0));
-    EXPECT_FLOAT_EQ(static_cast<float_t>(res[2]), static_cast<float_t>(0.0));
+  // relu({2,4,3} + {-1,2,-5}) = {1,6,0}
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[0]), static_cast<float_t>(1.0));
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[1]), static_cast<float_t>(6.0));
+  EXPECT_FLOAT_EQ(static_cast<float_t>(res[2]), static_cast<float_t>(0.0));
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_power_layer.h
+++ b/test/test_power_layer.h
@@ -10,37 +10,36 @@
 namespace tiny_dnn {
 
 TEST(power, forward) {
-    power_layer pw(shape3d(3,2,1), 2.0, 1.5);
+  power_layer pw(shape3d(3, 2, 1), 2.0, 1.5);
 
-    tensor_t in = {
-        { 0,1,2,3,4,5 },
-        { -5,-4,-3,-2,-1,0 },
-    };
+  tensor_t in = {
+      {0, 1, 2, 3, 4, 5}, {-5, -4, -3, -2, -1, 0},
+  };
 
-    tensor_t out_expected = {
-        { 0*0*1.5,1*1*1.5,2*2*1.5,3*3*1.5,4*4*1.5,5*5*1.5 },
-        { 5*5*1.5,4*4*1.5,3*3*1.5,2*2*1.5,1*1*1.5,0*0*1.5 }
-    };
+  tensor_t out_expected = {{0 * 0 * 1.5, 1 * 1 * 1.5, 2 * 2 * 1.5, 3 * 3 * 1.5,
+                            4 * 4 * 1.5, 5 * 5 * 1.5},
+                           {5 * 5 * 1.5, 4 * 4 * 1.5, 3 * 3 * 1.5, 2 * 2 * 1.5,
+                            1 * 1 * 1.5, 0 * 0 * 1.5}};
 
-    auto out = pw.forward({in});
+  auto out = pw.forward({in});
 
-    for (cnn_size_t i = 0; i < 6; i++) {
-        EXPECT_FLOAT_EQ(out_expected[0][i], out[0][0][i]);
-        EXPECT_FLOAT_EQ(out_expected[1][i], out[0][1][i]);
-    }
+  for (cnn_size_t i = 0; i < 6; i++) {
+    EXPECT_FLOAT_EQ(out_expected[0][i], out[0][0][i]);
+    EXPECT_FLOAT_EQ(out_expected[1][i], out[0][1][i]);
+  }
 }
-
 
 TEST(power, gradient_check) {
-    network<sequential> nn;
+  network<sequential> nn;
 
-    nn << fully_connected_layer<tan_h>(10, 20)
-       << power_layer(shape3d(20, 1, 1), 3.0, 1.5)
-       << fully_connected_layer<tan_h>(20, 10);
+  nn << fully_connected_layer<tan_h>(10, 20)
+     << power_layer(shape3d(20, 1, 1), 3.0, 1.5)
+     << fully_connected_layer<tan_h>(20, 10);
 
-    const auto test_data = generate_gradient_check_data(nn.in_data_size());
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second, epsilon<float_t>(), GRAD_CHECK_ALL));
+  const auto test_data = generate_gradient_check_data(nn.in_data_size());
+  nn.init_weight();
+  EXPECT_TRUE(nn.gradient_check<mse>(test_data.first, test_data.second,
+                                     epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_power_layer.h
+++ b/test/test_power_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_quantization.h
+++ b/test/test_quantization.h
@@ -10,64 +10,91 @@
 namespace tiny_dnn {
 
 TEST(quantization_utils, float_to_quantized) {
-  EXPECT_EQ(uint8_t(0), core::kernels::float_to_quantized<uint8_t>(0.0f, 0.0f, 1.0f));
-  EXPECT_EQ(uint8_t(0), core::kernels::float_to_quantized<uint8_t>(0.0f, 0.0f, 2.0f));
-  EXPECT_EQ(uint8_t(128), core::kernels::float_to_quantized<uint8_t>(0.5f, 0.0f, 1.0f));
-  EXPECT_EQ(uint8_t(128), core::kernels::float_to_quantized<uint8_t>(1.0f, 0.0f, 2.0f));
-  EXPECT_EQ(uint8_t(255), core::kernels::float_to_quantized<uint8_t>(1.0f, 0.0f, 1.0f));
-  EXPECT_EQ(uint8_t(255), core::kernels::float_to_quantized<uint8_t>(2.0f, 0.0f, 2.0f));
-  EXPECT_EQ(uint8_t(0), core::kernels::float_to_quantized<uint8_t>(-128.0f, -128.0f, 127.0f));
-  EXPECT_EQ(uint8_t(128), core::kernels::float_to_quantized<uint8_t>(0.0f, -128.0f, 127.0f));
-  EXPECT_EQ(uint8_t(255), core::kernels::float_to_quantized<uint8_t>(127.0f, -128.0f, 127.0f));
-  EXPECT_EQ(uint8_t(0), core::kernels::float_to_quantized<uint8_t>(1.0f, 1.0f, 256.0f));
-  EXPECT_EQ(uint8_t(127), core::kernels::float_to_quantized<uint8_t>(128.0f, 1.0f, 256.0f));
-  EXPECT_EQ(uint8_t(255), core::kernels::float_to_quantized<uint8_t>(256.0f, 1.0f, 256.0f));
+  EXPECT_EQ(uint8_t(0),
+            core::kernels::float_to_quantized<uint8_t>(0.0f, 0.0f, 1.0f));
+  EXPECT_EQ(uint8_t(0),
+            core::kernels::float_to_quantized<uint8_t>(0.0f, 0.0f, 2.0f));
+  EXPECT_EQ(uint8_t(128),
+            core::kernels::float_to_quantized<uint8_t>(0.5f, 0.0f, 1.0f));
+  EXPECT_EQ(uint8_t(128),
+            core::kernels::float_to_quantized<uint8_t>(1.0f, 0.0f, 2.0f));
+  EXPECT_EQ(uint8_t(255),
+            core::kernels::float_to_quantized<uint8_t>(1.0f, 0.0f, 1.0f));
+  EXPECT_EQ(uint8_t(255),
+            core::kernels::float_to_quantized<uint8_t>(2.0f, 0.0f, 2.0f));
+  EXPECT_EQ(uint8_t(0), core::kernels::float_to_quantized<uint8_t>(
+                            -128.0f, -128.0f, 127.0f));
+  EXPECT_EQ(uint8_t(128),
+            core::kernels::float_to_quantized<uint8_t>(0.0f, -128.0f, 127.0f));
+  EXPECT_EQ(uint8_t(255), core::kernels::float_to_quantized<uint8_t>(
+                              127.0f, -128.0f, 127.0f));
+  EXPECT_EQ(uint8_t(0),
+            core::kernels::float_to_quantized<uint8_t>(1.0f, 1.0f, 256.0f));
+  EXPECT_EQ(uint8_t(127),
+            core::kernels::float_to_quantized<uint8_t>(128.0f, 1.0f, 256.0f));
+  EXPECT_EQ(uint8_t(255),
+            core::kernels::float_to_quantized<uint8_t>(256.0f, 1.0f, 256.0f));
 
   const int int32_min = std::numeric_limits<int>::min();
   const int int32_max = std::numeric_limits<int>::max();
 
-  EXPECT_EQ(int32_t(int32_min),
-            core::kernels::float_to_quantized<int32_t>(-128.0f, -128.0f, 128.0f));
-  EXPECT_EQ(int32_t(0), core::kernels::float_to_quantized<int32_t>(0.0f, -128.0f, 128.0f));
-  EXPECT_EQ(int32_t(int32_max),
-            core::kernels::float_to_quantized<int32_t>(128.0f, -128.0f, 128.0f));
+  EXPECT_EQ(int32_t(int32_min), core::kernels::float_to_quantized<int32_t>(
+                                    -128.0f, -128.0f, 128.0f));
+  EXPECT_EQ(int32_t(0),
+            core::kernels::float_to_quantized<int32_t>(0.0f, -128.0f, 128.0f));
+  EXPECT_EQ(int32_t(int32_max), core::kernels::float_to_quantized<int32_t>(
+                                    128.0f, -128.0f, 128.0f));
 }
 
 TEST(quantization_utils, quantized_to_float) {
-  EXPECT_LT(fabsf(0.0f - core::kernels::quantized_to_float<uint8_t>(0, 0.0f, 1.0f)), 1 / 255.0f);
-  EXPECT_LT(fabsf(0.0f - core::kernels::quantized_to_float<uint8_t>(0, 0.0f, 2.0f)), 1 / 255.0f);
-  EXPECT_LT(fabsf(127.0f/255.0f - core::kernels::quantized_to_float<uint8_t>(127, 0.0f, 1.0f)),
+  EXPECT_LT(
+      fabsf(0.0f - core::kernels::quantized_to_float<uint8_t>(0, 0.0f, 1.0f)),
+      1 / 255.0f);
+  EXPECT_LT(
+      fabsf(0.0f - core::kernels::quantized_to_float<uint8_t>(0, 0.0f, 2.0f)),
+      1 / 255.0f);
+  EXPECT_LT(fabsf(127.0f / 255.0f -
+                  core::kernels::quantized_to_float<uint8_t>(127, 0.0f, 1.0f)),
             1 / 255.0f);
-  EXPECT_LT(fabsf(2*127.0f/255.0f - core::kernels::quantized_to_float<uint8_t>(127, 0.0f, 2.0f)),
+  EXPECT_LT(fabsf(2 * 127.0f / 255.0f -
+                  core::kernels::quantized_to_float<uint8_t>(127, 0.0f, 2.0f)),
             1 / 255.0f);
-  EXPECT_LT(fabsf(1.0f - core::kernels::quantized_to_float<uint8_t>(255, 0.0f, 1.0f)),
+  EXPECT_LT(
+      fabsf(1.0f - core::kernels::quantized_to_float<uint8_t>(255, 0.0f, 1.0f)),
+      1 / 255.0f);
+  EXPECT_LT(
+      fabsf(2.0f - core::kernels::quantized_to_float<uint8_t>(255, 0.0f, 2.0f)),
+      1 / 255.0f);
+  EXPECT_LT(
+      fabsf(1.0f - core::kernels::quantized_to_float<uint8_t>(0, 1.0f, 256.0f)),
+      1 / 255.0f);
+  EXPECT_LT(fabsf(128.0f - core::kernels::quantized_to_float<uint8_t>(127, 1.0f,
+                                                                      256.0f)),
             1 / 255.0f);
-  EXPECT_LT(fabsf(2.0f - core::kernels::quantized_to_float<uint8_t>(255, 0.0f, 2.0f)),
-            1 / 255.0f);
-  EXPECT_LT(fabsf(1.0f - core::kernels::quantized_to_float<uint8_t>(0, 1.0f, 256.0f)),
-            1 / 255.0f);
-  EXPECT_LT(fabsf(128.0f - core::kernels::quantized_to_float<uint8_t>(127, 1.0f, 256.0f)),
-            1 / 255.0f);
-  EXPECT_LT(fabsf(256.0f - core::kernels::quantized_to_float<uint8_t>(255, 1.0f, 256.0f)),
+  EXPECT_LT(fabsf(256.0f - core::kernels::quantized_to_float<uint8_t>(255, 1.0f,
+                                                                      256.0f)),
             1 / 255.0f);
 
   const int int32_min = std::numeric_limits<int>::min();
   const int int32_max = std::numeric_limits<int>::max();
 
-  EXPECT_LT(
-      fabsf(-1.0f - core::kernels::quantized_to_float<int32_t>(int32_t(int32_min), -1.0f, 1.0f)),
-      1e-5f);
-  EXPECT_LT(fabsf(0.0f - core::kernels::quantized_to_float<int32_t>(int32_t(0), -1.0f, 1.0f)),
+  EXPECT_LT(fabsf(-1.0f - core::kernels::quantized_to_float<int32_t>(
+                              int32_t(int32_min), -1.0f, 1.0f)),
             1e-5f);
-  EXPECT_LT(
-      fabsf(1.0f - core::kernels::quantized_to_float<int32_t>(int32_t(int32_max), -1.0f, 1.0f)),
-      1e-5f);
+  EXPECT_LT(fabsf(0.0f - core::kernels::quantized_to_float<int32_t>(
+                             int32_t(0), -1.0f, 1.0f)),
+            1e-5f);
+  EXPECT_LT(fabsf(1.0f - core::kernels::quantized_to_float<int32_t>(
+                             int32_t(int32_max), -1.0f, 1.0f)),
+            1e-5f);
 }
 
 TEST(quantization_utils, avoid_bias) {
   for (int i = 0; i < 256; ++i) {
-    const float as_float = core::kernels::quantized_to_float<uint8_t>(i, 0.0f, 2.0f);
-    const int back_to_int = core::kernels::float_to_quantized<uint8_t>(as_float, 0.0f, 2.0f);
+    const float as_float =
+        core::kernels::quantized_to_float<uint8_t>(i, 0.0f, 2.0f);
+    const int back_to_int =
+        core::kernels::float_to_quantized<uint8_t>(as_float, 0.0f, 2.0f);
     EXPECT_EQ(i, back_to_int);
   }
 }
@@ -91,16 +118,17 @@ TEST(quantization_utils, requantize_in_new_range) {
       const float input_max = ranges[range_index][1];
       const float output_min = ranges[range_index][2];
       const float output_max = ranges[range_index][3];
-      const uint8_t input_value =
-          core::kernels::float_to_quantized<uint8_t>(value_float, input_min, input_max);
+      const uint8_t input_value = core::kernels::float_to_quantized<uint8_t>(
+          value_float, input_min, input_max);
       // Here we convert the quantized input value to what we expect
       // to get in the output range.
       const int32_t expected_value = core::kernels::float_to_quantized<int32_t>(
-          core::kernels::quantized_to_float(input_value, input_min, input_max), output_min,
-          output_max);
-      EXPECT_EQ(expected_value,
-                (core::kernels::requantize_in_new_range<uint8_t, int32_t>(
-                    input_value, input_min, input_max, output_min, output_max)));
+          core::kernels::quantized_to_float(input_value, input_min, input_max),
+          output_min, output_max);
+      EXPECT_EQ(
+          expected_value,
+          (core::kernels::requantize_in_new_range<uint8_t, int32_t>(
+              input_value, input_min, input_max, output_min, output_max)));
     }
   }
 }
@@ -111,13 +139,14 @@ TEST(quantization_utils, requantize_in_new_range_real_data) {
   const float input_max = 0.641057f;
   const float output_min = -2381.49f;
   const float output_max = 2207.6f;
-  const uint8_t value_as_uint8_t =
-      core::kernels::float_to_quantized<uint8_t>(value_as_float, input_min, input_max);
+  const uint8_t value_as_uint8_t = core::kernels::float_to_quantized<uint8_t>(
+      value_as_float, input_min, input_max);
   EXPECT_EQ(uint8_t(83), value_as_uint8_t);
-  const int32_t actual_output = core::kernels::requantize_in_new_range<uint8_t, int32_t>(
-      value_as_uint8_t, input_min, input_max, output_min, output_max);
-  const int32_t value_as_int32_t =
-      core::kernels::float_to_quantized<int32_t>(value_as_float, output_min, output_max);
+  const int32_t actual_output =
+      core::kernels::requantize_in_new_range<uint8_t, int32_t>(
+          value_as_uint8_t, input_min, input_max, output_min, output_max);
+  const int32_t value_as_int32_t = core::kernels::float_to_quantized<int32_t>(
+      value_as_float, output_min, output_max);
   EXPECT_LT(std::abs(value_as_int32_t - actual_output), 10);
 }
 
@@ -140,16 +169,17 @@ TEST(quantization_utils, requantize_in_new_range_32_to_8bit) {
       const float input_max = ranges[range_index][1];
       const float output_min = ranges[range_index][2];
       const float output_max = ranges[range_index][3];
-      const int32_t input_value =
-          core::kernels::float_to_quantized<int32_t>(value_float, input_min, input_max);
+      const int32_t input_value = core::kernels::float_to_quantized<int32_t>(
+          value_float, input_min, input_max);
       // Here we convert the quantized input value to what we expect
       // to get in the output range.
       const uint8_t expected_value = core::kernels::float_to_quantized<uint8_t>(
-          core::kernels::quantized_to_float(input_value, input_min, input_max), output_min,
-          output_max);
-      EXPECT_EQ(expected_value,
-                (core::kernels::requantize_in_new_range<int32_t, uint8_t>(
-                    input_value, input_min, input_max, output_min, output_max)));
+          core::kernels::quantized_to_float(input_value, input_min, input_max),
+          output_min, output_max);
+      EXPECT_EQ(
+          expected_value,
+          (core::kernels::requantize_in_new_range<int32_t, uint8_t>(
+              input_value, input_min, input_max, output_min, output_max)));
     }
   }
 }
@@ -176,19 +206,22 @@ TEST(quantization_utils, requantize_many_in_new_range_32_to_8bit) {
     for (size_t value_index = 0; value_index < values_count; ++value_index) {
       const float value_float = values[value_index];
       values_quantized[value_index] =
-          core::kernels::float_to_quantized<int32_t>(value_float, input_min, input_max);
+          core::kernels::float_to_quantized<int32_t>(value_float, input_min,
+                                                     input_max);
       expected_values[value_index] = core::kernels::float_to_quantized<uint8_t>(
-          core::kernels::quantized_to_float(values_quantized[value_index], input_min, input_max),
+          core::kernels::quantized_to_float(values_quantized[value_index],
+                                            input_min, input_max),
           output_min, output_max);
     }
     uint8_t output_values[values_count];
-    core::kernels::requantize_many_in_new_range<int32_t, uint8_t>(values_quantized, values_count,
-                                             input_min, input_max, output_min,
-                                             output_max, output_values);
+    core::kernels::requantize_many_in_new_range<int32_t, uint8_t>(
+        values_quantized, values_count, input_min, input_max, output_min,
+        output_max, output_values);
     for (size_t value_index = 0; value_index < values_count; ++value_index) {
       // Here we convert the quantized input value to what we expect
       // to get in the output range.
-      EXPECT_EQ(static_cast<float>(expected_values[value_index]), static_cast<float>(output_values[value_index]));
+      EXPECT_EQ(static_cast<float>(expected_values[value_index]),
+                static_cast<float>(output_values[value_index]));
     }
   }
 }
@@ -196,10 +229,12 @@ TEST(quantization_utils, requantize_many_in_new_range_32_to_8bit) {
 TEST(quantization_utils, float_tensor_to_quantized) {
   const float input_min = 0.0f;
   const float input_max = 255.0f;
-  const vec_t input = {1.0f, -1.0f, 10.0f, 10.25f, 127.0f, 255.0f,
-                                   512.0f, 0.0f, 23.0f};
+  const vec_t input = {1.0f,   -1.0f,  10.0f, 10.25f, 127.0f,
+                       255.0f, 512.0f, 0.0f,  23.0f};
   uint8_t expected[9] = {1, 0, 10, 10, 127, 255, 255, 0, 23};
-  std::vector<uint8_t> output = core::kernels::float_tensor_to_quantized<uint8_t>(input, input_min, input_max);
+  std::vector<uint8_t> output =
+      core::kernels::float_tensor_to_quantized<uint8_t>(input, input_min,
+                                                        input_max);
   for (size_t value_index = 0; value_index < 9; ++value_index) {
     EXPECT_EQ(expected[value_index], output[value_index]);
   }
@@ -209,9 +244,10 @@ TEST(quantization_utils, quantized_tensor_to_float) {
   const float input_min = -128.0f;
   const float input_max = 127.0f;
   const std::vector<uint8_t> input = {0, 128, 255, 23, 24, 25, 243, 244, 245};
-  vec_t expected = {-128.0f, 0.0f, 127.0f, -105.0f, -104.0f,
-                                      -103.0f, 115.0f, 116.0f, 117.0f};
-  vec_t output = core::kernels::quantized_tensor_to_float<uint8_t>(input, input_min, input_max);
+  vec_t expected = {-128.0f, 0.0f,   127.0f, -105.0f, -104.0f,
+                    -103.0f, 115.0f, 116.0f, 117.0f};
+  vec_t output = core::kernels::quantized_tensor_to_float<uint8_t>(
+      input, input_min, input_max);
   for (size_t value_index = 0; value_index < 9; ++value_index) {
     EXPECT_EQ(expected[value_index], output[value_index]);
   }
@@ -229,8 +265,8 @@ TEST(quantization_utils, quantize_down_and_shrink_range) {
   float_t output_max;
   std::vector<int32_t> input = {-(1 << 23), 0, (1 << 23)};
   std::vector<uint8_t> output(input.size(), static_cast<uint8_t>(0));
-  core::kernels::quantize_down_and_shrink_range<int32_t, uint8_t>(input, input_min, input_max,
-    &output_min, &output_max, &output);
+  core::kernels::quantize_down_and_shrink_range<int32_t, uint8_t>(
+      input, input_min, input_max, &output_min, &output_max, &output);
   const std::vector<uint8_t> expected = {0, 127, 255};
   for (size_t value_index = 0; value_index < expected.size(); ++value_index) {
     EXPECT_EQ(expected[value_index], output[value_index]);
@@ -239,4 +275,4 @@ TEST(quantization_utils, quantize_down_and_shrink_range) {
   EXPECT_NEAR(1.0f, output_max, 1E-5);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_quantization.h
+++ b/test/test_quantization.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_quantized_convolutional_layer.h
+++ b/test/test_quantized_convolutional_layer.h
@@ -10,167 +10,229 @@
 namespace tiny_dnn {
 
 TEST(quantized_convolutional, setup_tiny) {
-    quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-        padding::valid, true, 1, 1, backend_t::tiny_dnn);
+  quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true,
+                                           1, 1, backend_t::tiny_dnn);
 
-    EXPECT_EQ(l.parallelize(),           true);           // if layer can be parallelized
-    EXPECT_EQ(l.in_channels(),           cnn_size_t(3));  // num of input tensors
-    EXPECT_EQ(l.out_channels(),          cnn_size_t(2));  // num of output tensors
-    EXPECT_EQ(l.in_data_size(),          cnn_size_t(25)); // size of input tensors
-    EXPECT_EQ(l.out_data_size(),         cnn_size_t(18)); // size of output tensors
-    EXPECT_EQ(l.in_data_shape().size(),  cnn_size_t(1));  // number of inputs shapes
-    EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
-    EXPECT_EQ(l.weights().size(),        cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.weights_grads().size(),  cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.inputs().size(),         cnn_size_t(3));  // num of input edges
-    EXPECT_EQ(l.outputs().size(),        cnn_size_t(2));  // num of outpus edges
-    EXPECT_EQ(l.in_types().size(),       cnn_size_t(3));  // num of input data types
-    EXPECT_EQ(l.out_types().size(),      cnn_size_t(2));  // num of output data types
-    EXPECT_EQ(l.fan_in_size(),           cnn_size_t(9));  // num of incoming connections
-    EXPECT_EQ(l.fan_out_size(),          cnn_size_t(18)); // num of outgoing connections
-    EXPECT_STREQ(l.layer_type().c_str(), "q_conv");  // string with layer type
+  EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));     // num of input tensors
+  EXPECT_EQ(l.out_channels(), cnn_size_t(2));    // num of output tensors
+  EXPECT_EQ(l.in_data_size(), cnn_size_t(25));   // size of input tensors
+  EXPECT_EQ(l.out_data_size(), cnn_size_t(18));  // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(),
+            cnn_size_t(1));  // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
+  EXPECT_EQ(l.weights().size(), cnn_size_t(2));  // the wieghts vector size
+  EXPECT_EQ(l.weights_grads().size(),
+            cnn_size_t(2));                        // the wieghts vector size
+  EXPECT_EQ(l.inputs().size(), cnn_size_t(3));     // num of input edges
+  EXPECT_EQ(l.outputs().size(), cnn_size_t(2));    // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), cnn_size_t(3));   // num of input data types
+  EXPECT_EQ(l.out_types().size(), cnn_size_t(2));  // num of output data types
+  EXPECT_EQ(l.fan_in_size(), cnn_size_t(9));    // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), cnn_size_t(18));  // num of outgoing connections
+  EXPECT_STREQ(l.layer_type().c_str(), "q_conv");  // string with layer type
 }
 
 TEST(quantized_convolutional, fprop) {
-    typedef network<sequential> CNN;
-    CNN nn;
+  typedef network<sequential> CNN;
+  CNN nn;
 
-    quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
+  quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
 
-    // layer::forward_propagation expects tensors, even if we feed only one input at a time
-    auto create_simple_tensor = [](size_t vector_size) {
-        return tensor_t(1, vec_t(vector_size));
-    };
+  // layer::forward_propagation expects tensors, even if we feed only one input
+  // at a time
+  auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    // create simple tensors that wrap the payload vectors of the correct size
-    tensor_t in_tensor = create_simple_tensor(25)
-        , out_tensor = create_simple_tensor(18)
-        , a_tensor = create_simple_tensor(18)
-        , weight_tensor = create_simple_tensor(18)
-        , bias_tensor = create_simple_tensor(2);
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor = create_simple_tensor(25),
+           out_tensor = create_simple_tensor(18),
+           a_tensor = create_simple_tensor(18),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor = create_simple_tensor(2);
 
-    // short-hand references to the payload vectors
-    vec_t &in = in_tensor[0]
-        , &out = out_tensor[0]
-        , &weight = weight_tensor[0];
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18)); // weight
+  ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18));  // weight
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    std::vector<tensor_t*> in_data, out_data;
-    in_data.push_back(&in_tensor);
-    in_data.push_back(&weight_tensor);
-    in_data.push_back(&bias_tensor);
-    out_data.push_back(&out_tensor);
-    out_data.push_back(&a_tensor);
-    l.setup(false);
-    {
-        l.forward_propagation(in_data, out_data);
+  std::vector<tensor_t *> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
+  out_data.push_back(&a_tensor);
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        for (auto o: out)
-            EXPECT_NEAR(0.5, o, 1E-3);
-    }
+    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+  }
 
-    weight[0] = 0.3f;  weight[1] = 0.1f; weight[2] = 0.2f;
-    weight[3] = 0.0f;  weight[4] = -0.1f; weight[5] = -0.1f;
-    weight[6] = 0.05f; weight[7] = -0.2f; weight[8] = 0.05f;
+  weight[0] = 0.3f;
+  weight[1] = 0.1f;
+  weight[2] = 0.2f;
+  weight[3] = 0.0f;
+  weight[4] = -0.1f;
+  weight[5] = -0.1f;
+  weight[6] = 0.05f;
+  weight[7] = -0.2f;
+  weight[8] = 0.05f;
 
-    weight[9] = 0.0f; weight[10] = -0.1f; weight[11] = 0.1f;
-    weight[12] = 0.1f; weight[13] = -0.2f; weight[14] = 0.3f;
-    weight[15] = 0.2f; weight[16] = -0.3f; weight[17] = 0.2f;
+  weight[9] = 0.0f;
+  weight[10] = -0.1f;
+  weight[11] = 0.1f;
+  weight[12] = 0.1f;
+  weight[13] = -0.2f;
+  weight[14] = 0.3f;
+  weight[15] = 0.2f;
+  weight[16] = -0.3f;
+  weight[17] = 0.2f;
 
-    in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-    in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-    in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-    in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-    in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 1;
+  in[3] = 5;
+  in[4] = 2;
+  in[5] = 3;
+  in[6] = 0;
+  in[7] = 2;
+  in[8] = 0;
+  in[9] = 1;
+  in[10] = 0;
+  in[11] = 6;
+  in[12] = 1;
+  in[13] = 1;
+  in[14] = 10;
+  in[15] = 3;
+  in[16] = -1;
+  in[17] = 2;
+  in[18] = 9;
+  in[19] = 0;
+  in[20] = 1;
+  in[21] = 2;
+  in[22] = 1;
+  in[23] = 5;
+  in[24] = 5;
 
-    {
-        l.forward_propagation(in_data, out_data);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.4875026, out[0], 2E-2);
-        EXPECT_NEAR(0.8388910, out[1], 2E-2);
-        EXPECT_NEAR(0.8099984, out[2], 2E-2);
-        EXPECT_NEAR(0.7407749, out[3], 2E-2);
-        EXPECT_NEAR(0.5000000, out[4], 2E-2);
-        EXPECT_NEAR(0.1192029, out[5], 2E-2);
-        EXPECT_NEAR(0.5986877, out[6], 2E-2);
-        EXPECT_NEAR(0.7595109, out[7], 2E-2);
-        EXPECT_NEAR(0.6899745, out[8], 2E-2);
-    }
+    EXPECT_NEAR(0.4875026, out[0], 2E-2);
+    EXPECT_NEAR(0.8388910, out[1], 2E-2);
+    EXPECT_NEAR(0.8099984, out[2], 2E-2);
+    EXPECT_NEAR(0.7407749, out[3], 2E-2);
+    EXPECT_NEAR(0.5000000, out[4], 2E-2);
+    EXPECT_NEAR(0.1192029, out[5], 2E-2);
+    EXPECT_NEAR(0.5986877, out[6], 2E-2);
+    EXPECT_NEAR(0.7595109, out[7], 2E-2);
+    EXPECT_NEAR(0.6899745, out[8], 2E-2);
+  }
 }
 
 #ifdef CNN_USE_NNPACK
 TEST(quantized_convolutional, fprop_npp) {
-    typedef network<sequential> CNN;
-    CNN nn;
+  typedef network<sequential> CNN;
+  CNN nn;
 
-    quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-        padding::valid, true, 1, 1, backend_t::nnpack);
+  quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true,
+                                           1, 1, backend_t::nnpack);
 
-    // layer::forward_propagation expects tensors, even if we feed only one input at a time
-    auto create_simple_tensor = [](size_t vector_size) {
-        return tensor_t(1, vec_t(vector_size));
-    };
+  // layer::forward_propagation expects tensors, even if we feed only one input
+  // at a time
+  auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    // create simple tensors that wrap the payload vectors of the correct size
-    tensor_t in_tensor = create_simple_tensor(25)
-        , out_tensor = create_simple_tensor(18)
-        , a_tensor = create_simple_tensor(18)
-        , weight_tensor = create_simple_tensor(18)
-        , bias_tensor = create_simple_tensor(2);
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor = create_simple_tensor(25),
+           out_tensor = create_simple_tensor(18),
+           a_tensor = create_simple_tensor(18),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor = create_simple_tensor(2);
 
-    // short-hand references to the payload vectors
-    vec_t &in = in_tensor[0]
-        , &out = out_tensor[0]
-        , &weight = weight_tensor[0];
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18)); // weight
+  ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18));  // weight
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    std::vector<tensor_t*> in_data, out_data;
-    in_data.push_back(&in_tensor);
-    in_data.push_back(&weight_tensor);
-    in_data.push_back(&bias_tensor);
-    out_data.push_back(&out_tensor);
-    out_data.push_back(&a_tensor);
-    l.setup(false);
-    {
-        l.forward_propagation(in_data, out_data);
+  std::vector<tensor_t *> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
+  out_data.push_back(&a_tensor);
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        for (auto o: out)
-            EXPECT_NEAR(0.5, o, 1E-3);
-    }
+    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+  }
 
-    weight[0] = 0.3;  weight[1] = 0.1; weight[2] = 0.2;
-    weight[3] = 0.0;  weight[4] =-0.1; weight[5] =-0.1;
-    weight[6] = 0.05; weight[7] =-0.2; weight[8] = 0.05;
+  weight[0] = 0.3;
+  weight[1] = 0.1;
+  weight[2] = 0.2;
+  weight[3] = 0.0;
+  weight[4] = -0.1;
+  weight[5] = -0.1;
+  weight[6] = 0.05;
+  weight[7] = -0.2;
+  weight[8] = 0.05;
 
-    weight[9]  = 0.0; weight[10] =-0.1; weight[11] = 0.1;
-    weight[12] = 0.1; weight[13] =-0.2; weight[14] = 0.3;
-    weight[15] = 0.2; weight[16] =-0.3; weight[17] = 0.2;
+  weight[9] = 0.0;
+  weight[10] = -0.1;
+  weight[11] = 0.1;
+  weight[12] = 0.1;
+  weight[13] = -0.2;
+  weight[14] = 0.3;
+  weight[15] = 0.2;
+  weight[16] = -0.3;
+  weight[17] = 0.2;
 
-    in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-    in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-    in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-    in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-    in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 1;
+  in[3] = 5;
+  in[4] = 2;
+  in[5] = 3;
+  in[6] = 0;
+  in[7] = 2;
+  in[8] = 0;
+  in[9] = 1;
+  in[10] = 0;
+  in[11] = 6;
+  in[12] = 1;
+  in[13] = 1;
+  in[14] = 10;
+  in[15] = 3;
+  in[16] = -1;
+  in[17] = 2;
+  in[18] = 9;
+  in[19] = 0;
+  in[20] = 1;
+  in[21] = 2;
+  in[22] = 1;
+  in[23] = 5;
+  in[24] = 5;
 
-    {
-        l.forward_propagation(in_data, out_data);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.4875026, out[0], 2E-2);
-        EXPECT_NEAR(0.8388910, out[1], 2E-2);
-        EXPECT_NEAR(0.8099984, out[2], 2E-2);
-        EXPECT_NEAR(0.7407749, out[3], 2E-2);
-        EXPECT_NEAR(0.5000000, out[4], 2E-2);
-        EXPECT_NEAR(0.1192029, out[5], 2E-2);
-        EXPECT_NEAR(0.5986877, out[6], 2E-2);
-        EXPECT_NEAR(0.7595109, out[7], 2E-2);
-        EXPECT_NEAR(0.6899745, out[8], 2E-2);
-    }
+    EXPECT_NEAR(0.4875026, out[0], 2E-2);
+    EXPECT_NEAR(0.8388910, out[1], 2E-2);
+    EXPECT_NEAR(0.8099984, out[2], 2E-2);
+    EXPECT_NEAR(0.7407749, out[3], 2E-2);
+    EXPECT_NEAR(0.5000000, out[4], 2E-2);
+    EXPECT_NEAR(0.1192029, out[5], 2E-2);
+    EXPECT_NEAR(0.5986877, out[6], 2E-2);
+    EXPECT_NEAR(0.7595109, out[7], 2E-2);
+    EXPECT_NEAR(0.6899745, out[8], 2E-2);
+  }
 }
 #endif
 
@@ -184,7 +246,8 @@ TEST(quantized_convolutional, gradient_check) { // tanh - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_convolutional, gradient_check2) { // sigmoid - mse
@@ -196,7 +259,8 @@ TEST(quantized_convolutional, gradient_check2) { // sigmoid - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_convolutional, gradient_check3) { // rectified - mse
@@ -209,7 +273,8 @@ TEST(quantized_convolutional, gradient_check3) { // rectified - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_convolutional, gradient_check4) { // identity - mse
@@ -222,7 +287,8 @@ TEST(quantized_convolutional, gradient_check4) { // identity - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_convolutional, gradient_check5) { // sigmoid - cross-entropy
@@ -235,7 +301,8 @@ TEST(quantized_convolutional, gradient_check5) { // sigmoid - cross-entropy
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<cross_entropy>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<cross_entropy>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_convolutional, read_write)
@@ -259,12 +326,14 @@ TEST(quantized_convolutional, read_write2) {
     };
 #undef O
 #undef X
-    quantized_convolutional_layer<tan_h> layer1(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
-    quantized_convolutional_layer<tan_h> layer2(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
+    quantized_convolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
+    quantized_convolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
     layer1.init_weight();
     layer2.init_weight();
 
     serialization_test(layer1, layer2);
 }
 */
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_quantized_convolutional_layer.h
+++ b/test/test_quantized_convolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_quantized_deconvolutional_layer.h
+++ b/test/test_quantized_deconvolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_quantized_deconvolutional_layer.h
+++ b/test/test_quantized_deconvolutional_layer.h
@@ -10,99 +10,113 @@
 namespace tiny_dnn {
 
 TEST(quantized_deconvolutional, setup_tiny) {
-    quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2,
-        padding::valid, true, 1, 1, backend_t::tiny_dnn);
-  
-    EXPECT_EQ(l.parallelize(),           true);            // if layer can be parallelized
-    EXPECT_EQ(l.in_channels(),           cnn_size_t(3));   // num of input tensors
-    EXPECT_EQ(l.out_channels(),          cnn_size_t(2));  // num of output tensors
-    EXPECT_EQ(l.in_data_size(),          cnn_size_t(4));  // size of input tensors
-    EXPECT_EQ(l.out_data_size(),         cnn_size_t(32)); // size of output tensors
-    EXPECT_EQ(l.in_data_shape().size(),  cnn_size_t(1));  // number of inputs shapes
-    EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
-    EXPECT_EQ(l.weights().size(),        cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.weights_grads().size(),  cnn_size_t(2));  // the wieghts vector size
-    EXPECT_EQ(l.inputs().size(),         cnn_size_t(3));  // num of input edges
-    EXPECT_EQ(l.outputs().size(),        cnn_size_t(2));  // num of outpus edges
-    EXPECT_EQ(l.in_types().size(),       cnn_size_t(3));  // num of input data types
-    EXPECT_EQ(l.out_types().size(),      cnn_size_t(2));  // num of output data types
-    EXPECT_EQ(l.fan_in_size(),           cnn_size_t(9));  // num of incoming connections
-    EXPECT_EQ(l.fan_out_size(),          cnn_size_t(18)); // num of outgoing connections
-    EXPECT_STREQ(l.layer_type().c_str(), "q_deconv");      // string with layer type
+  quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2, padding::valid,
+                                             true, 1, 1, backend_t::tiny_dnn);
+
+  EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));     // num of input tensors
+  EXPECT_EQ(l.out_channels(), cnn_size_t(2));    // num of output tensors
+  EXPECT_EQ(l.in_data_size(), cnn_size_t(4));    // size of input tensors
+  EXPECT_EQ(l.out_data_size(), cnn_size_t(32));  // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(),
+            cnn_size_t(1));  // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), cnn_size_t(1));  // num of output shapes
+  EXPECT_EQ(l.weights().size(), cnn_size_t(2));  // the wieghts vector size
+  EXPECT_EQ(l.weights_grads().size(),
+            cnn_size_t(2));                        // the wieghts vector size
+  EXPECT_EQ(l.inputs().size(), cnn_size_t(3));     // num of input edges
+  EXPECT_EQ(l.outputs().size(), cnn_size_t(2));    // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), cnn_size_t(3));   // num of input data types
+  EXPECT_EQ(l.out_types().size(), cnn_size_t(2));  // num of output data types
+  EXPECT_EQ(l.fan_in_size(), cnn_size_t(9));    // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), cnn_size_t(18));  // num of outgoing connections
+  EXPECT_STREQ(l.layer_type().c_str(), "q_deconv");  // string with layer type
 }
 
 TEST(quantized_deconvolutional, fprop) {
-    typedef network<sequential> CNN;
-    CNN nn;
+  typedef network<sequential> CNN;
+  CNN nn;
 
-    quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2);
+  quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2);
 
-    // layer::forward_propagation expects tensors, even if we feed only one input at a time
-    auto create_simple_tensor = [](size_t vector_size) {
-        return tensor_t(1, vec_t(vector_size));
-    };
+  // layer::forward_propagation expects tensors, even if we feed only one input
+  // at a time
+  auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    // create simple tensors that wrap the payload vectors of the correct size
-    tensor_t in_tensor     = create_simple_tensor(4)
-           , out_tensor    = create_simple_tensor(32)
-           , a_tensor      = create_simple_tensor(32)
-           , weight_tensor = create_simple_tensor(18)
-           , bias_tensor   = create_simple_tensor(2);
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor = create_simple_tensor(4),
+           out_tensor = create_simple_tensor(32),
+           a_tensor = create_simple_tensor(32),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor = create_simple_tensor(2);
 
-    // short-hand references to the payload vectors
-    vec_t &in = in_tensor[0]
-        , &out = out_tensor[0]
-        , &weight = weight_tensor[0];
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18)); // weight
+  ASSERT_EQ(l.in_shape()[1].size(), cnn_size_t(18));  // weight
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    std::vector<tensor_t*> in_data, out_data;
-    in_data.push_back(&in_tensor);
-    in_data.push_back(&weight_tensor);
-    in_data.push_back(&bias_tensor);
-    out_data.push_back(&out_tensor);
-    out_data.push_back(&a_tensor);
-    l.setup(false);
-    {
-        l.forward_propagation(in_data, out_data);
+  std::vector<tensor_t *> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
+  out_data.push_back(&a_tensor);
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        for (auto o: out)
-            EXPECT_NEAR(0.5, o, 1E-3);
-    }
+    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+  }
 
-    weight[0] = 0.3f;  weight[1] = 0.1f; weight[2] = 0.2f;
-    weight[3] = 0.0f;  weight[4] =-0.1f; weight[5] =-0.1f;
-    weight[6] = 0.05f; weight[7] =-0.2f; weight[8] = 0.05f;
+  weight[0] = 0.3f;
+  weight[1] = 0.1f;
+  weight[2] = 0.2f;
+  weight[3] = 0.0f;
+  weight[4] = -0.1f;
+  weight[5] = -0.1f;
+  weight[6] = 0.05f;
+  weight[7] = -0.2f;
+  weight[8] = 0.05f;
 
-    weight[9]  = 0.0f; weight[10] =-0.1f; weight[11] = 0.1f;
-    weight[12] = 0.1f; weight[13] =-0.2f; weight[14] = 0.3f;
-    weight[15] = 0.2f; weight[16] =-0.3f; weight[17] = 0.2f;
+  weight[9] = 0.0f;
+  weight[10] = -0.1f;
+  weight[11] = 0.1f;
+  weight[12] = 0.1f;
+  weight[13] = -0.2f;
+  weight[14] = 0.3f;
+  weight[15] = 0.2f;
+  weight[16] = -0.3f;
+  weight[17] = 0.2f;
 
-    in[0] = 3;  in[1] = 2;
-    in[2] = 3;  in[3] = 0;
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 3;
+  in[3] = 0;
 
-    {
-        l.forward_propagation(in_data, out_data);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.7109495, out[0], 1E-2);
-        EXPECT_NEAR(0.7109495, out[1], 1E-2);
-        EXPECT_NEAR(0.6899745, out[2], 1E-2);
-        EXPECT_NEAR(0.5986877, out[3], 1E-2);
-        EXPECT_NEAR(0.7109495, out[4], 1E-2);
-        EXPECT_NEAR(0.5000000, out[5], 1E-2);
-        EXPECT_NEAR(0.5249792, out[6], 1E-2);
-        EXPECT_NEAR(0.4501660, out[7], 1E-2);
-        EXPECT_NEAR(0.5374298, out[8], 1E-2);
-        EXPECT_NEAR(0.3100255, out[9], 1E-2);
-        EXPECT_NEAR(0.3658644, out[10], 1E-2);
-        EXPECT_NEAR(0.5249791, out[11], 1E-2);
-        EXPECT_NEAR(0.5374298, out[12], 1E-2);
-        EXPECT_NEAR(0.3543437, out[13], 1E-2);
-        EXPECT_NEAR(0.5374298, out[14], 1E-2);
-        EXPECT_NEAR(0.5000000, out[15], 1E-2);
-    }
+    EXPECT_NEAR(0.7109495, out[0], 1E-2);
+    EXPECT_NEAR(0.7109495, out[1], 1E-2);
+    EXPECT_NEAR(0.6899745, out[2], 1E-2);
+    EXPECT_NEAR(0.5986877, out[3], 1E-2);
+    EXPECT_NEAR(0.7109495, out[4], 1E-2);
+    EXPECT_NEAR(0.5000000, out[5], 1E-2);
+    EXPECT_NEAR(0.5249792, out[6], 1E-2);
+    EXPECT_NEAR(0.4501660, out[7], 1E-2);
+    EXPECT_NEAR(0.5374298, out[8], 1E-2);
+    EXPECT_NEAR(0.3100255, out[9], 1E-2);
+    EXPECT_NEAR(0.3658644, out[10], 1E-2);
+    EXPECT_NEAR(0.5249791, out[11], 1E-2);
+    EXPECT_NEAR(0.5374298, out[12], 1E-2);
+    EXPECT_NEAR(0.3543437, out[13], 1E-2);
+    EXPECT_NEAR(0.5374298, out[14], 1E-2);
+    EXPECT_NEAR(0.5000000, out[15], 1E-2);
+  }
 }
 
 /*
@@ -163,7 +177,8 @@ TEST(quantized_deconvolutional, gradient_check) { // tanh - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_deconvolutional, gradient_check2) { // sigmoid - mse
@@ -175,7 +190,8 @@ TEST(quantized_deconvolutional, gradient_check2) { // sigmoid - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_deconvolutional, gradient_check3) { // rectified - mse
@@ -188,7 +204,8 @@ TEST(quantized_deconvolutional, gradient_check3) { // rectified - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_deconvolutional, gradient_check4) { // identity - mse
@@ -201,7 +218,8 @@ TEST(quantized_deconvolutional, gradient_check4) { // identity - mse
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_deconvolutional, gradient_check5) { // sigmoid - cross-entropy
@@ -214,7 +232,8 @@ TEST(quantized_deconvolutional, gradient_check5) { // sigmoid - cross-entropy
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<cross_entropy>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<cross_entropy>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_deconvolutional, read_write)
@@ -238,12 +257,14 @@ TEST(quantized_deconvolutional, read_write2) {
     };
 #undef O
 #undef X
-    quantized_deconvolutional_layer<tan_h> layer1(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
-    quantized_deconvolutional_layer<tan_h> layer2(14, 14, 5, 3, 6, connection_table(connection, 3, 6));
+    quantized_deconvolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
+    quantized_deconvolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+connection_table(connection, 3, 6));
     layer1.init_weight();
     layer2.init_weight();
 
     serialization_test(layer1, layer2);
 }*/
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_quantized_fully_connected_layer.h
+++ b/test/test_quantized_fully_connected_layer.h
@@ -92,7 +92,8 @@ TEST(quantized_fully_connected, gradient_check) {
 
     uniform_rand(a.begin(), a.end(), -1, 1);
     nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
+    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
+GRAD_CHECK_ALL));
 }
 
 TEST(quantized_fully_connected, read_write)
@@ -106,56 +107,54 @@ TEST(quantized_fully_connected, read_write)
     quantized_serialization_test(l1, l2);
 }*/
 
-TEST(quantized_fully_connected, forward)
-{
-    quantized_fully_connected_layer<identity> l(4, 2);
-    EXPECT_EQ(l.in_channels(), cnn_size_t(3)); // in, W and b
+TEST(quantized_fully_connected, forward) {
+  quantized_fully_connected_layer<identity> l(4, 2);
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));  // in, W and b
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.5));
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.5));
 
-    vec_t in = {0,1,2,3};
-    vec_t out = l.forward({ { in } })[0][0];
-    vec_t out_expected = {6.5, 6.5}; // 0+1+2+3+0.5
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_NEAR(out_expected[i], out[i], 1E-2);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_NEAR(out_expected[i], out[i], 1E-2);
+  }
 }
 
 #ifdef CNN_USE_NNPACK
-TEST(quantized_fully_connected, forward_nnp)
-{
-    quantized_fully_connected_layer<identity> l(4, 2, true, core::backend_t::nnpack);
-    EXPECT_EQ(l.in_channels(), cnn_size_t(3)); // in, W and b
+TEST(quantized_fully_connected, forward_nnp) {
+  quantized_fully_connected_layer<identity> l(4, 2, true,
+                                              core::backend_t::nnpack);
+  EXPECT_EQ(l.in_channels(), cnn_size_t(3));  // in, W and b
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.5));
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.5));
 
-    vec_t in = {0,1,2,3};
-    vec_t out = l.forward({ {in} })[0][0];
-    vec_t out_expected = {6.5, 6.5}; // 0+1+2+3+0.5
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_NEAR(out_expected[i], out[i], 1E-2);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_NEAR(out_expected[i], out[i], 1E-2);
+  }
 }
 #endif
 
-TEST(quantized_fully_connected, forward_nobias)
-{
-    quantized_fully_connected_layer<identity> l(4, 2, false);
-    EXPECT_EQ(l.in_channels(), cnn_size_t(2));// in and W
+TEST(quantized_fully_connected, forward_nobias) {
+  quantized_fully_connected_layer<identity> l(4, 2, false);
+  EXPECT_EQ(l.in_channels(), cnn_size_t(2));  // in and W
 
-    l.weight_init(weight_init::constant(1.0));
+  l.weight_init(weight_init::constant(1.0));
 
-    vec_t in = { 0,1,2,3 };
-    vec_t out = l.forward({ { in } })[0][0];
-    vec_t out_expected = { 6.0, 6.0 }; // 0+1+2+3
+  vec_t in = {0, 1, 2, 3};
+  vec_t out = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.0, 6.0};  // 0+1+2+3
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_NEAR(out_expected[i], out[i], 1E-2);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_NEAR(out_expected[i], out[i], 1E-2);
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_quantized_fully_connected_layer.h
+++ b/test/test_quantized_fully_connected_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -7,114 +7,113 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
-
 namespace tiny_dnn {
 
 TEST(serialization, sequential_to_json) {
-    network<sequential> net1, net2;
+  network<sequential> net1, net2;
 
-    net1 << fully_connected_layer<tan_h>(10, 100)
-         << dropout_layer(100, 0.3f, net_phase::test)
-         << fully_connected_layer<softmax>(100, 9)
-         << convolutional_layer<tan_h>(3, 3, 3, 1, 1);
+  net1 << fully_connected_layer<tan_h>(10, 100)
+       << dropout_layer(100, 0.3f, net_phase::test)
+       << fully_connected_layer<softmax>(100, 9)
+       << convolutional_layer<tan_h>(3, 3, 3, 1, 1);
 
-    auto json = net1.to_json();
+  auto json = net1.to_json();
 
-    net2.from_json(json);
+  net2.from_json(json);
 
-    EXPECT_EQ(net1.in_data_size(), net2.in_data_size());
-    EXPECT_EQ(net1.layer_size(), net2.layer_size());
+  EXPECT_EQ(net1.in_data_size(), net2.in_data_size());
+  EXPECT_EQ(net1.layer_size(), net2.layer_size());
 
-    EXPECT_EQ(net1[0]->in_shape(), net2[0]->in_shape());
-    EXPECT_EQ(net1[1]->in_shape(), net2[1]->in_shape());
-    EXPECT_EQ(net1[2]->in_shape(), net2[2]->in_shape());
-    EXPECT_EQ(net1[3]->in_shape(), net2[3]->in_shape());
+  EXPECT_EQ(net1[0]->in_shape(), net2[0]->in_shape());
+  EXPECT_EQ(net1[1]->in_shape(), net2[1]->in_shape());
+  EXPECT_EQ(net1[2]->in_shape(), net2[2]->in_shape());
+  EXPECT_EQ(net1[3]->in_shape(), net2[3]->in_shape());
 
-    EXPECT_EQ(net1[0]->layer_type(), net2[0]->layer_type());
-    EXPECT_EQ(net1[1]->layer_type(), net2[1]->layer_type());
-    EXPECT_EQ(net1[2]->layer_type(), net2[2]->layer_type());
-    EXPECT_EQ(net1[3]->layer_type(), net2[3]->layer_type());
+  EXPECT_EQ(net1[0]->layer_type(), net2[0]->layer_type());
+  EXPECT_EQ(net1[1]->layer_type(), net2[1]->layer_type());
+  EXPECT_EQ(net1[2]->layer_type(), net2[2]->layer_type());
+  EXPECT_EQ(net1[3]->layer_type(), net2[3]->layer_type());
 
-    EXPECT_FLOAT_EQ(net1.at<dropout_layer>(1).dropout_rate(), net2.at<dropout_layer>(1).dropout_rate());
+  EXPECT_FLOAT_EQ(net1.at<dropout_layer>(1).dropout_rate(),
+                  net2.at<dropout_layer>(1).dropout_rate());
 }
 
 TEST(serialization, sequential_model) {
-    network<sequential> net1, net2;
+  network<sequential> net1, net2;
 
-    net1 << fully_connected_layer<tan_h>(10, 16)
-         << average_pooling_layer<relu>(4, 4, 1, 2)
-         << power_layer(shape3d(2,2,1),  0.5f);
+  net1 << fully_connected_layer<tan_h>(10, 16)
+       << average_pooling_layer<relu>(4, 4, 1, 2)
+       << power_layer(shape3d(2, 2, 1), 0.5f);
 
-    net1.init_weight();
+  net1.init_weight();
 
-    auto path = unique_path();
-    net1.save(path, content_type::model);
+  auto path = unique_path();
+  net1.save(path, content_type::model);
 
-    net2.load(path, content_type::model);
+  net2.load(path, content_type::model);
 
-    for (int i = 0; i < 3; i++) {
-        ASSERT_EQ(net1[i]->in_shape(), net2[i]->in_shape());
-        ASSERT_EQ(net1[i]->out_shape(), net2[i]->out_shape());
-        ASSERT_EQ(net1[i]->layer_type(), net2[i]->layer_type());
-    }
+  for (int i = 0; i < 3; i++) {
+    ASSERT_EQ(net1[i]->in_shape(), net2[i]->in_shape());
+    ASSERT_EQ(net1[i]->out_shape(), net2[i]->out_shape());
+    ASSERT_EQ(net1[i]->layer_type(), net2[i]->layer_type());
+  }
 }
 
-
 TEST(serialization, sequential_weights) {
-    network<sequential> net1, net2;
-    vec_t data = {1,2,3,4,5,0};
+  network<sequential> net1, net2;
+  vec_t data = {1, 2, 3, 4, 5, 0};
 
-    net1 << batch_normalization_layer(3,2,0.01f,0.99f,net_phase::train)
-         << linear_layer<elu>(3*2, 2.0f, 0.5f);
+  net1 << batch_normalization_layer(3, 2, 0.01f, 0.99f, net_phase::train)
+       << linear_layer<elu>(3 * 2, 2.0f, 0.5f);
 
-    net1.init_weight();
-    net1.at<batch_normalization_layer>(0).update_immidiately(true);
-    net1.predict(data);
-    net1.set_netphase(net_phase::test);
+  net1.init_weight();
+  net1.at<batch_normalization_layer>(0).update_immidiately(true);
+  net1.predict(data);
+  net1.set_netphase(net_phase::test);
 
-    auto path = unique_path();
-    net1.save(path, content_type::weights_and_model);
+  auto path = unique_path();
+  net1.save(path, content_type::weights_and_model);
 
-    net2.load(path, content_type::weights_and_model);
+  net2.load(path, content_type::weights_and_model);
 
-    auto res1 = net1.predict(data);
-    auto res2 = net2.predict(data);
+  auto res1 = net1.predict(data);
+  auto res2 = net2.predict(data);
 
-    EXPECT_TRUE(net1.has_same_weights(net2, 1e-3f));
+  EXPECT_TRUE(net1.has_same_weights(net2, 1e-3f));
 
-    for (int i = 0; i < 6; i++) {
-        EXPECT_FLOAT_EQ(res1[i], res2[i]);
-    }
+  for (int i = 0; i < 6; i++) {
+    EXPECT_FLOAT_EQ(res1[i], res2[i]);
+  }
 }
 
 TEST(serialization, graph_model_and_weights) {
-    network<graph> net1, net2;
-    vec_t in = {1, 2, 3};
+  network<graph> net1, net2;
+  vec_t in = {1, 2, 3};
 
-    fully_connected_layer<tan_h> f1(3, 4);
-    slice_layer s1(shape3d(2,1,2), slice_type::slice_channels, 2);
-    fully_connected_layer<softmax> f2(2, 2);
-    fully_connected_layer<elu> f3(2, 2);
-    elementwise_add_layer c4(2, 2);
+  fully_connected_layer<tan_h> f1(3, 4);
+  slice_layer s1(shape3d(2, 1, 2), slice_type::slice_channels, 2);
+  fully_connected_layer<softmax> f2(2, 2);
+  fully_connected_layer<elu> f3(2, 2);
+  elementwise_add_layer c4(2, 2);
 
-    f1 << s1;
-    s1 << (f2, f3) << c4;
+  f1 << s1;
+  s1 << (f2, f3) << c4;
 
-    construct_graph(net1, {&f1}, {&c4});
+  construct_graph(net1, {&f1}, {&c4});
 
-    net1.init_weight();
-    auto res1 = net1.predict(in);
+  net1.init_weight();
+  auto res1 = net1.predict(in);
 
-    auto path = unique_path();
+  auto path = unique_path();
 
-    net1.save(path, content_type::weights_and_model);
+  net1.save(path, content_type::weights_and_model);
 
-    net2.load(path, content_type::weights_and_model);
+  net2.load(path, content_type::weights_and_model);
 
-    auto res2 = net2.predict(in);
+  auto res2 = net2.predict(in);
 
-    EXPECT_FLOAT_EQ(res1[0], res2[0]);
-    EXPECT_FLOAT_EQ(res1[1], res2[1]);
+  EXPECT_FLOAT_EQ(res1[0], res2[0]);
+  EXPECT_FLOAT_EQ(res1[1], res2[1]);
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_slice_layer.h
+++ b/test/test_slice_layer.h
@@ -10,94 +10,68 @@
 namespace tiny_dnn {
 
 TEST(slice, forward_data) {
-    slice_layer sl(shape3d(3,2,1), slice_type::slice_samples, 3);
+  slice_layer sl(shape3d(3, 2, 1), slice_type::slice_samples, 3);
 
-    tensor_t in = {
-        { 0,1,2,3,4,5 },
-        { 6,7,8,9,10,11 },
-        { 12,13,14,15,16,17 },
-        { 18,19,20,21,22,23 }
-    };
+  tensor_t in = {{0, 1, 2, 3, 4, 5},
+                 {6, 7, 8, 9, 10, 11},
+                 {12, 13, 14, 15, 16, 17},
+                 {18, 19, 20, 21, 22, 23}};
 
-    tensor_t out0_expected = {
-        { 0,1,2,3,4,5 }
-    };
+  tensor_t out0_expected = {{0, 1, 2, 3, 4, 5}};
 
-    tensor_t out1_expected = {
-        { 6,7,8,9,10,11 }
-    };
+  tensor_t out1_expected = {{6, 7, 8, 9, 10, 11}};
 
-    tensor_t out2_expected = {
-        { 12, 13, 14, 15, 16, 17 },
-        { 18, 19, 20, 21, 22, 23 }
-    };
+  tensor_t out2_expected = {{12, 13, 14, 15, 16, 17}, {18, 19, 20, 21, 22, 23}};
 
-    auto out = sl.forward({in});
+  auto out = sl.forward({in});
 
-    for (cnn_size_t i = 0; i < 6; i++) {
-        EXPECT_FLOAT_EQ(out0_expected[0][i], out[0][0][i]);
-        EXPECT_FLOAT_EQ(out1_expected[0][i], out[1][0][i]);
-        EXPECT_FLOAT_EQ(out2_expected[0][i], out[2][0][i]);
-        EXPECT_FLOAT_EQ(out2_expected[1][i], out[2][1][i]);
+  for (cnn_size_t i = 0; i < 6; i++) {
+    EXPECT_FLOAT_EQ(out0_expected[0][i], out[0][0][i]);
+    EXPECT_FLOAT_EQ(out1_expected[0][i], out[1][0][i]);
+    EXPECT_FLOAT_EQ(out2_expected[0][i], out[2][0][i]);
+    EXPECT_FLOAT_EQ(out2_expected[1][i], out[2][1][i]);
+  }
+
+  out = sl.backward({out0_expected, out1_expected, out2_expected});
+
+  for (cnn_size_t i = 0; i < 4; i++) {
+    for (cnn_size_t j = 0; j < 6; j++) {
+      EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
     }
-
-    out = sl.backward({out0_expected,out1_expected,out2_expected});
-
-    for (cnn_size_t i = 0; i < 4; i++) {
-        for (cnn_size_t j = 0; j < 6; j++) {
-            EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
-        }
-    }
+  }
 }
 
 TEST(slice, forward_channels) {
-    slice_layer sl(shape3d(1, 2, 3), slice_type::slice_channels, 3);
+  slice_layer sl(shape3d(1, 2, 3), slice_type::slice_channels, 3);
 
-    tensor_t in = {
-        { 0, 1, 2, 3, 4, 5 },
-        { 6, 7, 8, 9, 10, 11 },
-        { 12, 13, 14, 15, 16, 17 },
-        { 18, 19, 20, 21, 22, 23 }
-    };
+  tensor_t in = {{0, 1, 2, 3, 4, 5},
+                 {6, 7, 8, 9, 10, 11},
+                 {12, 13, 14, 15, 16, 17},
+                 {18, 19, 20, 21, 22, 23}};
 
-    tensor_t out0_expected = {
-        { 0, 1 },
-        { 6, 7 },
-        { 12, 13 },
-        { 18, 19 }
-    };
+  tensor_t out0_expected = {{0, 1}, {6, 7}, {12, 13}, {18, 19}};
 
-    tensor_t out1_expected = {
-        {  2, 3 },
-        {  8, 9 },
-        { 14, 15 },
-        { 20, 21 }
-    };
+  tensor_t out1_expected = {{2, 3}, {8, 9}, {14, 15}, {20, 21}};
 
-    tensor_t out2_expected = {
-        { 4, 5 },
-        { 10, 11 },
-        { 16, 17 },
-        { 22, 23 }
-    };
+  tensor_t out2_expected = {{4, 5}, {10, 11}, {16, 17}, {22, 23}};
 
-    auto out = sl.forward({ in });
+  auto out = sl.forward({in});
 
-    for (cnn_size_t i = 0; i < 4; i++) {
-        for (cnn_size_t j = 0; j < 2; j++) {
-            EXPECT_FLOAT_EQ(out0_expected[i][j], out[0][i][j]);
-            EXPECT_FLOAT_EQ(out1_expected[i][j], out[1][i][j]);
-            EXPECT_FLOAT_EQ(out2_expected[i][j], out[2][i][j]);
-        }
+  for (cnn_size_t i = 0; i < 4; i++) {
+    for (cnn_size_t j = 0; j < 2; j++) {
+      EXPECT_FLOAT_EQ(out0_expected[i][j], out[0][i][j]);
+      EXPECT_FLOAT_EQ(out1_expected[i][j], out[1][i][j]);
+      EXPECT_FLOAT_EQ(out2_expected[i][j], out[2][i][j]);
     }
+  }
 
-    out = sl.backward({out0_expected, out1_expected, out2_expected});
+  out = sl.backward({out0_expected, out1_expected, out2_expected});
 
-    for (cnn_size_t i = 0; i < 4; i++) {
-        for (cnn_size_t j = 0; j < 6; j++) {
-            EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
-        }
+  for (cnn_size_t i = 0; i < 4; i++) {
+    for (cnn_size_t j = 0; j < 6; j++) {
+      EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
     }
+  }
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_slice_layer.h
+++ b/test/test_slice_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/test_target_cost.h
+++ b/test/test_target_cost.h
@@ -11,275 +11,307 @@
 namespace tiny_dnn {
 
 TEST(target_cost, calculate_label_counts) {
-    const std::vector<label_t> t = { 0, 1, 4, 0, 1, 2 }; // note that there's no class "3"
+  const std::vector<label_t> t = {0, 1, 4,
+                                  0, 1, 2};  // note that there's no class "3"
 
-    const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
+  const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
 
-    EXPECT_EQ(label_counts.size(), cnn_size_t(5));
-    EXPECT_EQ(label_counts[0], cnn_size_t(2));
-    EXPECT_EQ(label_counts[1], cnn_size_t(2));
-    EXPECT_EQ(label_counts[2], cnn_size_t(1));
-    EXPECT_EQ(label_counts[3], cnn_size_t(0));
-    EXPECT_EQ(label_counts[4], cnn_size_t(1));
+  EXPECT_EQ(label_counts.size(), cnn_size_t(5));
+  EXPECT_EQ(label_counts[0], cnn_size_t(2));
+  EXPECT_EQ(label_counts[1], cnn_size_t(2));
+  EXPECT_EQ(label_counts[2], cnn_size_t(1));
+  EXPECT_EQ(label_counts[3], cnn_size_t(0));
+  EXPECT_EQ(label_counts[4], cnn_size_t(1));
 }
 
 TEST(target_cost, get_sample_weight_for_balanced_target_cost) {
-    const std::vector<cnn_size_t> class_sample_counts = { 1000, 100, 10, 1 };
-    const cnn_size_t class_count = class_sample_counts.size();
-    const cnn_size_t total_samples = std::accumulate(class_sample_counts.begin(), class_sample_counts.end(), static_cast<cnn_size_t>(0));
+  const std::vector<cnn_size_t> class_sample_counts = {1000, 100, 10, 1};
+  const cnn_size_t class_count = class_sample_counts.size();
+  const cnn_size_t total_samples =
+      std::accumulate(class_sample_counts.begin(), class_sample_counts.end(),
+                      static_cast<cnn_size_t>(0));
 
-    std::vector<float_t> class_weights;
-    for (cnn_size_t class_sample_count : class_sample_counts) {
-        class_weights.push_back(get_sample_weight_for_balanced_target_cost(class_count, total_samples, class_sample_count));
-    }
+  std::vector<float_t> class_weights;
+  for (cnn_size_t class_sample_count : class_sample_counts) {
+    class_weights.push_back(get_sample_weight_for_balanced_target_cost(
+        class_count, total_samples, class_sample_count));
+  }
 
-    EXPECT_EQ(class_weights.size(), class_sample_counts.size());
+  EXPECT_EQ(class_weights.size(), class_sample_counts.size());
 
-    EXPECT_NEAR(class_weights[0], 0.27775, 1e-6);
-    EXPECT_NEAR(class_weights[1], 2.7775, 1e-6);
-    EXPECT_NEAR(class_weights[2], 27.775, 1e-6);
-    EXPECT_NEAR(class_weights[3], 277.75, 1e-6);
+  EXPECT_NEAR(class_weights[0], 0.27775, 1e-6);
+  EXPECT_NEAR(class_weights[1], 2.7775, 1e-6);
+  EXPECT_NEAR(class_weights[2], 27.775, 1e-6);
+  EXPECT_NEAR(class_weights[3], 277.75, 1e-6);
 
-    const float_t expected_product = class_weights[0] * class_sample_counts[0];
-    float_t sum_of_products = expected_product;
-    for (size_t i = 1; i < class_sample_counts.size(); ++i) {
-        const float_t actual_product = class_weights[i] * class_sample_counts[i];
-        EXPECT_NEAR(expected_product, actual_product, 1e-6);
-        sum_of_products += actual_product;
-    }
+  const float_t expected_product = class_weights[0] * class_sample_counts[0];
+  float_t sum_of_products = expected_product;
+  for (size_t i = 1; i < class_sample_counts.size(); ++i) {
+    const float_t actual_product = class_weights[i] * class_sample_counts[i];
+    EXPECT_NEAR(expected_product, actual_product, 1e-6);
+    sum_of_products += actual_product;
+  }
 
-    EXPECT_NEAR(sum_of_products, total_samples, 1e-6);
+  EXPECT_NEAR(sum_of_products, total_samples, 1e-6);
 }
 
 TEST(target_cost, create_balanced_target_cost_0) {
-    const float_t w = 0;
+  const float_t w = 0;
 
-    const std::vector<label_t> t = { 0, 1, 4, 0, 1, 2 }; // note that there's no class "3"
+  const std::vector<label_t> t = {0, 1, 4,
+                                  0, 1, 2};  // note that there's no class "3"
 
-    const auto target_cost = create_balanced_target_cost(t, w);
+  const auto target_cost = create_balanced_target_cost(t, w);
 
-    EXPECT_EQ(target_cost.size(), t.size());
+  EXPECT_EQ(target_cost.size(), t.size());
 
-    for (size_t sample = 0; sample < t.size(); ++sample) {
-        const vec_t& sample_cost = target_cost[sample];
-        EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
+  for (size_t sample = 0; sample < t.size(); ++sample) {
+    const vec_t& sample_cost = target_cost[sample];
+    EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
 
-        for (size_t i = 0; i < sample_cost.size(); ++i) {
-            EXPECT_NEAR(sample_cost[i], 1.0, 1e-6);
-        }
+    for (size_t i = 0; i < sample_cost.size(); ++i) {
+      EXPECT_NEAR(sample_cost[i], 1.0, 1e-6);
     }
+  }
 }
 
 TEST(target_cost, create_balanced_target_cost_1) {
-    const float_t w = 1;
+  const float_t w = 1;
 
-    const std::vector<label_t> t = { 0, 1, 4, 0, 1, 2 }; // note that there's no class "3"
+  const std::vector<label_t> t = {0, 1, 4,
+                                  0, 1, 2};  // note that there's no class "3"
 
-    const auto target_cost = create_balanced_target_cost(t, w);
+  const auto target_cost = create_balanced_target_cost(t, w);
 
-    const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
+  const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
 
-    EXPECT_EQ(target_cost.size(), t.size());
+  EXPECT_EQ(target_cost.size(), t.size());
 
-    for (size_t sample = 0; sample < t.size(); ++sample) {
-        const vec_t& sample_cost = target_cost[sample];
-        EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
-        EXPECT_GE(label_counts[t[sample]], 1U);
+  for (size_t sample = 0; sample < t.size(); ++sample) {
+    const vec_t& sample_cost = target_cost[sample];
+    EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
+    EXPECT_GE(label_counts[t[sample]], 1U);
 
-        float_t expected_weight = t.size() / static_cast<float_t>(label_counts.size() * label_counts[t[sample]]);
+    float_t expected_weight =
+        t.size() /
+        static_cast<float_t>(label_counts.size() * label_counts[t[sample]]);
 
-        for (size_t label = 0; label < sample_cost.size(); ++label) {
-            EXPECT_NEAR(sample_cost[label], expected_weight, 1e-6);
-        }
+    for (size_t label = 0; label < sample_cost.size(); ++label) {
+      EXPECT_NEAR(sample_cost[label], expected_weight, 1e-6);
     }
+  }
 }
 
 TEST(target_cost, create_balanced_target_cost_0_5) {
-    const float_t w = 0.5;
+  const float_t w = 0.5;
 
-    const std::vector<label_t> t = { 0, 1, 4, 0, 1, 2 }; // note that there's no class "3"
+  const std::vector<label_t> t = {0, 1, 4,
+                                  0, 1, 2};  // note that there's no class "3"
 
-    const auto target_cost = create_balanced_target_cost(t, w);
+  const auto target_cost = create_balanced_target_cost(t, w);
 
-    const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
+  const std::vector<cnn_size_t> label_counts = calculate_label_counts(t);
 
-    EXPECT_EQ(target_cost.size(), t.size());
+  EXPECT_EQ(target_cost.size(), t.size());
 
-    for (size_t sample = 0; sample < t.size(); ++sample) {
-        const vec_t& sample_cost = target_cost[sample];
-        EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
-        EXPECT_GE(label_counts[t[sample]], 1U);
+  for (size_t sample = 0; sample < t.size(); ++sample) {
+    const vec_t& sample_cost = target_cost[sample];
+    EXPECT_EQ(sample_cost.size(), cnn_size_t(5));
+    EXPECT_GE(label_counts[t[sample]], 1U);
 
-        const float_t expected_weight_w_0 = 1;
-        const float_t expected_weight_w_1 = t.size() / static_cast<float_t>(label_counts.size() * label_counts[t[sample]]);
+    const float_t expected_weight_w_0 = 1;
+    const float_t expected_weight_w_1 =
+        t.size() /
+        static_cast<float_t>(label_counts.size() * label_counts[t[sample]]);
 
-        for (size_t label = 0; label < sample_cost.size(); ++label) {
-            const float_t label_cost = sample_cost[label];
-            if (expected_weight_w_1 > 1) {
-                EXPECT_GE(label_cost, expected_weight_w_0);
-                EXPECT_LE(label_cost, expected_weight_w_1);
-            }
-            else if (expected_weight_w_1 < 1) {
-                EXPECT_LE(label_cost, expected_weight_w_0);
-                EXPECT_GE(label_cost, expected_weight_w_1);
-            }
-            else {
-                EXPECT_NEAR(label_cost, 1.0, 1e-6);
-            }
+    for (size_t label = 0; label < sample_cost.size(); ++label) {
+      const float_t label_cost = sample_cost[label];
+      if (expected_weight_w_1 > 1) {
+        EXPECT_GE(label_cost, expected_weight_w_0);
+        EXPECT_LE(label_cost, expected_weight_w_1);
+      } else if (expected_weight_w_1 < 1) {
+        EXPECT_LE(label_cost, expected_weight_w_0);
+        EXPECT_GE(label_cost, expected_weight_w_1);
+      } else {
+        EXPECT_NEAR(label_cost, 1.0, 1e-6);
+      }
 
-            EXPECT_NEAR(label_cost, (1 - w) * expected_weight_w_0 + w * expected_weight_w_1, 1e-6);
-        }
+      EXPECT_NEAR(label_cost,
+                  (1 - w) * expected_weight_w_0 + w * expected_weight_w_1,
+                  1e-6);
     }
+  }
 }
 
 TEST(target_cost, train_unbalanced_data_1dim) {
-    // train a really simple function with noisy, unbalanced training data:
-    // 1) assuming equal cost for each training sample, in which case the total cost
-    //    (error) is rightly minimized by always guessing the majority class (1), and
-    // 2) assuming equal cost for each class, in which case the "true" function
-    //    (identity) can be learned
+  // train a really simple function with noisy, unbalanced training data:
+  // 1) assuming equal cost for each training sample, in which case the total
+  // cost
+  //    (error) is rightly minimized by always guessing the majority class (1),
+  //    and
+  // 2) assuming equal cost for each class, in which case the "true" function
+  //    (identity) can be learned
 
-    const float_t p = 0.9f;  // p(in == 1)
-    const float_t p0 = 0.6f; // p(label == 1 | in == 0)
-    const float_t p1 = 0.9f; // p(label == 1 | in == 1)
+  const float_t p = 0.9f;   // p(in == 1)
+  const float_t p0 = 0.6f;  // p(label == 1 | in == 0)
+  const float_t p1 = 0.9f;  // p(label == 1 | in == 1)
 
-    auto create_net = []() {
-        network<sequential> net;
-        net << fully_connected_layer<tan_h>(1, 10)
-            << fully_connected_layer<tan_h>(10, 2);
-        return net;
-    };
+  auto create_net = []() {
+    network<sequential> net;
+    net << fully_connected_layer<tan_h>(1, 10)
+        << fully_connected_layer<tan_h>(10, 2);
+    return net;
+  };
 
-    network<sequential> net_equal_sample_cost = create_net();
-    network<sequential> net_equal_class_cost  = create_net();
-    adagrad optimizer1, optimizer2;
-    std::vector<vec_t> data;
-    std::vector<label_t> labels;
-    const size_t tnum = 2000;
+  network<sequential> net_equal_sample_cost = create_net();
+  network<sequential> net_equal_class_cost = create_net();
+  adagrad optimizer1, optimizer2;
+  std::vector<vec_t> data;
+  std::vector<label_t> labels;
+  const size_t tnum = 2000;
 
-    for (size_t i = 0; i < tnum; i++) {
-        bool in = bernoulli(p);
-        bool label = in ? bernoulli(p1) : bernoulli(p0);
+  for (size_t i = 0; i < tnum; i++) {
+    bool in = bernoulli(p);
+    bool label = in ? bernoulli(p1) : bernoulli(p0);
 
-        data.push_back({ static_cast<float_t>(in) });
-        labels.push_back(label ? 1 : 0);
-    }
+    data.push_back({static_cast<float_t>(in)});
+    labels.push_back(label ? 1 : 0);
+  }
 
-    { // some simple checks
-        const float_t p_label1 = p0 * (1 - p) + p1 * p; // p(label == 1) = p(label == 1 | in == 0) * p(in == 0) + p(label == 1 | in == 1) * p(in == 1)
-        const cnn_size_t n_label1 = std::accumulate(labels.begin(), labels.end(), static_cast<cnn_size_t>(0));
+  {                                                  // some simple checks
+    const float_t p_label1 = p0 * (1 - p) + p1 * p;  // p(label == 1) = p(label
+                                                     // == 1 | in == 0) * p(in
+                                                     // == 0) + p(label == 1 |
+                                                     // in == 1) * p(in == 1)
+    const cnn_size_t n_label1 = std::accumulate(labels.begin(), labels.end(),
+                                                static_cast<cnn_size_t>(0));
 
-        EXPECT_NEAR(n_label1 / static_cast<float_t>(tnum), p_label1, 0.05);
-        EXPECT_GE(n_label1, 1600U);
-        EXPECT_LE(n_label1, 1800U);
-    }
+    EXPECT_NEAR(n_label1 / static_cast<float_t>(tnum), p_label1, 0.05);
+    EXPECT_GE(n_label1, 1600U);
+    EXPECT_LE(n_label1, 1800U);
+  }
 
-    const auto balanced_cost = create_balanced_target_cost(labels); // give higher weight to samples in the minority class
-    optimizer1.alpha *= 5;
-    optimizer2.alpha *= 5;
+  const auto balanced_cost = create_balanced_target_cost(
+      labels);  // give higher weight to samples in the minority class
+  optimizer1.alpha *= 5;
+  optimizer2.alpha *= 5;
 
-    // train both networks - one with implicit cost (equal for each sample),
-    // and the other with explicit cost (balanced, or equal for each class)
-    net_equal_sample_cost.train<mse>(optimizer1, data, labels, 10, 100, nop, nop, true, CNN_TASK_SIZE);
-    net_equal_class_cost .train<mse>(optimizer2, data, labels, 10, 100, nop, nop, true, CNN_TASK_SIZE, balanced_cost);
+  // train both networks - one with implicit cost (equal for each sample),
+  // and the other with explicit cost (balanced, or equal for each class)
+  net_equal_sample_cost.train<mse>(optimizer1, data, labels, 10, 100, nop, nop,
+                                   true, CNN_TASK_SIZE);
+  net_equal_class_cost.train<mse>(optimizer2, data, labels, 10, 100, nop, nop,
+                                  true, CNN_TASK_SIZE, balanced_cost);
+
+  // count errors
+  size_t errors_equal_sample_cost = 0;
+  size_t errors_equal_class_cost = 0;
+
+  for (size_t i = 0; i < tnum; i++) {
+    // the test data is balanced between the classes
+    const bool in = bernoulli(0.5);
+    const label_t expected = in ? 1 : 0;
+    const vec_t input = {static_cast<float_t>(in)};
+    const label_t actual_equal_sample_cost =
+        net_equal_sample_cost.predict_label(input);
+    const label_t actual_equal_class_cost =
+        net_equal_class_cost.predict_label(input);
+
+    // the first net always guesses the majority class
+    EXPECT_EQ(actual_equal_sample_cost, cnn_size_t(1));
 
     // count errors
-    size_t errors_equal_sample_cost = 0;
-    size_t errors_equal_class_cost  = 0;
+    errors_equal_sample_cost += (expected == actual_equal_sample_cost) ? 0 : 1;
+    errors_equal_class_cost += (expected == actual_equal_class_cost) ? 0 : 1;
+  }
 
-    for (size_t i = 0; i < tnum; i++) {
-        // the test data is balanced between the classes
-        const bool in = bernoulli(0.5);
-        const label_t expected = in ? 1 : 0;
-        const vec_t input = {static_cast<float_t>(in) };
-        const label_t actual_equal_sample_cost = net_equal_sample_cost.predict_label(input);
-        const label_t actual_equal_class_cost  = net_equal_class_cost .predict_label(input);
-
-        // the first net always guesses the majority class
-        EXPECT_EQ(actual_equal_sample_cost, cnn_size_t(1));
-
-        // count errors
-        errors_equal_sample_cost += (expected == actual_equal_sample_cost) ? 0 : 1;
-        errors_equal_class_cost  += (expected == actual_equal_class_cost)  ? 0 : 1;
-    }
-
-    EXPECT_GE(errors_equal_sample_cost, 0.25 * tnum); // should have plenty of errors
-    EXPECT_EQ(errors_equal_class_cost,  cnn_size_t(0)); // should have learned the desired function
+  EXPECT_GE(errors_equal_sample_cost,
+            0.25 * tnum);  // should have plenty of errors
+  EXPECT_EQ(errors_equal_class_cost,
+            cnn_size_t(0));  // should have learned the desired function
 }
 
 TEST(target_cost, train_unbalanced_data) {
-    // train xor function with noisy, unbalanced training data:
-    // 1) assuming equal cost for each training sample, in which case the total cost
-    //    (error) is rightly minimized by always guessing the majority class (1), and
-    // 2) assuming equal cost for each class, in which case the correct underlying
-    //    function can be learned.
+  // train xor function with noisy, unbalanced training data:
+  // 1) assuming equal cost for each training sample, in which case the total
+  // cost
+  //    (error) is rightly minimized by always guessing the majority class (1),
+  //    and
+  // 2) assuming equal cost for each class, in which case the correct underlying
+  //    function can be learned.
 
-    const float_t p = 0.9f; // p(label == 1)
-    const float_t noise = 0.25f;
+  const float_t p = 0.9f;  // p(label == 1)
+  const float_t noise = 0.25f;
 
-    auto create_net = []() {
-        network<sequential> net;
-        net << fully_connected_layer<tan_h>(2, 10)
-            << fully_connected_layer<tan_h>(10, 2);
-        return net;
-    };
+  auto create_net = []() {
+    network<sequential> net;
+    net << fully_connected_layer<tan_h>(2, 10)
+        << fully_connected_layer<tan_h>(10, 2);
+    return net;
+  };
 
-    network<sequential> net_equal_sample_cost = create_net();
-    network<sequential> net_equal_class_cost  = create_net();
-    adagrad optimizer1, optimizer2;
-    optimizer1.alpha = 0.02f;
-    optimizer2.alpha = 0.02f;
+  network<sequential> net_equal_sample_cost = create_net();
+  network<sequential> net_equal_class_cost = create_net();
+  adagrad optimizer1, optimizer2;
+  optimizer1.alpha = 0.02f;
+  optimizer2.alpha = 0.02f;
 
-    std::vector<vec_t> data;
-    std::vector<label_t> labels;
-    const size_t tnum = 2000;
+  std::vector<vec_t> data;
+  std::vector<label_t> labels;
+  const size_t tnum = 2000;
 
-    for (size_t i = 0; i < tnum; i++) {
-        const bool label = bernoulli(p);
+  for (size_t i = 0; i < tnum; i++) {
+    const bool label = bernoulli(p);
 
-        bool in0 = bernoulli(0.5);
-        bool in1 = (in0 ^ label);
+    bool in0 = bernoulli(0.5);
+    bool in1 = (in0 ^ label);
 
-        // add noise to make things more interesting
-        if (bernoulli(noise)) {
-            in1 = !in1;
-        }
-
-        data.push_back({ static_cast<float_t>(in0),
-                         static_cast<float_t>(in1) });
-        labels.push_back(label ? 1 : 0);
+    // add noise to make things more interesting
+    if (bernoulli(noise)) {
+      in1 = !in1;
     }
 
-    const auto balanced_cost = create_balanced_target_cost(labels); // give higher weight to samples in the minority class
+    data.push_back({static_cast<float_t>(in0), static_cast<float_t>(in1)});
+    labels.push_back(label ? 1 : 0);
+  }
 
-    // train both networks - one with implicit cost (equal for each sample),
-    // and the other with explicit cost (balanced, or equal for each class)
-    net_equal_sample_cost.train<mse>(optimizer1, data, labels, 10, 100, nop, nop, true, CNN_TASK_SIZE);
-    net_equal_class_cost .train<mse>(optimizer2, data, labels, 10, 100, nop, nop, true, CNN_TASK_SIZE, balanced_cost);
+  const auto balanced_cost = create_balanced_target_cost(
+      labels);  // give higher weight to samples in the minority class
+
+  // train both networks - one with implicit cost (equal for each sample),
+  // and the other with explicit cost (balanced, or equal for each class)
+  net_equal_sample_cost.train<mse>(optimizer1, data, labels, 10, 100, nop, nop,
+                                   true, CNN_TASK_SIZE);
+  net_equal_class_cost.train<mse>(optimizer2, data, labels, 10, 100, nop, nop,
+                                  true, CNN_TASK_SIZE, balanced_cost);
+
+  // count errors
+  size_t errors_equal_sample_cost = 0;
+  size_t errors_equal_class_cost = 0;
+
+  for (size_t i = 0; i < tnum; i++) {
+    // the test data is balanced between the classes
+    const bool in[2] = {bernoulli(0.5), bernoulli(0.5)};
+    const label_t expected = (in[0] ^ in[1]) ? 1 : 0;
+    const vec_t input = {static_cast<float_t>(in[0]),
+                         static_cast<float_t>(in[1])};
+    const label_t actual_equal_sample_cost =
+        net_equal_sample_cost.predict_label(input);
+    const label_t actual_equal_class_cost =
+        net_equal_class_cost.predict_label(input);
+
+    // the first net always guesses the majority class
+    EXPECT_EQ(actual_equal_sample_cost, cnn_size_t(1));
 
     // count errors
-    size_t errors_equal_sample_cost = 0;
-    size_t errors_equal_class_cost  = 0;
+    errors_equal_sample_cost += (expected == actual_equal_sample_cost) ? 0 : 1;
+    errors_equal_class_cost += (expected == actual_equal_class_cost) ? 0 : 1;
+  }
 
-    for (size_t i = 0; i < tnum; i++) {
-        // the test data is balanced between the classes
-        const bool in[2] = { bernoulli(0.5), bernoulli(0.5) };
-        const label_t expected = (in[0] ^ in[1]) ? 1 : 0;
-        const vec_t input = { static_cast<float_t>(in[0]),
-                              static_cast<float_t>(in[1]) };
-        const label_t actual_equal_sample_cost = net_equal_sample_cost.predict_label(input);
-        const label_t actual_equal_class_cost  = net_equal_class_cost .predict_label(input);
-
-        // the first net always guesses the majority class
-        EXPECT_EQ(actual_equal_sample_cost, cnn_size_t(1));
-
-        // count errors
-        errors_equal_sample_cost += (expected == actual_equal_sample_cost) ? 0 : 1;
-        errors_equal_class_cost  += (expected == actual_equal_class_cost)  ? 0 : 1;
-    }
-
-    EXPECT_GE(errors_equal_sample_cost, 0.25 * tnum); // should have plenty of errors
-    EXPECT_EQ(errors_equal_class_cost,  cnn_size_t(0)); // should have learned the desired function
+  EXPECT_GE(errors_equal_sample_cost,
+            0.25 * tnum);  // should have plenty of errors
+  EXPECT_EQ(errors_equal_class_cost,
+            cnn_size_t(0));  // should have learned the desired function
 }
 
-} // namespace tiny-dnn
+}  // namespace tiny-dnn

--- a/test/test_target_cost.h
+++ b/test/test_target_cost.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 #include "picotest/picotest.h"
 #include "testhelper.h"

--- a/test/testhelper.h
+++ b/test/testhelper.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <string>
 #include <iostream>

--- a/test/testhelper.h
+++ b/test/testhelper.h
@@ -3,187 +3,189 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <string>
-#include <iostream>
 #include <cstdio>
+#include <iostream>
+#include <string>
 #include "picotest/picotest.h"
 #include "tiny_dnn/tiny_dnn.h"
 
 namespace tiny_dnn {
 
 template <typename Container, typename T>
-inline bool is_near_container(const Container& expected, const Container& actual, T abs_error) {
-    auto i1 = std::begin(expected);
-    auto i2 = std::begin(actual);
+inline bool is_near_container(const Container& expected,
+                              const Container& actual, T abs_error) {
+  auto i1 = std::begin(expected);
+  auto i2 = std::begin(actual);
 
-    for (; i1 != std::end(expected); ++i1, ++i2) {
-        if(std::abs(*i1 - *i2) > abs_error) return false;
-    }
-    return true;
+  for (; i1 != std::end(expected); ++i1, ++i2) {
+    if (std::abs(*i1 - *i2) > abs_error) return false;
+  }
+  return true;
 }
 
 template <typename Container>
-inline bool is_different_container(const Container& expected, const Container& actual) {
-    auto i1 = std::begin(expected);
-    auto i2 = std::begin(actual);
+inline bool is_different_container(const Container& expected,
+                                   const Container& actual) {
+  auto i1 = std::begin(expected);
+  auto i2 = std::begin(actual);
 
-    for (; i1 != std::end(expected); ++i1, ++i2) {
-        if (*i1 != *i2) return true;
-    }
-    return false;
+  for (; i1 != std::end(expected); ++i1, ++i2) {
+    if (*i1 != *i2) return true;
+  }
+  return false;
 }
 
 inline bool exists(const std::string& path) {
-    if (FILE *file = std::fopen(path.c_str(), "r")) {
-        fclose(file);
-        return true;
-    } else {
-        return false;
-    }
+  if (FILE* file = std::fopen(path.c_str(), "r")) {
+    fclose(file);
+    return true;
+  } else {
+    return false;
+  }
 }
 
 inline std::string unique_path() {
-    std::string pattern = "%%%%-%%%%-%%%%-%%%%";
+  std::string pattern = "%%%%-%%%%-%%%%-%%%%";
 
-    for (auto p = pattern.begin(); p != pattern.end(); ++p) {
-        if (*p == '%') *p = (rand()%10)+'0';
-    }
-    return exists(pattern) ? unique_path() : pattern;
+  for (auto p = pattern.begin(); p != pattern.end(); ++p) {
+    if (*p == '%') *p = (rand() % 10) + '0';
+  }
+  return exists(pattern) ? unique_path() : pattern;
 }
 
 vec_t forward_pass(layer& src, const vec_t& vec) {
-    src.setup(false);
-    (*src.inputs()[0]->get_data())[0] = vec;
-    src.forward();
-    return src.output()[0][0];
+  src.setup(false);
+  (*src.inputs()[0]->get_data())[0] = vec;
+  src.forward();
+  return src.output()[0][0];
 }
 
 template <typename N>
 vec_t forward_pass(network<N>& net, const vec_t& vec) {
-    return net.predict(vec);
+  return net.predict(vec);
 }
 
 template <typename T>
-void serialization_test(T& src, T& dst)
-{
-    //EXPECT_FALSE(src.has_same_weights(dst, 1E-5));
+void serialization_test(T& src, T& dst) {
+  // EXPECT_FALSE(src.has_same_weights(dst, 1E-5));
 
-    std::string tmp_file_path = unique_path();
+  std::string tmp_file_path = unique_path();
 
-    // write
-    {
-        std::ofstream ofs(tmp_file_path.c_str());
-        src.save(ofs);
-    }
+  // write
+  {
+    std::ofstream ofs(tmp_file_path.c_str());
+    src.save(ofs);
+  }
 
-    // read
-    {
-        std::ifstream ifs(tmp_file_path.c_str());
-        dst.load(ifs);
-    }
+  // read
+  {
+    std::ifstream ifs(tmp_file_path.c_str());
+    dst.load(ifs);
+  }
 
-    std::remove(tmp_file_path.c_str());
+  std::remove(tmp_file_path.c_str());
 
-    vec_t v(src.in_data_size());
-    uniform_rand(v.begin(), v.end(), -1.0f, 1.0f);
+  vec_t v(src.in_data_size());
+  uniform_rand(v.begin(), v.end(), -1.0f, 1.0f);
 
-    EXPECT_TRUE(src.has_same_weights(dst, 1E-5f));
+  EXPECT_TRUE(src.has_same_weights(dst, 1E-5f));
 
-    vec_t r1 = forward_pass(src, v);
-    vec_t r2 = forward_pass(dst, v);
+  vec_t r1 = forward_pass(src, v);
+  vec_t r2 = forward_pass(dst, v);
 
-    EXPECT_TRUE(is_near_container(r1, r2, 1E-4f));
+  EXPECT_TRUE(is_near_container(r1, r2, 1E-4f));
 }
 
-
 template <typename T>
-void quantized_serialization_test(T& src, T& dst)
-{
-    //EXPECT_FALSE(src.has_same_weights(dst, 1E-5));
+void quantized_serialization_test(T& src, T& dst) {
+  // EXPECT_FALSE(src.has_same_weights(dst, 1E-5));
 
-    std::string tmp_file_path = unique_path();
+  std::string tmp_file_path = unique_path();
 
-    // write
-    {
-        std::ofstream ofs(tmp_file_path.c_str());
-        src.save(ofs);
-    }
+  // write
+  {
+    std::ofstream ofs(tmp_file_path.c_str());
+    src.save(ofs);
+  }
 
-    // read
-    {
-        std::ifstream ifs(tmp_file_path.c_str());
-        dst.load(ifs);
-    }
+  // read
+  {
+    std::ifstream ifs(tmp_file_path.c_str());
+    dst.load(ifs);
+  }
 
-    std::remove(tmp_file_path.c_str());
+  std::remove(tmp_file_path.c_str());
 
-    vec_t v(src.in_data_size());
-    uniform_rand(v.begin(), v.end(), -1.0, 1.0);
+  vec_t v(src.in_data_size());
+  uniform_rand(v.begin(), v.end(), -1.0, 1.0);
 
-    EXPECT_TRUE(src.has_same_weights(dst, 1E-5));
+  EXPECT_TRUE(src.has_same_weights(dst, 1E-5));
 
-    vec_t r1 = forward_pass(src, v);
-    vec_t r2 = forward_pass(dst, v);
+  vec_t r1 = forward_pass(src, v);
+  vec_t r2 = forward_pass(dst, v);
 
-    EXPECT_TRUE(is_near_container(r1, r2, 1E-2));
+  EXPECT_TRUE(is_near_container(r1, r2, 1E-2));
 }
 
 template <typename T>
 inline T epsilon() {
-    return 0;
+  return 0;
 }
 
 template <>
 inline float epsilon() {
-    return 1e-2f;
+  return 1e-2f;
 }
 
 template <>
 inline double epsilon() {
-    return 1e-4;
+  return 1e-4;
 }
 
 inline bool resolve_path(const std::string& filename, std::string& path) {
-    static const char* path_list[] = {
-       "",
-       "./test/",
-       "../test/",
-       "../../test/",
-       "../../../test/",
-       "../../tiny-dnn/test/",
-       "../../../tiny-dnn/test/" 
-    };
+  static const char* path_list[] = {"",
+                                    "./test/",
+                                    "../test/",
+                                    "../../test/",
+                                    "../../../test/",
+                                    "../../tiny-dnn/test/",
+                                    "../../../tiny-dnn/test/"};
 
-    for (size_t i = 0; i < sizeof(path_list) / sizeof(path_list[0]); i++) {
-        if (exists(path_list[i] + filename)) {
-            path = path_list[i] + filename;
-            return true;
-        }
+  for (size_t i = 0; i < sizeof(path_list) / sizeof(path_list[0]); i++) {
+    if (exists(path_list[i] + filename)) {
+      path = path_list[i] + filename;
+      return true;
     }
-    return false;
+  }
+  return false;
 }
 
 namespace {
-    std::pair<std::vector<tensor_t>, std::vector<std::vector<label_t>>> generate_gradient_check_data(
-        cnn_size_t input_dimension, cnn_size_t sample_count = 5, cnn_size_t class_count = 2)
-    {
-        const cnn_size_t input_channel_count = 1;
-        const cnn_size_t output_channel_count = 1;
-        std::vector<tensor_t> a(sample_count, tensor_t(input_channel_count, vec_t(input_dimension, 0.0)));
-        std::vector<std::vector<label_t>> t(sample_count, std::vector<label_t>(output_channel_count));
+std::pair<std::vector<tensor_t>, std::vector<std::vector<label_t>>>
+generate_gradient_check_data(cnn_size_t input_dimension,
+                             cnn_size_t sample_count = 5,
+                             cnn_size_t class_count = 2) {
+  const cnn_size_t input_channel_count = 1;
+  const cnn_size_t output_channel_count = 1;
+  std::vector<tensor_t> a(
+      sample_count, tensor_t(input_channel_count, vec_t(input_dimension, 0.0)));
+  std::vector<std::vector<label_t>> t(
+      sample_count, std::vector<label_t>(output_channel_count));
 
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            for (cnn_size_t input_channel = 0; input_channel < input_channel_count; ++input_channel) {
-                vec_t& v = a[sample][input_channel];
-                uniform_rand(v.begin(), v.end(), -1, 1);
-            }
-            for (cnn_size_t output_channel = 0; output_channel < output_channel_count; ++output_channel) {
-                t[sample][output_channel] = sample % class_count;
-            }
-        }
-
-        return std::make_pair(a, t);
+  for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+    for (cnn_size_t input_channel = 0; input_channel < input_channel_count;
+         ++input_channel) {
+      vec_t& v = a[sample][input_channel];
+      uniform_rand(v.begin(), v.end(), -1, 1);
     }
+    for (cnn_size_t output_channel = 0; output_channel < output_channel_count;
+         ++output_channel) {
+      t[sample][output_channel] = sample % class_count;
+    }
+  }
+
+  return std::make_pair(a, t);
+}
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/activations/activation_function.h
+++ b/tiny_dnn/activations/activation_function.h
@@ -3,153 +3,185 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include <algorithm>
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 namespace activation {
 
 class function {
-public:
-    function() = default;
-    function(const function &) = default;
+ public:
+  function() = default;
+  function(const function&) = default;
 #ifndef CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
-    function(function &&) = default;
+  function(function&&) = default;
 #endif
-    function &operator =(const function &) = default;
+  function& operator=(const function&) = default;
 #ifndef CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
-    function &operator =(function &&) = default;
+  function& operator=(function&&) = default;
 #endif
-    virtual ~function() = default;
+  virtual ~function() = default;
 
-    virtual float_t f(const vec_t& v, cnn_size_t index) const = 0;
+  virtual float_t f(const vec_t& v, cnn_size_t index) const = 0;
 
-    // dfi/dyi
-    virtual float_t df(float_t y) const = 0;
+  // dfi/dyi
+  virtual float_t df(float_t y) const = 0;
 
-    // dfi/dyk (k=0,1,..n)
-    virtual vec_t df(const vec_t& y, cnn_size_t i) const { vec_t v(y.size(), 0); v[i] = df(y[i]); return v; }
+  // dfi/dyk (k=0,1,..n)
+  virtual vec_t df(const vec_t& y, cnn_size_t i) const {
+    vec_t v(y.size(), 0);
+    v[i] = df(y[i]);
+    return v;
+  }
 
-    // return if dfi/dyk is one-hot vector
-    virtual bool one_hot() const { return true; }
+  // return if dfi/dyk is one-hot vector
+  virtual bool one_hot() const { return true; }
 
-    // target value range for learning
-    virtual std::pair<float_t, float_t> scale() const = 0;
+  // target value range for learning
+  virtual std::pair<float_t, float_t> scale() const = 0;
 };
 
 class identity : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override { return v[i]; }
-    float_t df(float_t /*y*/) const override { return float_t(1); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override { return v[i]; }
+  float_t df(float_t /*y*/) const override { return float_t(1); }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
 class sigmoid : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override { return float_t(1) / (float_t(1) + std::exp(-v[i])); }
-    float_t df(float_t y) const override { return y * (float_t(1) - y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    return float_t(1) / (float_t(1) + std::exp(-v[i]));
+  }
+  float_t df(float_t y) const override { return y * (float_t(1) - y); }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
 class relu : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override { return std::max(float_t(0), v[i]); }
-    float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    return std::max(float_t(0), v[i]);
+  }
+  float_t df(float_t y) const override {
+    return y > float_t(0) ? float_t(1) : float_t(0);
+  }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
-typedef relu rectified_linear; // for compatibility
+typedef relu rectified_linear;  // for compatibility
 
 class leaky_relu : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override { return (v[i] > float_t(0)) ? v[i] : float_t(0.01) * v[i]; }
-    float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0.01); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    return (v[i] > float_t(0)) ? v[i] : float_t(0.01) * v[i];
+  }
+  float_t df(float_t y) const override {
+    return y > float_t(0) ? float_t(1) : float_t(0.01);
+  }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
 class elu : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override { return (v[i]<float_t(0) ? (exp(v[i])- float_t(1)) : v[i]); }
-    float_t df(float_t y) const override { return (y > float_t(0) ? float_t(1) : (float_t(1)+y)); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    return (v[i] < float_t(0) ? (exp(v[i]) - float_t(1)) : v[i]);
+  }
+  float_t df(float_t y) const override {
+    return (y > float_t(0) ? float_t(1) : (float_t(1) + y));
+  }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
 class softmax : public function {
-public:
-    float_t f(const vec_t& v, cnn_size_t i) const override {
-        float_t alpha = *std::max_element(v.begin(), v.end());
-        float_t numer = std::exp(v[i] - alpha);
-        float_t denom = float_t(0);
-        for (auto x : v)
-            denom += std::exp(x - alpha);
-        return numer / denom;
-    }
+ public:
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    float_t alpha = *std::max_element(v.begin(), v.end());
+    float_t numer = std::exp(v[i] - alpha);
+    float_t denom = float_t(0);
+    for (auto x : v) denom += std::exp(x - alpha);
+    return numer / denom;
+  }
 
-    float_t df(float_t y) const override {
-        return y * (float_t(1) - y);
-    }
+  float_t df(float_t y) const override { return y * (float_t(1) - y); }
 
-    virtual vec_t df(const vec_t& y, cnn_size_t index) const override {
-        vec_t v(y.size(), 0);
-        for (cnn_size_t i = 0; i < y.size(); i++)
-            v[i] = (i == index) ? df(y[index]) : -y[i] * y[index];
+  virtual vec_t df(const vec_t& y, cnn_size_t index) const override {
+    vec_t v(y.size(), 0);
+    for (cnn_size_t i = 0; i < y.size(); i++)
+      v[i] = (i == index) ? df(y[index]) : -y[i] * y[index];
 
-        return v;
-    }
+    return v;
+  }
 
-    virtual bool one_hot() const override { return false; }
+  virtual bool one_hot() const override { return false; }
 
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0), float_t(1)); }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0), float_t(1));
+  }
 };
 
 class tan_h : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override {
-        const float_t ep = std::exp(v[i]);
-        const float_t em = std::exp(-v[i]); 
-        return (ep - em) / (ep + em);
-    }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    const float_t ep = std::exp(v[i]);
+    const float_t em = std::exp(-v[i]);
+    return (ep - em) / (ep + em);
+  }
 
-    // fast approximation of tanh (improve 2-3% speed in LeNet-5)
-    /*float_t f(float_t x) const {
-        const float_t x2 = x * x;
-        x *= 1.0 + x2 * (0.1653 + x2 * 0.0097);
-        return x / std::sqrt(1.0 + x * x);// invsqrt(static_cast<float>(1.0 + x * x));
-    }*/
+  // fast approximation of tanh (improve 2-3% speed in LeNet-5)
+  /*float_t f(float_t x) const {
+      const float_t x2 = x * x;
+      x *= 1.0 + x2 * (0.1653 + x2 * 0.0097);
+      return x / std::sqrt(1.0 + x * x);// invsqrt(static_cast<float>(1.0 + x *
+  x));
+  }*/
 
-    float_t df(float_t y) const override { return float_t(1) - sqr(y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(-0.8), float_t(0.8)); }
+  float_t df(float_t y) const override { return float_t(1) - sqr(y); }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(-0.8), float_t(0.8));
+  }
 
-private:
-    /*float invsqrt(float x) const {
-        float x2 = x * 0.5f;
-        long i = *reinterpret_cast<long*>(&x);
+ private:
+  /*float invsqrt(float x) const {
+      float x2 = x * 0.5f;
+      long i = *reinterpret_cast<long*>(&x);
 
-        i = 0x5f3759df - (i >> 1);
-        x = *reinterpret_cast<float*>(&i);
-        x = x * (1.5f - (x2 * x * x));
-        return x;
-    }*/
+      i = 0x5f3759df - (i >> 1);
+      x = *reinterpret_cast<float*>(&i);
+      x = x * (1.5f - (x2 * x * x));
+      return x;
+  }*/
 };
 
 // s tan_h, but scaled to match the other functions
 class tan_hp1m2 : public function {
-public:
-    using function::df;
-    float_t f(const vec_t& v, cnn_size_t i) const override {
-        const float_t ep = std::exp(v[i]);
-        return ep / (ep + std::exp(-v[i]));
-    }
+ public:
+  using function::df;
+  float_t f(const vec_t& v, cnn_size_t i) const override {
+    const float_t ep = std::exp(v[i]);
+    return ep / (ep + std::exp(-v[i]));
+  }
 
-    float_t df(float_t y) const override { return 2 * y *(float_t(1) - y); }
-    std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
+  float_t df(float_t y) const override { return 2 * y * (float_t(1) - y); }
+  std::pair<float_t, float_t> scale() const override {
+    return std::make_pair(float_t(0.1), float_t(0.9));
+  }
 };
 
-} // namespace activation
-} // namespace tiny_dnn
+}  // namespace activation
+}  // namespace tiny_dnn

--- a/tiny_dnn/activations/activation_function.h
+++ b/tiny_dnn/activations/activation_function.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <algorithm>

--- a/tiny_dnn/config.h
+++ b/tiny_dnn/config.h
@@ -31,10 +31,9 @@
 #define CNN_USE_EXCEPTIONS
 
 /**
- * comment out if you want tiny-dnn to be quiet 
+ * comment out if you want tiny-dnn to be quiet
  */
 #define CNN_USE_STDOUT
-
 
 /**
  * disable serialization/deserialization function
@@ -54,7 +53,7 @@
 #endif
 
 #if !defined(_MSC_VER) && !defined(_WIN32) && !defined(WIN32)
-#define CNN_USE_GEMMLOWP // gemmlowp doesn't support MSVC/mingw
+#define CNN_USE_GEMMLOWP  // gemmlowp doesn't support MSVC/mingw
 #endif
 
 namespace tiny_dnn {
@@ -70,5 +69,4 @@ typedef float float_t;
  * change to smaller type if memory footprint is severe
  **/
 typedef std::size_t cnn_size_t;
-
 }

--- a/tiny_dnn/config.h
+++ b/tiny_dnn/config.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <cstddef>
 

--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -4,11 +4,11 @@
 
 #pragma once
 
-#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/params/deconv_params.h"
-#include "tiny_dnn/core/params/maxpool_params.h"
 #include "tiny_dnn/core/params/fully_params.h"
+#include "tiny_dnn/core/params/maxpool_params.h"
+#include "tiny_dnn/layers/layer.h"
 
 namespace tiny_dnn {
 namespace core {
@@ -18,18 +18,28 @@ class context;
 
 enum class backend_t { tiny_dnn, nnpack, libdnn, avx, opencl };
 
-inline std::ostream& operator << (std::ostream& os, backend_t type) {
-    switch (type) {
-        case backend_t::tiny_dnn: os << "TinyDNN"; break;
-        case backend_t::nnpack:   os << "NNPACK";  break;
-        case backend_t::libdnn:   os << "LibDNN";  break;
-        case backend_t::avx:      os << "AVX";     break;
-        case backend_t::opencl:   os << "OpenCL";  break;
-        default:
-            throw nn_error("Not supported ostream enum.");
-            break;
-    }
-    return os;
+inline std::ostream& operator<<(std::ostream& os, backend_t type) {
+  switch (type) {
+    case backend_t::tiny_dnn:
+      os << "TinyDNN";
+      break;
+    case backend_t::nnpack:
+      os << "NNPACK";
+      break;
+    case backend_t::libdnn:
+      os << "LibDNN";
+      break;
+    case backend_t::avx:
+      os << "AVX";
+      break;
+    case backend_t::opencl:
+      os << "OpenCL";
+      break;
+    default:
+      throw nn_error("Not supported ostream enum.");
+      break;
+  }
+  return os;
 }
 
 /*enum class Engine { OpenCL };*/
@@ -37,99 +47,99 @@ inline std::ostream& operator << (std::ostream& os, backend_t type) {
 inline backend_t default_engine() {
 #ifdef CNN_USE_AVX
 #if defined(__AVX__) || defined(__AVX2__)
-    return backend_t::avx;
+  return backend_t::avx;
 #endif
-#endif // CNN_USE_AVX
-    return backend_t::tiny_dnn;
+#endif  // CNN_USE_AVX
+  return backend_t::tiny_dnn;
 }
 
 // TODO(edgar): remove this
 struct backend_params {
-    backend_params() {}
+  backend_params() {}
 };
 
 class backend {
  public:
-    // context holds solution-dependent parameters
-    // context should be able to hold any types of structures (like boost::any)
-    explicit backend(context* ctx_ = nullptr) {}
+  // context holds solution-dependent parameters
+  // context should be able to hold any types of structures (like boost::any)
+  explicit backend(context* ctx_ = nullptr) {}
 
-    // core math functions
+  // core math functions
 
-    virtual void conv2d(const std::vector<tensor_t*>& in_data,
-                        std::vector<tensor_t*>&       out_data) = 0;
+  virtual void conv2d(const std::vector<tensor_t*>& in_data,
+                      std::vector<tensor_t*>& out_data) = 0;
 
-    virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
-                          std::vector<tensor_t*>&       out_data) = 0;
+  virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
+                        std::vector<tensor_t*>& out_data) = 0;
 
-    virtual void conv2d_eq(const std::vector<tensor_t*>& in_data,
-                           std::vector<tensor_t*>&       out_data) = 0;
+  virtual void conv2d_eq(const std::vector<tensor_t*>& in_data,
+                         std::vector<tensor_t*>& out_data) = 0;
 
-    virtual void conv2d(const std::vector<tensor_t*>& in_data,
+  virtual void conv2d(const std::vector<tensor_t*>& in_data,
+                      const std::vector<tensor_t*>& out_data,
+                      std::vector<tensor_t*>& out_grad,
+                      std::vector<tensor_t*>& in_grad) = 0;
+
+  virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
                         const std::vector<tensor_t*>& out_data,
-                        std::vector<tensor_t*>&       out_grad,
-                        std::vector<tensor_t*>&       in_grad) = 0;
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) = 0;
 
-    virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
+  virtual void deconv2d(const std::vector<tensor_t*>& in_data,
+                        std::vector<tensor_t*>& out_data) = 0;
+
+  virtual void deconv2d_q(const std::vector<tensor_t*>& in_data,
+                          std::vector<tensor_t*>& out_data) = 0;
+
+  virtual void deconv2d_eq(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) = 0;
+
+  virtual void deconv2d(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) = 0;
+
+  virtual void deconv2d_q(const std::vector<tensor_t*>& in_data,
                           const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) = 0;
+                          std::vector<tensor_t*>& out_grad,
+                          std::vector<tensor_t*>& in_grad) = 0;
 
-    virtual void deconv2d(const std::vector<tensor_t*>& in_data,
-                          std::vector<tensor_t*>&       out_data) = 0;
+  virtual void maxpool(const std::vector<tensor_t*>& in_data,
+                       std::vector<tensor_t*>& out_data) = 0;
 
-    virtual void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                            std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void deconv2d_eq(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void deconv2d(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) = 0;
-
-    virtual void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                            const std::vector<tensor_t*>& out_data,
-                            std::vector<tensor_t*>&       out_grad,
-                            std::vector<tensor_t*>&       in_grad) = 0;
-
-    virtual void maxpool(const std::vector<tensor_t*>& in_data,
-                         std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void maxpool(const std::vector<tensor_t*>& in_data,
-                         const std::vector<tensor_t*>& out_data,
-                         std::vector<tensor_t*>&       out_grad,
-                         std::vector<tensor_t*>&       in_grad) = 0;
-
-    virtual void fully(const std::vector<tensor_t*>& in_data,
-                       std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void fully_q(const std::vector<tensor_t*>& in_data,
-                         std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void fully_eq(const std::vector<tensor_t*>& in_data,
-                          std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void fully(const std::vector<tensor_t*>& in_data,
+  virtual void maxpool(const std::vector<tensor_t*>& in_data,
                        const std::vector<tensor_t*>& out_data,
-                       std::vector<tensor_t*>&       out_grad,
-                       std::vector<tensor_t*>&       in_grad) = 0;
+                       std::vector<tensor_t*>& out_grad,
+                       std::vector<tensor_t*>& in_grad) = 0;
 
-    virtual void fully_q(const std::vector<tensor_t*>& in_data,
-                         const std::vector<tensor_t*>& out_data,
-                         std::vector<tensor_t*>&       out_grad,
-                         std::vector<tensor_t*>&       in_grad) = 0;
+  virtual void fully(const std::vector<tensor_t*>& in_data,
+                     std::vector<tensor_t*>& out_data) = 0;
 
-    context* get_context() const { return ctx_; }
+  virtual void fully_q(const std::vector<tensor_t*>& in_data,
+                       std::vector<tensor_t*>& out_data) = 0;
 
-    void set_layer(layerptr_t layer) { layer_ = layer; }
+  virtual void fully_eq(const std::vector<tensor_t*>& in_data,
+                        std::vector<tensor_t*>& out_data) = 0;
 
-    virtual backend_t type() const = 0;
+  virtual void fully(const std::vector<tensor_t*>& in_data,
+                     const std::vector<tensor_t*>& out_data,
+                     std::vector<tensor_t*>& out_grad,
+                     std::vector<tensor_t*>& in_grad) = 0;
+
+  virtual void fully_q(const std::vector<tensor_t*>& in_data,
+                       const std::vector<tensor_t*>& out_data,
+                       std::vector<tensor_t*>& out_grad,
+                       std::vector<tensor_t*>& in_grad) = 0;
+
+  context* get_context() const { return ctx_; }
+
+  void set_layer(layerptr_t layer) { layer_ = layer; }
+
+  virtual backend_t type() const = 0;
 
  protected:
-    context* ctx_;
-    layerptr_t layer_;
+  context* ctx_;
+  layerptr_t layer_;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/backend_avx.h
+++ b/tiny_dnn/core/backend_avx.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/backend.h"

--- a/tiny_dnn/core/backend_avx.h
+++ b/tiny_dnn/core/backend_avx.h
@@ -8,278 +8,284 @@
 
 // #include "tiny_dnn/core/kernels/avx_conv2d_kernel.h"
 // #include "tiny_dnn/core/kernels/avx_conv2d_back_kernel.h"
-#include "tiny_dnn/core/kernels/avx_deconv2d_kernel.h"
 #include "tiny_dnn/core/kernels/avx_deconv2d_back_kernel.h"
-#include "tiny_dnn/core/kernels/avx_maxpool_kernel.h"
+#include "tiny_dnn/core/kernels/avx_deconv2d_kernel.h"
 #include "tiny_dnn/core/kernels/avx_fully_connected_kernel.h"
+#include "tiny_dnn/core/kernels/avx_maxpool_kernel.h"
 
 namespace tiny_dnn {
 namespace core {
 
 class avx_backend : public backend {
  public:
-    // context holds solution-dependent parameters
-    // context should be able to hold any types of structures (like boost::any)
+  // context holds solution-dependent parameters
+  // context should be able to hold any types of structures (like boost::any)
 
-    // convolution
-    avx_backend(conv_params* params,
-                std::function<void(const tensor_t&)> f1,
-                std::function<void(const tensor_t&, tensor_t&)> f2,
-                std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
-                conv_layer_worker_specific_storage* ptr)
-      : params_c_(params)
-      , conv_layer_worker_storage_(ptr)
-      , copy_and_pad_input(f1)
-      , copy_and_unpad_delta(f2)
-      , backward_activation(f3) {}
+  // convolution
+  avx_backend(
+      conv_params* params, std::function<void(const tensor_t&)> f1,
+      std::function<void(const tensor_t&, tensor_t&)> f2,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
+      conv_layer_worker_specific_storage* ptr)
+      : params_c_(params),
+        conv_layer_worker_storage_(ptr),
+        copy_and_pad_input(f1),
+        copy_and_unpad_delta(f2),
+        backward_activation(f3) {}
 
-    // deconvolution
-    avx_backend(deconv_params* params,
-                std::function<void(const tensor_t&)> f1,
-                std::function<void(const tensor_t&, tensor_t&)> f2,
-                std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
-                deconv_layer_worker_specific_storage* ptr)
-      : params_d_(params)
-      , deconv_layer_worker_storage_(ptr)
-      , copy_and_unpad_output(f1)
-      , copy_and_pad_delta(f2)
-      , backward_activation(f3) {}
+  // deconvolution
+  avx_backend(
+      deconv_params* params, std::function<void(const tensor_t&)> f1,
+      std::function<void(const tensor_t&, tensor_t&)> f2,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
+      deconv_layer_worker_specific_storage* ptr)
+      : params_d_(params),
+        deconv_layer_worker_storage_(ptr),
+        copy_and_unpad_output(f1),
+        copy_and_pad_delta(f2),
+        backward_activation(f3) {}
 
-    // maxpooling
-    avx_backend(std::vector<std::vector<cnn_size_t>>* out2in,
-                std::vector<cnn_size_t>* in2out,
-                std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f,
-                max_pooling_layer_worker_specific_storage* ptr)
-      : max_pooling_layer_worker_storage_(ptr)
-      , out2in_(out2in)
-      , in2out_(in2out)
-      , backward_activation(f) {}
+  // maxpooling
+  avx_backend(
+      std::vector<std::vector<cnn_size_t>>* out2in,
+      std::vector<cnn_size_t>* in2out,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f,
+      max_pooling_layer_worker_specific_storage* ptr)
+      : max_pooling_layer_worker_storage_(ptr),
+        out2in_(out2in),
+        in2out_(in2out),
+        backward_activation(f) {}
 
-    // fully_connected
-    avx_backend(fully_params* params,
-                std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f)
-      : params_f_(params)
-      , backward_activation(f) {}
+  // fully_connected
+  avx_backend(
+      fully_params* params,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f)
+      : params_f_(params), backward_activation(f) {}
 
-    // core math functions
+  // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        copy_and_pad_input(*in_data[0]);
-        //const vec_t& W    = (*in_data[1])[0];
-        //const vec_t& bias = (*in_data[2])[0];
-        //tensor_t&    a    = *out_data[1];
-        //const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              std::vector<tensor_t*>& out_data) override {
+    copy_and_pad_input(*in_data[0]);
+    // const vec_t& W    = (*in_data[1])[0];
+    // const vec_t& bias = (*in_data[2])[0];
+    // tensor_t&    a    = *out_data[1];
+    // const std::vector<const vec_t*> &in =
+    // (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
 
-        //fill_tensor(a, float_t(0));
+    // fill_tensor(a, float_t(0));
 
-        //kernels::avx_conv2d_kernel(*params_c_,
-        //    in, W, bias, a, layer_->parallelize());
+    // kernels::avx_conv2d_kernel(*params_c_,
+    //    in, W, bias, a, layer_->parallelize());
+  }
+
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void conv2d_eq(const std::vector<tensor_t*>& in_data,
+                 std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              const std::vector<tensor_t*>& out_data,
+              std::vector<tensor_t*>& out_grad,
+              std::vector<tensor_t*>& in_grad) override {
+    conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
+
+    // std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    // tensor_t&    db = *in_grad[2];
+    tensor_t& curr_delta = *out_grad[1];
+    tensor_t* prev_delta = (params_c_->pad_type == padding::same)
+                               ? &cws.prev_delta_padded_
+                               : in_grad[0];
+
+    assert(W.size() == params_c_->weight.size());
+    assert(dW[0].size() == params_c_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    fill_tensor(*prev_delta, float_t(0));
+
+    // kernels::avx_conv2d_back_kernel(*params_c_,
+    //    prev_out, W, dW, db, curr_delta, prev_delta);
+
+    if (params_c_->pad_type == padding::same) {
+      copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
     }
+  }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void conv2d_eq(const std::vector<tensor_t*>& in_data,
-                   std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void conv2d(const std::vector<tensor_t*>& in_data,
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
                 const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
 
-        //std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
-        const vec_t& W  = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        //tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = *out_grad[1];
-        tensor_t*    prev_delta = (params_c_->pad_type == padding::same) ?
-                                   &cws.prev_delta_padded_ : in_grad[0];
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+    const tensor_t& in = *in_data[0];  // input
 
-        assert(W.size() == params_c_->weight.size());
-        assert(dW[0].size() == params_c_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
+    fill_tensor(a, float_t(0));
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    kernels::avx_deconv2d_kernel(*params_d_, in, W, bias, a,
+                                 layer_->parallelize());
 
-        fill_tensor(*prev_delta, float_t(0));
+    copy_and_unpad_output(a);
+    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+  }
 
-        //kernels::avx_conv2d_back_kernel(*params_c_,
-        //    prev_out, W, dW, db, curr_delta, prev_delta);
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
+                  std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-        if (params_c_->pad_type == padding::same) {
-            copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
-        }
-    }
+  void deconv2d_eq(const std::vector<tensor_t*>& in_data,
+                   std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                const std::vector<tensor_t*>& out_data,
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
+    if (params_d_->pad_type == padding::same)
+      copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
+
+    const tensor_t& prev_out = *(cws.prev_out_);
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& curr_delta = (params_d_->pad_type == padding::same)
+                               ? cws.curr_delta_padded
+                               : *out_grad[1];
+    tensor_t* prev_delta = in_grad[0];
+
+    assert(W.size() == params_d_->weight.size());
+    assert(dW[0].size() == params_d_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    fill_tensor(*prev_delta, float_t(0));
+
+    kernels::avx_deconv2d_back_kernel(*params_d_, prev_out, W, dW, db,
+                                      curr_delta, prev_delta);
+  }
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
                   const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+                  std::vector<tensor_t*>& out_grad,
+                  std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void deconv2d(const std::vector<tensor_t*>&  in_data,
-                  std::vector<tensor_t*>&        out_data) override {
-        (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const vec_t& W = (*in_data[1])[0];
-        const vec_t& bias = (*in_data[2])[0];
-        tensor_t&       a = *out_data[1];
-        const tensor_t &in = *in_data[0]; // input
+  void maxpool(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    tensor_t& a = *out_data[1];
+    std::vector<std::vector<cnn_size_t>>& max_idx =
+        (*max_pooling_layer_worker_storage_).out2inmax_;
 
-        fill_tensor(a, float_t(0));
+    kernels::avx_maxpool_kernel(in, a, max_idx, *out2in_,
+                                layer_->parallelize());
+  }
 
-        kernels::avx_deconv2d_kernel(*params_d_,
-            in, W, bias, a, layer_->parallelize());
-
-        copy_and_unpad_output(a);
-        a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
-    }
-
-    void deconv2d_q(const std::vector<tensor_t*>&  in_data,
-                    std::vector<tensor_t*>&        out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void deconv2d_eq(const std::vector<tensor_t*>&  in_data,
-                     std::vector<tensor_t*>&        out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-
-        deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
-        if (params_d_->pad_type == padding::same)
-            copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
-
-        const tensor_t& prev_out = *(cws.prev_out_);
-        const vec_t& W = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = (params_d_->pad_type == padding::same) ? cws.curr_delta_padded : *out_grad[1];
-        tensor_t*    prev_delta = in_grad[0];
-
-        assert(W.size() == params_d_->weight.size());
-        assert(dW[0].size() == params_d_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        fill_tensor(*prev_delta, float_t(0));
-
-        kernels::avx_deconv2d_back_kernel(*params_d_,
-            prev_out, W, dW, db, curr_delta, prev_delta);
-    }
-
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    const std::vector<tensor_t*>& out_data,
-                    std::vector<tensor_t*>&       out_grad,
-                    std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        const tensor_t& in  = *in_data[0];
-        tensor_t&       a   = *out_data[1];
-        std::vector<std::vector<cnn_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        kernels::avx_maxpool_kernel(in, a,
-            max_idx, *out2in_, layer_->parallelize());
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
-        std::vector<std::vector<cnn_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::avx_maxpool_back_kernel(prev_delta, curr_delta,
-            max_idx, *in2out_,  layer_->parallelize());
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        const tensor_t& in = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::avx_fully_connected_kernel(*params_f_,
-            in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(),
-            a, layer_->parallelize());
-    }
-
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully_eq(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
+  void maxpool(const std::vector<tensor_t*>& in_data,
                const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        const tensor_t& prev_out = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        tensor_t&       dW = *in_grad[1];
-        tensor_t&       db = *in_grad[2];
-        tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+    std::vector<std::vector<cnn_size_t>>& max_idx =
+        (*max_pooling_layer_worker_storage_).out2inmax_;
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    CNN_UNREFERENCED_PARAMETER(in_data);
 
-        kernels::avx_fully_connected_back_kernel(*params_f_, prev_out,
-            W, dW, prev_delta, curr_delta, db, layer_->parallelize());
-    }
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+    kernels::avx_maxpool_back_kernel(prev_delta, curr_delta, max_idx, *in2out_,
+                                     layer_->parallelize());
+  }
 
-    backend_t type() const override { return backend_t::avx; }
+  void fully(const std::vector<tensor_t*>& in_data,
+             std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& a = *out_data[1];
+
+    kernels::avx_fully_connected_kernel(
+        *params_f_, in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(), a,
+        layer_->parallelize());
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully_eq(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully(const std::vector<tensor_t*>& in_data,
+             const std::vector<tensor_t*>& out_data,
+             std::vector<tensor_t*>& out_grad,
+             std::vector<tensor_t*>& in_grad) override {
+    const tensor_t& prev_out = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    kernels::avx_fully_connected_back_kernel(*params_f_, prev_out, W, dW,
+                                             prev_delta, curr_delta, db,
+                                             layer_->parallelize());
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               const std::vector<tensor_t*>& out_data,
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  backend_t type() const override { return backend_t::avx; }
 
  private:
-    /* Pointer to the convolution parameters */
-    conv_params* params_c_;
-    deconv_params* params_d_;
-    fully_params* params_f_;
+  /* Pointer to the convolution parameters */
+  conv_params* params_c_;
+  deconv_params* params_d_;
+  fully_params* params_f_;
 
-    /* Pointer to the workers */
-    conv_layer_worker_specific_storage* conv_layer_worker_storage_;
-    deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
-    max_pooling_layer_worker_specific_storage* max_pooling_layer_worker_storage_;
-    std::vector<std::vector<cnn_size_t>>* out2in_;
-    std::vector<cnn_size_t>* in2out_;
+  /* Pointer to the workers */
+  conv_layer_worker_specific_storage* conv_layer_worker_storage_;
+  deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
+  max_pooling_layer_worker_specific_storage* max_pooling_layer_worker_storage_;
+  std::vector<std::vector<cnn_size_t>>* out2in_;
+  std::vector<cnn_size_t>* in2out_;
 
-    /* Pointers to parent class functions */
-    std::function<void(const tensor_t&)> copy_and_pad_input;
-    std::function<void(const tensor_t&)> copy_and_unpad_output;
-    std::function<void(const tensor_t&, tensor_t&)> copy_and_unpad_delta;
-    std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
-    std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> backward_activation;
+  /* Pointers to parent class functions */
+  std::function<void(const tensor_t&)> copy_and_pad_input;
+  std::function<void(const tensor_t&)> copy_and_unpad_output;
+  std::function<void(const tensor_t&, tensor_t&)> copy_and_unpad_delta;
+  std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
+  std::function<void(const tensor_t&, const tensor_t&, tensor_t&)>
+      backward_activation;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/backend_dnn.h
+++ b/tiny_dnn/core/backend_dnn.h
@@ -11,112 +11,112 @@ namespace core {
 
 class dnn_backend : public backend {
  public:
-    // context holds solution-dependent parameters
-    // context should be able to hold any types of structures (like boost::any)
-    dnn_backend() {}
+  // context holds solution-dependent parameters
+  // context should be able to hold any types of structures (like boost::any)
+  dnn_backend() {}
 
-    // core math functions
+  // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void conv2d_eq(const std::vector<tensor_t*>& in_data,
-                   std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+  void conv2d_eq(const std::vector<tensor_t*>& in_data,
+                 std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              const std::vector<tensor_t*>& out_data,
+              std::vector<tensor_t*>& out_grad,
+              std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
                 const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
+                  std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d_eq(const std::vector<tensor_t*>& in_data,
+                   std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                const std::vector<tensor_t*>& out_data,
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
                   const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+                  std::vector<tensor_t*>& out_grad,
+                  std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+  void maxpool(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void deconv2d_eq(const std::vector<tensor_t*>& in_data,
-                     std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    const std::vector<tensor_t*>& out_data,
-                    std::vector<tensor_t*>&       out_grad,
-                    std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully_eq(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
+  void maxpool(const std::vector<tensor_t*>& in_data,
                const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("not implemented yet.");
-    }
+  void fully(const std::vector<tensor_t*>& in_data,
+             std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
 
-    backend_t type() const override { return backend_t::libdnn; }
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully_eq(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully(const std::vector<tensor_t*>& in_data,
+             const std::vector<tensor_t*>& out_data,
+             std::vector<tensor_t*>& out_grad,
+             std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               const std::vector<tensor_t*>& out_data,
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  backend_t type() const override { return backend_t::libdnn; }
 };
 
 }  // namespace core

--- a/tiny_dnn/core/backend_dnn.h
+++ b/tiny_dnn/core/backend_dnn.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/backend.h"

--- a/tiny_dnn/core/backend_nnp.h
+++ b/tiny_dnn/core/backend_nnp.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/backend.h"

--- a/tiny_dnn/core/backend_nnp.h
+++ b/tiny_dnn/core/backend_nnp.h
@@ -7,277 +7,309 @@
 #include "tiny_dnn/core/backend.h"
 // #include "tiny_dnn/core/kernels/nnp_conv2d_kernel.h"
 #include "tiny_dnn/core/kernels/nnp_deconv2d_kernel.h"
-#include "tiny_dnn/core/kernels/nnp_maxpool_kernel.h"
 #include "tiny_dnn/core/kernels/nnp_fully_kernel.h"
+#include "tiny_dnn/core/kernels/nnp_maxpool_kernel.h"
 
 namespace tiny_dnn {
 namespace core {
 
 class nnp_backend : public backend {
  public:
-    // context holds solution-dependent parameters
-    // context should be able to hold any types of structures (like boost::any)
+  // context holds solution-dependent parameters
+  // context should be able to hold any types of structures (like boost::any)
 
-    // convolution
-    nnp_backend(conv_params* params,
-                std::function<void(const tensor_t&)> f1,
-                conv_layer_worker_specific_storage* ptr)
-        : params_c_(params)
-        , conv_layer_worker_storage_(ptr)
-        , copy_and_pad_input(f1) { init_nnp_engine(); }
+  // convolution
+  nnp_backend(conv_params* params, std::function<void(const tensor_t&)> f1,
+              conv_layer_worker_specific_storage* ptr)
+      : params_c_(params),
+        conv_layer_worker_storage_(ptr),
+        copy_and_pad_input(f1) {
+    init_nnp_engine();
+  }
 
-    // deconvolution
-    explicit nnp_backend(deconv_params* params)
-        : params_d_(params) { init_nnp_engine(); }
+  // deconvolution
+  explicit nnp_backend(deconv_params* params) : params_d_(params) {
+    init_nnp_engine();
+  }
 
-    // maxpool
-    explicit nnp_backend(maxpool_params* params)
-        : params_m_(params) { init_nnp_engine(); }
+  // maxpool
+  explicit nnp_backend(maxpool_params* params) : params_m_(params) {
+    init_nnp_engine();
+  }
 
-    // fully_connected
-    explicit nnp_backend(fully_params* params)
-        : params_f_(params) { init_nnp_engine(); }
+  // fully_connected
+  explicit nnp_backend(fully_params* params) : params_f_(params) {
+    init_nnp_engine();
+  }
 
-    nnp_backend() { init_nnp_engine(); }
+  nnp_backend() { init_nnp_engine(); }
 
-    // core math functions
+  // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        if (!params_c_->has_bias) {
-            throw nn_error("NNPACK Convolution requires a bias term.");
-        }
-
-        if (params_c_->w_stride != 1 || params_c_->h_stride != 1) {
-            throw nn_error("NNPACK Convolution requires stride 1.");
-        }
-
-/*
-        copy_and_pad_input(*in_data[0]);
-        //const vec_t& W = (*in_data[1])[0];
-        //const vec_t& bias = (*in_data[2])[0];
-        tensor_t&    a = *out_data[1];
-        //const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
-
-        fill_tensor(a, float_t(0));
-*/
-
-        // TODO
-        throw nn_not_implemented_error();
-
-        // kernels::nnp_conv2d_kernel(*params_c_, in, W, bias, a);
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              std::vector<tensor_t*>& out_data) override {
+    if (!params_c_->has_bias) {
+      throw nn_error("NNPACK Convolution requires a bias term.");
     }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
+    if (params_c_->w_stride != 1 || params_c_->h_stride != 1) {
+      throw nn_error("NNPACK Convolution requires stride 1.");
     }
 
-    void conv2d_eq(const std::vector<tensor_t*>& in_data,
-                   std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+    /*
+            copy_and_pad_input(*in_data[0]);
+            //const vec_t& W = (*in_data[1])[0];
+            //const vec_t& bias = (*in_data[2])[0];
+            tensor_t&    a = *out_data[1];
+            //const std::vector<const vec_t*> &in =
+       (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
+            fill_tensor(a, float_t(0));
+    */
+
+    // TODO
+    throw nn_not_implemented_error();
+
+    // kernels::nnp_conv2d_kernel(*params_c_, in, W, bias, a);
+  }
+
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void conv2d_eq(const std::vector<tensor_t*>& in_data,
+                 std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              const std::vector<tensor_t*>& out_data,
+              std::vector<tensor_t*>& out_grad,
+              std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
+
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
                 const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {}
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
+                  std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d_eq(const std::vector<tensor_t*>& in_data,
+                   std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                const std::vector<tensor_t*>& out_data,
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
                   const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
+                  std::vector<tensor_t*>& out_grad,
+                  std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
+
+  void maxpool(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    if (params_m_->stride_ != 2) {
+      throw nn_error("NNPACK Max-Pool requires a stride == 2.");
     }
 
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
+    if (params_m_->pool_size_ != 2) {
+      throw nn_error("NNPACK Max-Pool requires a pool size == 2.");
     }
 
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+    const tensor_t& in = *in_data[0];
+    tensor_t& a = *out_data[1];
 
-    void deconv2d_eq(const std::vector<tensor_t*>& in_data,
-                     std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
+    kernels::nnp_maxpool_kernel(*params_m_, in, a);
+  }
 
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
-
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    const std::vector<tensor_t*>& out_data,
-                    std::vector<tensor_t*>&       out_grad,
-                    std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        if (params_m_->stride_ != 2) {
-            throw nn_error("NNPACK Max-Pool requires a stride == 2.");
-        }
-
-        if (params_m_->pool_size_ != 2) {
-            throw nn_error("NNPACK Max-Pool requires a pool size == 2.");
-        }
-
-        const tensor_t& in = *in_data[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::nnp_maxpool_kernel(*params_m_, in, a);
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        const tensor_t& in = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        vec_t&          b = (*in_data[2])[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::nnp_fully_connected_kernel(*params_f_,
-            in, W, b, a, layer_->parallelize());
-    }
-
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully_eq(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
+  void maxpool(const std::vector<tensor_t*>& in_data,
                const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
 
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        throw nn_error("NNPACK does not support back propagation.");
-    }
+  void fully(const std::vector<tensor_t*>& in_data,
+             std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    vec_t& b = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
 
-   backend_t type() const override { return backend_t::nnpack; }
+    kernels::nnp_fully_connected_kernel(*params_f_, in, W, b, a,
+                                        layer_->parallelize());
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully_eq(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    throw nn_error("not implemented yet.");
+  }
+
+  void fully(const std::vector<tensor_t*>& in_data,
+             const std::vector<tensor_t*>& out_data,
+             std::vector<tensor_t*>& out_grad,
+             std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               const std::vector<tensor_t*>& out_data,
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    throw nn_error("NNPACK does not support back propagation.");
+  }
+
+  backend_t type() const override { return backend_t::nnpack; }
 
  private:
-    /* Pointer to the convolution parameters */
-    conv_params* params_c_;
-    deconv_params* params_d_;
-    maxpool_params* params_m_;
-    fully_params* params_f_;
+  /* Pointer to the convolution parameters */
+  conv_params* params_c_;
+  deconv_params* params_d_;
+  maxpool_params* params_m_;
+  fully_params* params_f_;
 
-    /* Pointer to the convolution workers */
-    conv_layer_worker_specific_storage* conv_layer_worker_storage_;
-    deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
+  /* Pointer to the convolution workers */
+  conv_layer_worker_specific_storage* conv_layer_worker_storage_;
+  deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
 
-    /* Pointers to parent class functions */
-    std::function<void(const tensor_t&)> copy_and_pad_input;
-    std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
+  /* Pointers to parent class functions */
+  std::function<void(const tensor_t&)> copy_and_pad_input;
+  std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
 
-    void init_nnp_engine() {
+  void init_nnp_engine() {
 #ifdef CNN_USE_NNPACK
-        nnp_status init_status = nnp_initialize();
-        check_nnp_status(init_status);
+    nnp_status init_status = nnp_initialize();
+    check_nnp_status(init_status);
 
-        if (init_status != nnp_status_success) {
-            throw nn_error("Could not initialize NNPACK.");
-        }
+    if (init_status != nnp_status_success) {
+      throw nn_error("Could not initialize NNPACK.");
+    }
 #else
-        throw nn_error("Tiny-cnn has not been compiled with NNPACK support.");
+    throw nn_error("Tiny-cnn has not been compiled with NNPACK support.");
 #endif
-    }
+  }
 
 #ifdef CNN_USE_NNPACK
-    void check_nnp_status(nnp_status status) {
-        switch (status) {
-            case nnp_status_success:
-                break;
-            case nnp_status_invalid_batch_size:
-                nn_warn("NNPACK function was called with batch_size == 0");
-                break;
-            case nnp_status_invalid_channels:
-                nn_warn("NNPACK function was called with channels == 0.");
-                break;
-            case nnp_status_invalid_input_channels:
-                nn_warn("NNPACK function was called with input_channels == 0.");
-                break;
-            case nnp_status_invalid_output_channels:
-                nn_warn("NNPACK function was called with output_channels == 0.");
-                break;
-            case nnp_status_invalid_input_size:
-                nn_warn(" NNPACK function was called with input_size.height == 0 or input_size.width == 0.");
-                break;
-            case nnp_status_invalid_input_stride:
-                nn_warn(" NNPACK function was called with input_stride.height == 0 or input_stride.width == 0.");
-                break;
-            case nnp_status_invalid_input_padding:
-                nn_warn("NNPACK function was called with input_padding not less than respective kernel (or pooling) size.");
-                break;
-            case nnp_status_invalid_kernel_size:
-                nn_warn("NNPACK function was called with kernel_size.height == 0 or kernel_size.width == 0.");
-                break;
-            case nnp_status_invalid_pooling_size:
-                nn_warn("NNPACK function was called with pooling_size.height == 0 or pooling_size.width == 0.");
-                break;
-            //case nnp_status_invalid_pooling_stride:
-            //    nn_warn("NNPACK function was called with pooling_stride.height == 0 or pooling_stride.width == 0.");
-            //    break;
-            case nnp_status_invalid_algorithm:
-                nn_warn("NNPACK function was called with convolution algorithm not in nnp_convolution_algorithm enumeration.");
-                break;
-            case nnp_status_unsupported_input_size:
-                nn_warn("NNPACK does not support the particular input size for the function.");
-                break;
-            case nnp_status_unsupported_input_stride:
-                nn_warn("NNPACK does not support the particular input sride for the function.");
-                break;
-            case nnp_status_unsupported_input_padding:
-                nn_warn("NNPACK does not support the particular input padding for the function.");
-                break;
-            case nnp_status_unsupported_kernel_size:
-                nn_warn("NNPACK does not support the particular kernel size for the function.");
-                break;
-            case nnp_status_unsupported_pooling_size:
-                nn_warn("NNPACK does not support the particular pooling size for the function.");
-                break;
-            case nnp_status_unsupported_pooling_stride:
-                nn_warn("NNPACK does not support the particular pooling stride for the function .");
-                break;
-            case nnp_status_unsupported_algorithm:
-                nn_warn("NNPACK does not support the particular convolution algorithm for the function.");
-                break;
-            case nnp_status_uninitialized:
-                nn_warn("NNPACK function was called before the library was initialized.");
-                break;
-            case nnp_status_unsupported_hardware:
-                nn_warn("NNPACK does not implement this function for the host CPU.");
-                break;
-            case nnp_status_out_of_memory:
-                nn_warn("NNPACK failed to allocate memory for temporary buffers.");
-                break;
-        }
+  void check_nnp_status(nnp_status status) {
+    switch (status) {
+      case nnp_status_success:
+        break;
+      case nnp_status_invalid_batch_size:
+        nn_warn("NNPACK function was called with batch_size == 0");
+        break;
+      case nnp_status_invalid_channels:
+        nn_warn("NNPACK function was called with channels == 0.");
+        break;
+      case nnp_status_invalid_input_channels:
+        nn_warn("NNPACK function was called with input_channels == 0.");
+        break;
+      case nnp_status_invalid_output_channels:
+        nn_warn("NNPACK function was called with output_channels == 0.");
+        break;
+      case nnp_status_invalid_input_size:
+        nn_warn(
+            " NNPACK function was called with input_size.height == 0 or "
+            "input_size.width == 0.");
+        break;
+      case nnp_status_invalid_input_stride:
+        nn_warn(
+            " NNPACK function was called with input_stride.height == 0 or "
+            "input_stride.width == 0.");
+        break;
+      case nnp_status_invalid_input_padding:
+        nn_warn(
+            "NNPACK function was called with input_padding not less than "
+            "respective kernel (or pooling) size.");
+        break;
+      case nnp_status_invalid_kernel_size:
+        nn_warn(
+            "NNPACK function was called with kernel_size.height == 0 or "
+            "kernel_size.width == 0.");
+        break;
+      case nnp_status_invalid_pooling_size:
+        nn_warn(
+            "NNPACK function was called with pooling_size.height == 0 or "
+            "pooling_size.width == 0.");
+        break;
+      // case nnp_status_invalid_pooling_stride:
+      //    nn_warn("NNPACK function was called with pooling_stride.height == 0
+      //    or pooling_stride.width == 0.");
+      //    break;
+      case nnp_status_invalid_algorithm:
+        nn_warn(
+            "NNPACK function was called with convolution algorithm not in "
+            "nnp_convolution_algorithm enumeration.");
+        break;
+      case nnp_status_unsupported_input_size:
+        nn_warn(
+            "NNPACK does not support the particular input size for the "
+            "function.");
+        break;
+      case nnp_status_unsupported_input_stride:
+        nn_warn(
+            "NNPACK does not support the particular input sride for the "
+            "function.");
+        break;
+      case nnp_status_unsupported_input_padding:
+        nn_warn(
+            "NNPACK does not support the particular input padding for the "
+            "function.");
+        break;
+      case nnp_status_unsupported_kernel_size:
+        nn_warn(
+            "NNPACK does not support the particular kernel size for the "
+            "function.");
+        break;
+      case nnp_status_unsupported_pooling_size:
+        nn_warn(
+            "NNPACK does not support the particular pooling size for the "
+            "function.");
+        break;
+      case nnp_status_unsupported_pooling_stride:
+        nn_warn(
+            "NNPACK does not support the particular pooling stride for the "
+            "function .");
+        break;
+      case nnp_status_unsupported_algorithm:
+        nn_warn(
+            "NNPACK does not support the particular convolution algorithm for "
+            "the function.");
+        break;
+      case nnp_status_uninitialized:
+        nn_warn(
+            "NNPACK function was called before the library was initialized.");
+        break;
+      case nnp_status_unsupported_hardware:
+        nn_warn("NNPACK does not implement this function for the host CPU.");
+        break;
+      case nnp_status_out_of_memory:
+        nn_warn("NNPACK failed to allocate memory for temporary buffers.");
+        break;
     }
+  }
 #endif
 };
 

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -7,14 +7,14 @@
 #include "tiny_dnn/config.h"
 #include "tiny_dnn/core/backend.h"
 
-#include "tiny_dnn/core/kernels/tiny_conv2d_kernel.h"
-#include "tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h"
 #include "tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h"
-#include "tiny_dnn/core/kernels/tiny_deconv2d_kernel.h"
-#include "tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h"
+#include "tiny_dnn/core/kernels/tiny_conv2d_kernel.h"
 #include "tiny_dnn/core/kernels/tiny_deconv2d_back_kernel.h"
-#include "tiny_dnn/core/kernels/tiny_maxpool_kernel.h"
+#include "tiny_dnn/core/kernels/tiny_deconv2d_kernel.h"
 #include "tiny_dnn/core/kernels/tiny_fully_connected_kernel.h"
+#include "tiny_dnn/core/kernels/tiny_maxpool_kernel.h"
+#include "tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h"
+#include "tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h"
 #ifdef CNN_USE_GEMMLOWP
 #include "tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h"
 #endif
@@ -24,420 +24,449 @@ namespace core {
 
 class tiny_backend : public backend {
  public:
-    // context holds solution-dependent parameters
-    // context should be able to hold any types of structures (like boost::any)
+  // context holds solution-dependent parameters
+  // context should be able to hold any types of structures (like boost::any)
 
-    // convolution
-    tiny_backend(conv_params* params,
-                 std::function<void(const tensor_t&)> f1,
-                 std::function<void(const tensor_t&, tensor_t&)> f2,
-                 std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
-                 conv_layer_worker_specific_storage* ptr)
-      : params_c_(params)
-      , conv_layer_worker_storage_(ptr)
-      , copy_and_pad_input(f1)
-      , copy_and_unpad_delta(f2)
-      , backward_activation(f3) {}
+  // convolution
+  tiny_backend(
+      conv_params* params, std::function<void(const tensor_t&)> f1,
+      std::function<void(const tensor_t&, tensor_t&)> f2,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
+      conv_layer_worker_specific_storage* ptr)
+      : params_c_(params),
+        conv_layer_worker_storage_(ptr),
+        copy_and_pad_input(f1),
+        copy_and_unpad_delta(f2),
+        backward_activation(f3) {}
 
-    // deconvolution
-    tiny_backend(deconv_params* params,
-                 std::function<void(const tensor_t&)> f1,
-                 std::function<void(const tensor_t&, tensor_t&)> f2,
-                 std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
-                 deconv_layer_worker_specific_storage* ptr)
-      : params_d_(params)
-      , deconv_layer_worker_storage_(ptr)
-      , copy_and_unpad_output(f1)
-      , copy_and_pad_delta(f2)
-      , backward_activation(f3) {}
+  // deconvolution
+  tiny_backend(
+      deconv_params* params, std::function<void(const tensor_t&)> f1,
+      std::function<void(const tensor_t&, tensor_t&)> f2,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f3,
+      deconv_layer_worker_specific_storage* ptr)
+      : params_d_(params),
+        deconv_layer_worker_storage_(ptr),
+        copy_and_unpad_output(f1),
+        copy_and_pad_delta(f2),
+        backward_activation(f3) {}
 
-    // maxpooling
-    tiny_backend(std::vector<std::vector<cnn_size_t>>* out2in,
-                 std::vector<cnn_size_t>* in2out,
-                 std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f,
-                 max_pooling_layer_worker_specific_storage* ptr)
-      : max_pooling_layer_worker_storage_(ptr)
-      , out2in_(out2in)
-      , in2out_(in2out)
-      , backward_activation(f) {}
+  // maxpooling
+  tiny_backend(
+      std::vector<std::vector<cnn_size_t>>* out2in,
+      std::vector<cnn_size_t>* in2out,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f,
+      max_pooling_layer_worker_specific_storage* ptr)
+      : max_pooling_layer_worker_storage_(ptr),
+        out2in_(out2in),
+        in2out_(in2out),
+        backward_activation(f) {}
 
-    // fully_connected
-    tiny_backend(fully_params* params,
-                 std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f)
-      : params_f_(params)
-      , backward_activation(f) {}
+  // fully_connected
+  tiny_backend(
+      fully_params* params,
+      std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> f)
+      : params_f_(params), backward_activation(f) {}
 
-    // core math functions
+  // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        copy_and_pad_input(*in_data[0]);
-        const vec_t& W     = (*in_data[1])[0];
-        const vec_t& bias  = (*in_data[2])[0];
-        tensor_t&    a     = *out_data[1];
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              std::vector<tensor_t*>& out_data) override {
+    copy_and_pad_input(*in_data[0]);
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+    const std::vector<const vec_t*>& in =
+        (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
 
-        fill_tensor(a, float_t(0));
+    fill_tensor(a, float_t(0));
 
-        kernels::tiny_conv2d_kernel(*params_c_,
-            in, W, bias, a, layer_->parallelize());
+    kernels::tiny_conv2d_kernel(*params_c_, in, W, bias, a,
+                                layer_->parallelize());
+  }
+
+  // quantized convolution
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    copy_and_pad_input(*in_data[0]);
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+    const std::vector<const vec_t*>& in =
+        (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
+
+    fill_tensor(a, float_t(0));
+
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_conv2d_kernel(*params_c_, *in[i], W, bias, a[i],
+                                            layer_->parallelize());
     }
+  }
 
-    // quantized convolution
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-        copy_and_pad_input(*in_data[0]);
-        const vec_t& W    = (*in_data[1])[0];
-        const vec_t& bias = (*in_data[2])[0];
-        tensor_t&    a    = *out_data[1];
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
+  // efficient quantization without abundant quantization/dequantization
+  void conv2d_eq(const std::vector<tensor_t*>& in_data,
+                 std::vector<tensor_t*>& out_data) override {
+    copy_and_pad_input(*in_data[0]);
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    const tensor_t& in_r = *in_data[3];
+    const vec_t& W_r = (*in_data[4])[0];
+    const vec_t& b_r = (*in_data[5])[0];
+    tensor_t& a = *out_data[1];
+    tensor_t& a_r = *out_data[2];
 
-        fill_tensor(a, float_t(0));
+    const std::vector<const vec_t*>& in =
+        (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
 
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_conv2d_kernel(*params_c_,
-                *in[i], W, bias, a[i], layer_->parallelize());
-        }
+    fill_tensor(a, float_t(0));
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_conv2d_kernel(*params_c_, *in[i], W, bias,
+                                            in_r[i], W_r, b_r, a[i], a_r[i],
+                                            layer_->parallelize());
     }
+  }
 
-    // efficient quantization without abundant quantization/dequantization
-    void conv2d_eq(const std::vector<tensor_t*>& in_data,
-                   std::vector<tensor_t*>&       out_data) override {
-        copy_and_pad_input(*in_data[0]);
-        const vec_t&    W    = (*in_data[1])[0];
-        const vec_t&    bias = (*in_data[2])[0];
-        const tensor_t& in_r = *in_data[3];
-        const vec_t&    W_r  = (*in_data[4])[0];
-        const vec_t&    b_r  = (*in_data[5])[0];
-        tensor_t&       a    = *out_data[1];
-        tensor_t&       a_r  = *out_data[2];
+  void conv2d(const std::vector<tensor_t*>& in_data,
+              const std::vector<tensor_t*>& out_data,
+              std::vector<tensor_t*>& out_grad,
+              std::vector<tensor_t*>& in_grad) override {
+    conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
 
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
+    std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& curr_delta = *out_grad[1];
+    tensor_t* prev_delta = (params_c_->pad_type == padding::same)
+                               ? &cws.prev_delta_padded_
+                               : in_grad[0];
 
-        fill_tensor(a, float_t(0));
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_conv2d_kernel(*params_c_,
-                *in[i], W, bias, in_r[i], W_r, b_r, a[i], a_r[i], layer_->parallelize());
-        }
+    assert(W.size() == params_c_->weight.size());
+    assert(dW[0].size() == params_c_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    fill_tensor(*prev_delta, float_t(0));
+
+    kernels::tiny_conv2d_back_kernel(*params_c_, prev_out, W, dW, db,
+                                     curr_delta, prev_delta);
+
+    if (params_c_->pad_type == padding::same) {
+      copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
     }
+  }
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
+  void conv2d_q(const std::vector<tensor_t*>& in_data,
                 const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
 
-        std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
-        const vec_t& W  = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = *out_grad[1];
-        tensor_t*    prev_delta = (params_c_->pad_type == padding::same) ?
-                                   &cws.prev_delta_padded_ : in_grad[0];
+    std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& curr_delta = *out_grad[1];
+    tensor_t* prev_delta = (params_c_->pad_type == padding::same)
+                               ? &cws.prev_delta_padded_
+                               : in_grad[0];
 
-        assert(W.size() == params_c_->weight.size());
-        assert(dW[0].size() == params_c_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
+    assert(W.size() == params_c_->weight.size());
+    assert(dW[0].size() == params_c_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-        fill_tensor(*prev_delta, float_t(0));
+    fill_tensor(*prev_delta, float_t(0));
 
-        kernels::tiny_conv2d_back_kernel(*params_c_,
-            prev_out, W, dW, db, curr_delta, prev_delta);
-
-        if (params_c_->pad_type == padding::same) {
-            copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
-        }
+    for (cnn_size_t i = 0; i < prev_out.size(); i++) {
+      kernels::tiny_quantized_conv2d_back_kernel(*params_c_, *prev_out[i], W,
+                                                 dW[i], db[i], curr_delta[i],
+                                                 &(*prev_delta)[i]);
     }
 
-    void conv2d_q(const std::vector<tensor_t*>& in_data,
+    if (params_c_->pad_type == padding::same) {
+      copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
+    }
+  }
+
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+    (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+    const tensor_t& in = *in_data[0];  // input
+
+    fill_tensor(
+        a, float_t(0),
+        params_d_->out.size());  // deconv2d-kernel requires padded size buffer
+
+    kernels::tiny_deconv2d_kernel(*params_d_, in, W, bias, a,
+                                  layer_->parallelize());
+
+    copy_and_unpad_output(a);
+    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+  }
+
+  // quantized deconvolution
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
+                  std::vector<tensor_t*>& out_data) override {
+    (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
+    const tensor_t& in = *in_data[0];  // input
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+
+    fill_tensor(
+        a, float_t(0),
+        params_d_->out.size());  // deconv2d-kernel requires padded size buffer
+
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_deconv2d_kernel(*params_d_, in[i], W, bias, a[i],
+                                              layer_->parallelize());
+    }
+
+    copy_and_unpad_output(a);
+    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+  }
+
+  // efficient quantization without abundant quantization/dequantization
+  void deconv2d_eq(const std::vector<tensor_t*>& in_data,
+                   std::vector<tensor_t*>& out_data) override {
+    (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
+    const tensor_t& in = *in_data[0];  // input
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& bias = (*in_data[2])[0];
+    const tensor_t& in_r = *in_data[3];
+    const vec_t& W_r = (*in_data[4])[0];
+    const vec_t& b_r = (*in_data[5])[0];
+    tensor_t& a = *out_data[1];
+    tensor_t& a_r = *out_data[2];
+
+    fill_tensor(
+        a, float_t(0),
+        params_d_->out.size());  // deconv2d-kernel requires padded size buffer
+
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_deconv2d_kernel(*params_d_, in[i], W, bias,
+                                              in_r[i], W_r, b_r, a[i], a_r[i],
+                                              layer_->parallelize());
+    }
+
+    copy_and_unpad_output(a);
+    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+  }
+
+  void deconv2d(const std::vector<tensor_t*>& in_data,
+                const std::vector<tensor_t*>& out_data,
+                std::vector<tensor_t*>& out_grad,
+                std::vector<tensor_t*>& in_grad) override {
+    deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
+    if (params_d_->pad_type == padding::same)
+      copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
+
+    const tensor_t& prev_out = *(cws.prev_out_);
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& curr_delta = (params_d_->pad_type == padding::same)
+                               ? cws.curr_delta_padded
+                               : *out_grad[1];
+    tensor_t* prev_delta = in_grad[0];
+
+    assert(W.size() == params_d_->weight.size());
+    assert(dW[0].size() == params_d_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    fill_tensor(*prev_delta, float_t(0));
+
+    kernels::tiny_deconv2d_back_kernel(*params_d_, prev_out, W, dW, db,
+                                       curr_delta, prev_delta);
+  }
+
+  void deconv2d_q(const std::vector<tensor_t*>& in_data,
                   const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-        conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
+                  std::vector<tensor_t*>& out_grad,
+                  std::vector<tensor_t*>& in_grad) override {
+    deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
+    if (params_d_->pad_type == padding::same)
+      copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
 
-        std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
-        const vec_t& W = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = *out_grad[1];
-        tensor_t*    prev_delta = (params_c_->pad_type == padding::same) ?
-            &cws.prev_delta_padded_ : in_grad[0];
+    const tensor_t& prev_out = *(cws.prev_out_);
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& curr_delta = (params_d_->pad_type == padding::same)
+                               ? cws.curr_delta_padded
+                               : *out_grad[1];
+    tensor_t* prev_delta = in_grad[0];
 
-        assert(W.size() == params_c_->weight.size());
-        assert(dW[0].size() == params_c_->weight.size());
-        assert(curr_delta[0].size() == layer_->out_shape()[0].size());
+    assert(W.size() == params_d_->weight.size());
+    assert(dW[0].size() == params_d_->weight.size());
+    assert(curr_delta[0].size() == layer_->out_shape()[0].size());
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-        fill_tensor(*prev_delta, float_t(0));
+    fill_tensor(*prev_delta, float_t(0));
 
-        for (cnn_size_t i = 0; i < prev_out.size(); i++) {
-            kernels::tiny_quantized_conv2d_back_kernel(*params_c_,
-                *prev_out[i], W, dW[i], db[i], curr_delta[i], &(*prev_delta)[i]);
-        }
-
-        if (params_c_->pad_type == padding::same) {
-            copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
-        }
+    for (cnn_size_t i = 0; i < prev_out.size(); i++) {
+      kernels::tiny_quantized_deconv2d_back_kernel(*params_d_, prev_out[i], W,
+                                                   dW[i], db[i], curr_delta[i],
+                                                   &(*prev_delta)[i]);
     }
+  }
 
-    void deconv2d(const std::vector<tensor_t*>&  in_data,
-                  std::vector<tensor_t*>&        out_data) override {
-        (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const vec_t&    W    = (*in_data[1])[0];
-        const vec_t&    bias = (*in_data[2])[0];
-        tensor_t&       a    = *out_data[1];
-        const tensor_t &in   = *in_data[0]; // input
+  void maxpool(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    tensor_t& a = *out_data[1];
+    std::vector<std::vector<cnn_size_t>>& max_idx =
+        (*max_pooling_layer_worker_storage_).out2inmax_;
 
-        fill_tensor(a, float_t(0), params_d_->out.size()); // deconv2d-kernel requires padded size buffer
+    kernels::tiny_maxpool_kernel(in, a, max_idx, *out2in_,
+                                 layer_->parallelize());
+  }
 
-        kernels::tiny_deconv2d_kernel(*params_d_,
-            in, W, bias, a, layer_->parallelize());
-
-        copy_and_unpad_output(a);
-        a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
-    }
-
-    // quantized deconvolution
-    void deconv2d_q(const std::vector<tensor_t*>&  in_data,
-                    std::vector<tensor_t*>&        out_data) override {
-        (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const tensor_t &in   =  *in_data[0]; // input
-        const vec_t&    W    = (*in_data[1])[0];
-        const vec_t&    bias = (*in_data[2])[0];
-        tensor_t&       a    =  *out_data[1];
-
-        fill_tensor(a, float_t(0), params_d_->out.size()); // deconv2d-kernel requires padded size buffer
-
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_deconv2d_kernel(*params_d_,
-                in[i], W, bias, a[i], layer_->parallelize());
-        }
-
-        copy_and_unpad_output(a);
-        a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
-    }
-
-    // efficient quantization without abundant quantization/dequantization
-    void deconv2d_eq(const std::vector<tensor_t*>&  in_data,
-                     std::vector<tensor_t*>&        out_data) override {
-        (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const tensor_t &in   =  *in_data[0]; // input
-        const vec_t&    W    = (*in_data[1])[0];
-        const vec_t&    bias = (*in_data[2])[0];
-        const tensor_t& in_r =  *in_data[3];
-        const vec_t&    W_r  = (*in_data[4])[0];
-        const vec_t&    b_r  = (*in_data[5])[0];
-        tensor_t&       a    = *out_data[1];
-        tensor_t&       a_r  = *out_data[2];
-
-        fill_tensor(a, float_t(0), params_d_->out.size()); // deconv2d-kernel requires padded size buffer
-
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_deconv2d_kernel(*params_d_,
-                in[i], W, bias, in_r[i], W_r, b_r, a[i], a_r[i], layer_->parallelize());
-        }
-
-        copy_and_unpad_output(a);
-        a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
-    }
-
-    void deconv2d(const std::vector<tensor_t*>& in_data,
-                  const std::vector<tensor_t*>& out_data,
-                  std::vector<tensor_t*>&       out_grad,
-                  std::vector<tensor_t*>&       in_grad) override {
-
-        deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
-        if (params_d_->pad_type == padding::same)
-            copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
-
-        const tensor_t& prev_out = *(cws.prev_out_);
-        const vec_t& W = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = (params_d_->pad_type == padding::same) ? cws.curr_delta_padded : *out_grad[1];
-        tensor_t*    prev_delta = in_grad[0];
-
-        assert(W.size() == params_d_->weight.size());
-        assert(dW[0].size() == params_d_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        fill_tensor(*prev_delta, float_t(0));
-
-        kernels::tiny_deconv2d_back_kernel(*params_d_,
-            prev_out, W, dW, db, curr_delta, prev_delta);
-    }
-
-    void deconv2d_q(const std::vector<tensor_t*>& in_data,
-                    const std::vector<tensor_t*>& out_data,
-                    std::vector<tensor_t*>&       out_grad,
-                    std::vector<tensor_t*>&       in_grad) override {
-
-        deconv_layer_worker_specific_storage& cws = (*deconv_layer_worker_storage_);
-        if (params_d_->pad_type == padding::same)
-            copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
-
-        const tensor_t& prev_out = *(cws.prev_out_);
-        const vec_t& W = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = (params_d_->pad_type == padding::same) ? cws.curr_delta_padded : *out_grad[1];
-        tensor_t*    prev_delta = in_grad[0];
-
-        assert(W.size() == params_d_->weight.size());
-        assert(dW[0].size() == params_d_->weight.size());
-        assert(curr_delta[0].size() == layer_->out_shape()[0].size());
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        fill_tensor(*prev_delta, float_t(0));
-
-        for (cnn_size_t i = 0; i < prev_out.size(); i++) {
-            kernels::tiny_quantized_deconv2d_back_kernel(*params_d_,
-                prev_out[i], W, dW[i], db[i], curr_delta[i], &(*prev_delta)[i]);
-        }
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        const tensor_t& in  = *in_data[0];
-        tensor_t&       a   = *out_data[1];
-        std::vector<std::vector<cnn_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        kernels::tiny_maxpool_kernel(in, a,
-            max_idx, *out2in_, layer_->parallelize());
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
-        std::vector<std::vector<cnn_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::tiny_maxpool_back_kernel(prev_delta, curr_delta,
-            max_idx, *in2out_,  layer_->parallelize());
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        const tensor_t& in  = *in_data[0];
-        const vec_t&    W   = (*in_data[1])[0];
-        tensor_t&       a   = *out_data[1];
-
-        kernels::tiny_fully_connected_kernel(*params_f_,
-            in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(),
-            a, layer_->parallelize());
-    }
-
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-#ifdef CNN_USE_GEMMLOWP
-        const tensor_t& in = *in_data[0];
-        const vec_t&    W  = (*in_data[1])[0];
-        tensor_t&       a  = *out_data[1];
-
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_fully_connected_kernel(*params_f_,
-                in[i], W,  params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(),
-                a[i], layer_->parallelize());
-        }
-#else
-        throw nn_not_implemented_error("quantized fully op requires gemmlowp library. please define CNN_USE_GEMMLOWP");
-#endif
-    }
-
-    void fully_eq(const std::vector<tensor_t*>& in_data,
-                  std::vector<tensor_t*>&       out_data) override {
-#ifdef CNN_USE_GEMMLOWP
-        const tensor_t& in   =  *in_data[0];
-        const vec_t&    W    = (*in_data[1])[0];
-        vec_t&          b    = (*in_data[2])[0];
-        const tensor_t& in_r =  *in_data[3];
-        const vec_t&    W_r  = (*in_data[4])[0];
-        const vec_t&    b_r  = (*in_data[5])[0];
-        tensor_t&       a    =  *out_data[1];
-        tensor_t&       a_r  =  *out_data[2];
-
-        for (cnn_size_t i = 0; i < in.size(); i++) {
-            kernels::tiny_quantized_fully_connected_kernel(*params_f_,
-                in[i], W, b, in_r[i], W_r, b_r, a[i], a_r[i], layer_->parallelize());
-        }
-#else
-        throw nn_not_implemented_error("quantized fully op requires gemmlowp library. please define CNN_USE_GEMMLOWP");
-#endif
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
+  void maxpool(const std::vector<tensor_t*>& in_data,
                const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        const tensor_t& prev_out   =  *in_data[0];
-        const vec_t&    W          = (*in_data[1])[0];
-        tensor_t&       dW         =  *in_grad[1];
-        tensor_t&       db         =  *in_grad[2];
-        tensor_t&       prev_delta =  *in_grad[0];
-        tensor_t&       curr_delta =  *out_grad[1];
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+    std::vector<std::vector<cnn_size_t>>& max_idx =
+        (*max_pooling_layer_worker_storage_).out2inmax_;
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-        kernels::tiny_fully_connected_back_kernel(*params_f_, prev_out,
-            W, dW, prev_delta, curr_delta, db, layer_->parallelize());
-    }
+    kernels::tiny_maxpool_back_kernel(prev_delta, curr_delta, max_idx, *in2out_,
+                                      layer_->parallelize());
+  }
 
-    void fully_q(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
+  void fully(const std::vector<tensor_t*>& in_data,
+             std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& a = *out_data[1];
+
+    kernels::tiny_fully_connected_kernel(
+        *params_f_, in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(), a,
+        layer_->parallelize());
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               std::vector<tensor_t*>& out_data) override {
 #ifdef CNN_USE_GEMMLOWP
-        const tensor_t& prev_out   =  *in_data[0];
-        const vec_t&    W          = (*in_data[1])[0];
-        tensor_t&       dW         =  *in_grad[1];
-        tensor_t&       db         =  *in_grad[2];
-        tensor_t&       prev_delta =  *in_grad[0];
-        tensor_t&       curr_delta =  *out_grad[1];
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& a = *out_data[1];
 
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        for (cnn_size_t i = 0; i < prev_out.size(); i++) {
-            kernels::tiny_quantized_fully_connected_back_kernel(*params_f_, prev_out[i],
-                W, dW[i], prev_delta[i], curr_delta[i], db[i], layer_->parallelize());
-        }
-#else
-        throw nn_not_implemented_error("quantized fully op requires gemmlowp library. please define CNN_USE_GEMMLOWP");
-#endif
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_fully_connected_kernel(
+          *params_f_, in[i], W,
+          params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(), a[i],
+          layer_->parallelize());
     }
+#else
+    throw nn_not_implemented_error(
+        "quantized fully op requires gemmlowp library. please define "
+        "CNN_USE_GEMMLOWP");
+#endif
+  }
 
-    backend_t type() const override { return backend_t::tiny_dnn; }
+  void fully_eq(const std::vector<tensor_t*>& in_data,
+                std::vector<tensor_t*>& out_data) override {
+#ifdef CNN_USE_GEMMLOWP
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    vec_t& b = (*in_data[2])[0];
+    const tensor_t& in_r = *in_data[3];
+    const vec_t& W_r = (*in_data[4])[0];
+    const vec_t& b_r = (*in_data[5])[0];
+    tensor_t& a = *out_data[1];
+    tensor_t& a_r = *out_data[2];
+
+    for (cnn_size_t i = 0; i < in.size(); i++) {
+      kernels::tiny_quantized_fully_connected_kernel(
+          *params_f_, in[i], W, b, in_r[i], W_r, b_r, a[i], a_r[i],
+          layer_->parallelize());
+    }
+#else
+    throw nn_not_implemented_error(
+        "quantized fully op requires gemmlowp library. please define "
+        "CNN_USE_GEMMLOWP");
+#endif
+  }
+
+  void fully(const std::vector<tensor_t*>& in_data,
+             const std::vector<tensor_t*>& out_data,
+             std::vector<tensor_t*>& out_grad,
+             std::vector<tensor_t*>& in_grad) override {
+    const tensor_t& prev_out = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    kernels::tiny_fully_connected_back_kernel(*params_f_, prev_out, W, dW,
+                                              prev_delta, curr_delta, db,
+                                              layer_->parallelize());
+  }
+
+  void fully_q(const std::vector<tensor_t*>& in_data,
+               const std::vector<tensor_t*>& out_data,
+               std::vector<tensor_t*>& out_grad,
+               std::vector<tensor_t*>& in_grad) override {
+#ifdef CNN_USE_GEMMLOWP
+    const tensor_t& prev_out = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    tensor_t& dW = *in_grad[1];
+    tensor_t& db = *in_grad[2];
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+
+    backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    for (cnn_size_t i = 0; i < prev_out.size(); i++) {
+      kernels::tiny_quantized_fully_connected_back_kernel(
+          *params_f_, prev_out[i], W, dW[i], prev_delta[i], curr_delta[i],
+          db[i], layer_->parallelize());
+    }
+#else
+    throw nn_not_implemented_error(
+        "quantized fully op requires gemmlowp library. please define "
+        "CNN_USE_GEMMLOWP");
+#endif
+  }
+
+  backend_t type() const override { return backend_t::tiny_dnn; }
 
  private:
-    /* Pointer to the convolution parameters */
-    conv_params* params_c_;
-    deconv_params* params_d_;
-    fully_params* params_f_;
+  /* Pointer to the convolution parameters */
+  conv_params* params_c_;
+  deconv_params* params_d_;
+  fully_params* params_f_;
 
-    /* Pointer to the workers */
-    conv_layer_worker_specific_storage* conv_layer_worker_storage_;
-    deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
-    max_pooling_layer_worker_specific_storage* max_pooling_layer_worker_storage_;
-    std::vector<std::vector<cnn_size_t>>* out2in_;
-    std::vector<cnn_size_t>* in2out_;
+  /* Pointer to the workers */
+  conv_layer_worker_specific_storage* conv_layer_worker_storage_;
+  deconv_layer_worker_specific_storage* deconv_layer_worker_storage_;
+  max_pooling_layer_worker_specific_storage* max_pooling_layer_worker_storage_;
+  std::vector<std::vector<cnn_size_t>>* out2in_;
+  std::vector<cnn_size_t>* in2out_;
 
-    /* Pointers to parent class functions */
-    std::function<void(const tensor_t&)> copy_and_pad_input;
-    std::function<void(const tensor_t&)> copy_and_unpad_output;
-    std::function<void(const tensor_t&, tensor_t&)> copy_and_unpad_delta;
-    std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
-    std::function<void(const tensor_t&, const tensor_t&, tensor_t&)> backward_activation;
+  /* Pointers to parent class functions */
+  std::function<void(const tensor_t&)> copy_and_pad_input;
+  std::function<void(const tensor_t&)> copy_and_unpad_output;
+  std::function<void(const tensor_t&, tensor_t&)> copy_and_unpad_delta;
+  std::function<void(const tensor_t&, tensor_t&)> copy_and_pad_delta;
+  std::function<void(const tensor_t&, const tensor_t&, tensor_t&)>
+      backward_activation;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/config.h"

--- a/tiny_dnn/core/device.h
+++ b/tiny_dnn/core/device.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/core/device.h
+++ b/tiny_dnn/core/device.h
@@ -13,13 +13,13 @@ namespace core {
 
 class device {
  public:
-    explicit device(const int id) : id_(id) {}
+  explicit device(const int id) : id_(id) {}
 
-    int get_id() const { return id_; }
+  int get_id() const { return id_; }
 
  private:
-    int id_;
-    std::vector<std::shared_ptr<backend>> backends_;
+  int id_;
+  std::vector<std::shared_ptr<backend>> backends_;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/device_cpu.h
+++ b/tiny_dnn/core/device_cpu.h
@@ -11,8 +11,7 @@ namespace core {
 
 class cpu_device : public device {
  public:
-    explicit cpu_device(const int id) : device(id) {}
-
+  explicit cpu_device(const int id) : device(id) {}
 };
 
 }  // namespace core

--- a/tiny_dnn/core/device_cpu.h
+++ b/tiny_dnn/core/device_cpu.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/device.h"

--- a/tiny_dnn/core/device_ocl.h
+++ b/tiny_dnn/core/device_ocl.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/device.h"

--- a/tiny_dnn/core/device_ocl.h
+++ b/tiny_dnn/core/device_ocl.h
@@ -11,8 +11,7 @@ namespace core {
 
 class ocl_device : public device {
  public:
-    explicit ocl_device(const int id) : device(id) {}
-
+  explicit ocl_device(const int id) : device(id) {}
 };
 
 }  // namespace core

--- a/tiny_dnn/core/framework/device.fwd.h
+++ b/tiny_dnn/core/framework/device.fwd.h
@@ -16,93 +16,95 @@ namespace tiny_dnn {
 
 enum class device_t { CPU, GPU /*, FPGA */ };
 
-inline std::ostream& operator << (std::ostream& os, device_t type) {
-    switch (type) {
-        case device_t::CPU: os << "CPU"; break;
-        case device_t::GPU: os << "GPU"; break;
-        default:
-            throw nn_error("Not supported ostream enum: " +
-                    to_string(static_cast<int>(type)));
-            break;
-    }
-    return os;
+inline std::ostream& operator<<(std::ostream& os, device_t type) {
+  switch (type) {
+    case device_t::CPU:
+      os << "CPU";
+      break;
+    case device_t::GPU:
+      os << "GPU";
+      break;
+    default:
+      throw nn_error("Not supported ostream enum: " +
+                     to_string(static_cast<int>(type)));
+      break;
+  }
+  return os;
 }
 
 /* The class models a physical device */
 class Device {
  public:
-    /* Custom CPU constructor
-     *
-     * @param type The device type. Can be only CPU.
-     */
-    inline explicit Device(device_t type);
+  /* Custom CPU constructor
+   *
+   * @param type The device type. Can be only CPU.
+   */
+  inline explicit Device(device_t type);
 
-    /* CPU/GPU OpenCL constructor.
-     * Device context is initialized in constructor.
-     *
-     * @param type The device type. Can be both CPU and GPU.
-     * @param platform_id The platform identification number.
-     * @param device_id The device identification number.
-     */
-    inline explicit Device(device_t type,
-                           const int platform_id,
-                           const int device_id);
+  /* CPU/GPU OpenCL constructor.
+   * Device context is initialized in constructor.
+   *
+   * @param type The device type. Can be both CPU and GPU.
+   * @param platform_id The platform identification number.
+   * @param device_id The device identification number.
+   */
+  inline explicit Device(device_t type, const int platform_id,
+                         const int device_id);
 
-    // Returns the device type
-    device_t type() const { return type_; }
+  // Returns the device type
+  device_t type() const { return type_; }
 
-    // Returns true if CLCudaAPI is enabled to this device 
-    bool hasCLCudaAPI() const { return has_clcuda_api_; }
+  // Returns true if CLCudaAPI is enabled to this device
+  bool hasCLCudaAPI() const { return has_clcuda_api_; }
 
-    // Returns the platform id
-    int platformId() const { return platform_id_; }
-    
-    // Returns the device id
-    int deviceId() const { return device_id_; }
+  // Returns the platform id
+  int platformId() const { return platform_id_; }
+
+  // Returns the device id
+  int deviceId() const { return device_id_; }
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    // Returns the CLCudaAPI Device object
-    CLCudaAPI::Device device() const { return *device_;  }
+  // Returns the CLCudaAPI Device object
+  CLCudaAPI::Device device() const { return *device_; }
 
-    // Returns the CLCudaAPI Context object
-    CLCudaAPI::Context context() const { return *context_; }
+  // Returns the CLCudaAPI Context object
+  CLCudaAPI::Context context() const { return *context_; }
 
-    // Returns the CLCudaAPI Queue object
-    CLCudaAPI::Queue queue() const { return *queue_; }
+  // Returns the CLCudaAPI Queue object
+  CLCudaAPI::Queue queue() const { return *queue_; }
 #endif
 
-    bool operator==(const Device& d) const {
-        if (d.type() == this->type() &&
-            d.hasCLCudaAPI() == this->hasCLCudaAPI() &&
-            d.platformId() == this->platformId() &&
-            d.deviceId() == this->deviceId()) {
-            return true;
-        }
-        return false;
+  bool operator==(const Device& d) const {
+    if (d.type() == this->type() && d.hasCLCudaAPI() == this->hasCLCudaAPI() &&
+        d.platformId() == this->platformId() &&
+        d.deviceId() == this->deviceId()) {
+      return true;
     }
+    return false;
+  }
 
-    /* Registers and create an OpenCL program per Operation type.
-     *
-     * @param l The layer to be registered
-     */
-    inline void registerOp(layer& l);
+  /* Registers and create an OpenCL program per Operation type.
+   *
+   * @param l The layer to be registered
+   */
+  inline void registerOp(layer& l);
 
  private:
-    /* The device type */
-    device_t type_;
-    /* Boolean to check if device has OpenCL */
-    bool has_clcuda_api_;
-    /* The platform identification number */
-    int platform_id_;
-    /* The device identification number */
-    int device_id_;
+  /* The device type */
+  device_t type_;
+  /* Boolean to check if device has OpenCL */
+  bool has_clcuda_api_;
+  /* The platform identification number */
+  int platform_id_;
+  /* The device identification number */
+  int device_id_;
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    /* The CLCudaAPI device */
-    std::shared_ptr<CLCudaAPI::Device> device_;
-    /* The CLCudaAPI device context */
-    std::shared_ptr<CLCudaAPI::Context> context_;
-    /* The CLCudaAPI device queue */
-    std::shared_ptr<CLCudaAPI::Queue> queue_;
+  /* The CLCudaAPI device */
+  std::shared_ptr<CLCudaAPI::Device> device_;
+  /* The CLCudaAPI device context */
+  std::shared_ptr<CLCudaAPI::Context> context_;
+  /* The CLCudaAPI device queue */
+  std::shared_ptr<CLCudaAPI::Queue> queue_;
 #endif
 };
 

--- a/tiny_dnn/core/framework/device.fwd.h
+++ b/tiny_dnn/core/framework/device.fwd.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)

--- a/tiny_dnn/core/framework/device.h
+++ b/tiny_dnn/core/framework/device.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/device.fwd.h"

--- a/tiny_dnn/core/framework/device.h
+++ b/tiny_dnn/core/framework/device.h
@@ -8,83 +8,79 @@
 #include "tiny_dnn/core/framework/program_manager.h"
 
 namespace tiny_dnn {
- 
-inline Device::Device(device_t type)
-        : type_(type), has_clcuda_api_(false) {
-    nn_info("Initializing Non-OpenCL device ...");
-    if (type == device_t::GPU) {
-        throw nn_error("Bad GPU device initialization. "
-                       "Please provide platform_id and device_id");
-    }
-    nn_info("Initializing Non-OpenCL device ... OK");
+
+inline Device::Device(device_t type) : type_(type), has_clcuda_api_(false) {
+  nn_info("Initializing Non-OpenCL device ...");
+  if (type == device_t::GPU) {
+    throw nn_error(
+        "Bad GPU device initialization. "
+        "Please provide platform_id and device_id");
+  }
+  nn_info("Initializing Non-OpenCL device ... OK");
 }
 
-inline Device::Device(device_t type,
-                      const int platform_id,
-                      const int device_id)
-        : type_(type)
-        , has_clcuda_api_(true)
-        , platform_id_(platform_id)
-        , device_id_(device_id) {
+inline Device::Device(device_t type, const int platform_id, const int device_id)
+    : type_(type),
+      has_clcuda_api_(true),
+      platform_id_(platform_id),
+      device_id_(device_id) {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    // Instantiate Platform and Device
-    nn_info("Initializing OpenCL platform ...");
-    auto platform = CLCudaAPI::Platform(platform_id);
+  // Instantiate Platform and Device
+  nn_info("Initializing OpenCL platform ...");
+  auto platform = CLCudaAPI::Platform(platform_id);
 
-    // Print short pltform info
-    nn_info("Initializing OpenCL platform ... OK");
-    nn_info("-- Running on platform " 
-                       + to_string(platform_id) +
-            ". Found " + to_string(platform.NumDevices()) + " devices.");
+  // Print short pltform info
+  nn_info("Initializing OpenCL platform ... OK");
+  nn_info("-- Running on platform " + to_string(platform_id) + ". Found " +
+          to_string(platform.NumDevices()) + " devices.");
 
-    // Create and retain device object
-    nn_info("Initializing OpenCL device ...");
-    device_.reset(new CLCudaAPI::Device(platform, device_id));
+  // Create and retain device object
+  nn_info("Initializing OpenCL device ...");
+  device_.reset(new CLCudaAPI::Device(platform, device_id));
 
-    // Print short device info
-    nn_info("Initializing OpenCL device ... OK");
-    nn_info("-- Running on device " + to_string(device_->Name()) +
-                             " of " + to_string(device_->Vendor()));
-    nn_info("-- Device type: "  + to_string(device_->Type()));
-    nn_info("-- Capabilities: " + to_string(device_->Capabilities()));
+  // Print short device info
+  nn_info("Initializing OpenCL device ... OK");
+  nn_info("-- Running on device " + to_string(device_->Name()) + " of " +
+          to_string(device_->Vendor()));
+  nn_info("-- Device type: " + to_string(device_->Type()));
+  nn_info("-- Capabilities: " + to_string(device_->Capabilities()));
 
-    // check device type
-    if (type == device_t::CPU && !device_->IsCPU()) {
-        throw nn_error("Not found a CPU device. You are on: " +
-                       to_string(device_->Type()));
-    }
-    else if (type == device_t::GPU && !device_->IsGPU()) {
-        throw nn_error("Not found a GPU device. You are on: " +
-                       to_string(device_->Type()));
-    }
+  // check device type
+  if (type == device_t::CPU && !device_->IsCPU()) {
+    throw nn_error("Not found a CPU device. You are on: " +
+                   to_string(device_->Type()));
+  } else if (type == device_t::GPU && !device_->IsGPU()) {
+    throw nn_error("Not found a GPU device. You are on: " +
+                   to_string(device_->Type()));
+  }
 
-    // Create and retain device context
-    nn_info("Initializing OpenCL device context ...");
+  // Create and retain device context
+  nn_info("Initializing OpenCL device context ...");
 
-    context_.reset(new CLCudaAPI::Context(*device_));
-    queue_.reset(new CLCudaAPI::Queue(*context_, *device_));
+  context_.reset(new CLCudaAPI::Context(*device_));
+  queue_.reset(new CLCudaAPI::Queue(*context_, *device_));
 
-    nn_info("Initializing OpenCL device context ... OK");
-#else 
-    nn_error("TinyDNN has not been compiled with OpenCL or CUDA support.");
+  nn_info("Initializing OpenCL device context ... OK");
+#else
+  nn_error("TinyDNN has not been compiled with OpenCL or CUDA support.");
 #endif
 }
 
 inline void Device::registerOp(layer& l) {
-    // TODO(egdar/nyanp): Should we raise an error here?
-    if (!hasCLCudaAPI()) {
-        throw nn_error("Cannot register layer: " + l.layer_type() +
-            ". Device has disabled OpenCL support.");
-    }
+  // TODO(egdar/nyanp): Should we raise an error here?
+  if (!hasCLCudaAPI()) {
+    throw nn_error("Cannot register layer: " + l.layer_type() +
+                   ". Device has disabled OpenCL support.");
+  }
 
-    if (l.engine() != core::backend_t::opencl &&
-        l.engine() != core::backend_t::libdnn) {
-        throw nn_error("Cannot register layer: " + l.layer_type() +
-            ". Enabled engine: " + to_string(l.engine()));
-    }
+  if (l.engine() != core::backend_t::opencl &&
+      l.engine() != core::backend_t::libdnn) {
+    throw nn_error("Cannot register layer: " + l.layer_type() +
+                   ". Enabled engine: " + to_string(l.engine()));
+  }
 
-    // Register the op to this device
-    ProgramManager::getInstance().registerOp(*this, l);
+  // Register the op to this device
+  ProgramManager::getInstance().registerOp(*this, l);
 }
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/framework/op_kernel.h
+++ b/tiny_dnn/core/framework/op_kernel.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/device.fwd.h"

--- a/tiny_dnn/core/framework/op_kernel.h
+++ b/tiny_dnn/core/framework/op_kernel.h
@@ -14,138 +14,111 @@ class OpKernel;  // delared below
 
 class OpKernelConstruction {
  public:
-    explicit OpKernelConstruction() {}
-    explicit OpKernelConstruction(Device* device, Params* params)
-        : device_(device), params_(params) {}
-    
-    // Returns the device raw pointer
-    Device* device() const { return device_; }
+  explicit OpKernelConstruction() {}
+  explicit OpKernelConstruction(Device* device, Params* params)
+      : device_(device), params_(params) {}
 
-    // Returns the device raw pointer
-    Params* params() const { return params_; }
+  // Returns the device raw pointer
+  Device* device() const { return device_; }
+
+  // Returns the device raw pointer
+  Params* params() const { return params_; }
 
  private:
-    Device* device_ = nullptr;
-    Params* params_ = nullptr;
+  Device* device_ = nullptr;
+  Params* params_ = nullptr;
 };
 
 class OpKernelContext {
  public:
-    struct OpParams {
-        // the op kernel being computed.
-        OpKernel* op_kernel_ptr = nullptr;
+  struct OpParams {
+    // the op kernel being computed.
+    OpKernel* op_kernel_ptr = nullptr;
 
-        // the device on which the kernel is running.
-        Device* device_ptr = nullptr;
+    // the device on which the kernel is running.
+    Device* device_ptr = nullptr;
 
-        // the layer on which kernel is runnning
-        layer* layer_ptr_ = nullptr;
+    // the layer on which kernel is runnning
+    layer* layer_ptr_ = nullptr;
 
-        // the operation params
-        Params* params_ptr_ = nullptr;
+    // the operation params
+    Params* params_ptr_ = nullptr;
 
-        // parallelize operation
-        bool parallelize = false;
+    // parallelize operation
+    bool parallelize = false;
 
-        backend_t engine = backend_t::tiny_dnn;
-    };
+    backend_t engine = backend_t::tiny_dnn;
+  };
 
-    explicit OpKernelContext(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data)
-            : in_data_(in_data), out_data_(out_data) {
-        op_params_ = std::unique_ptr<OpParams>(new OpParams());
-    }
+  explicit OpKernelContext(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data)
+      : in_data_(in_data), out_data_(out_data) {
+    op_params_ = std::unique_ptr<OpParams>(new OpParams());
+  }
 
-    explicit OpKernelContext(const std::vector<tensor_t*>& in_data,
-                             const std::vector<tensor_t*>& out_data,
-                             std::vector<tensor_t*>&       out_grad,
-                             std::vector<tensor_t*>&       in_grad)
-            : in_data_(in_data)
-            , out_data_(out_data)
-            , out_grad_(out_grad)
-            , in_grad_(in_grad) {
-        op_params_ = std::unique_ptr<OpParams>(new OpParams());
-    }
+  explicit OpKernelContext(const std::vector<tensor_t*>& in_data,
+                           const std::vector<tensor_t*>& out_data,
+                           std::vector<tensor_t*>& out_grad,
+                           std::vector<tensor_t*>& in_grad)
+      : in_data_(in_data),
+        out_data_(out_data),
+        out_grad_(out_grad),
+        in_grad_(in_grad) {
+    op_params_ = std::unique_ptr<OpParams>(new OpParams());
+  }
 
-    tensor_t& input(const int idx) const {
-        return *in_data_[idx];
-    }
+  tensor_t& input(const int idx) const { return *in_data_[idx]; }
 
-    tensor_t& output(const int idx) const {
-        return *out_data_[idx];
-    }
+  tensor_t& output(const int idx) const { return *out_data_[idx]; }
 
-    tensor_t& input_grad(const int idx) const {
-        return *in_grad_[idx];
-    }
+  tensor_t& input_grad(const int idx) const { return *in_grad_[idx]; }
 
-    tensor_t& output_grad(const int idx) const {
-        return *out_grad_[idx];
-    }
+  tensor_t& output_grad(const int idx) const { return *out_grad_[idx]; }
 
-    void setParams(Params* params) {
-        op_params_->params_ptr_ = params;
-    }
+  void setParams(Params* params) { op_params_->params_ptr_ = params; }
 
-    Params* params() const {
-        return op_params_->params_ptr_;
-    }
+  Params* params() const { return op_params_->params_ptr_; }
 
-    void setParallelize(const bool parallelize) {
-        op_params_->parallelize = parallelize;
-    }
+  void setParallelize(const bool parallelize) {
+    op_params_->parallelize = parallelize;
+  }
 
-    bool parallelize() const {
-        return op_params_->parallelize;
-    }
+  bool parallelize() const { return op_params_->parallelize; }
 
-    void setDevice(Device* device) {
-        op_params_->device_ptr = device;
-    }
+  void setDevice(Device* device) { op_params_->device_ptr = device; }
 
-    Device* device() const {
-        return op_params_->device_ptr;
-    }
+  Device* device() const { return op_params_->device_ptr; }
 
-    void setLayer(layer* layer) {
-        op_params_->layer_ptr_ = layer;
-    }
+  void setLayer(layer* layer) { op_params_->layer_ptr_ = layer; }
 
-    layer* Layer() const {
-        return op_params_->layer_ptr_;
-    }
+  layer* Layer() const { return op_params_->layer_ptr_; }
 
-    backend_t engine() const {
-        return op_params_->engine;
-    }
+  backend_t engine() const { return op_params_->engine; }
 
-    void setEngine(const backend_t engine) {
-        op_params_->engine = engine;
-    }
+  void setEngine(const backend_t engine) { op_params_->engine = engine; }
 
  private:
-    std::vector<tensor_t*> in_data_;
-    std::vector<tensor_t*> out_data_;
-    std::vector<tensor_t*> out_grad_;
-    std::vector<tensor_t*> in_grad_;
+  std::vector<tensor_t*> in_data_;
+  std::vector<tensor_t*> out_data_;
+  std::vector<tensor_t*> out_grad_;
+  std::vector<tensor_t*> in_grad_;
 
-    std::unique_ptr<OpParams> op_params_;
+  std::unique_ptr<OpParams> op_params_;
 };
 
 class OpKernel {
  public:
-    explicit OpKernel() {}
-    explicit OpKernel(const OpKernelConstruction& context)
-        : device_(context.device())
-        , params_(context.params()) {}
+  explicit OpKernel() {}
+  explicit OpKernel(const OpKernelConstruction& context)
+      : device_(context.device()), params_(context.params()) {}
 
-    virtual ~OpKernel() {}
+  virtual ~OpKernel() {}
 
-    virtual void compute(const OpKernelContext& context) = 0;
+  virtual void compute(const OpKernelContext& context) = 0;
 
  protected:
-    Device* device_ = nullptr;
-    Params* params_ = nullptr;
+  Device* device_ = nullptr;
+  Params* params_ = nullptr;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/framework/program.h
+++ b/tiny_dnn/core/framework/program.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/core/framework/program.h
+++ b/tiny_dnn/core/framework/program.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/core/framework/device.fwd.h"
+#include "tiny_dnn/layers/layer.h"
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
 #ifdef USE_OPENCL
@@ -22,47 +22,47 @@ namespace tiny_dnn {
  */
 class Program {
  public:
-    explicit Program(const Device* device, const layer* op)
-        : device_(device), op_(op) {}
+  explicit Program(const Device* device, const layer* op)
+      : device_(device), op_(op) {}
 
-    // Returns the device associated to the program
-    const Device* device() const { return device_; }
+  // Returns the device associated to the program
+  const Device* device() const { return device_; }
 
-    // Return the layer pointer
-    const layer* op() const { return op_; }
+  // Return the layer pointer
+  const layer* op() const { return op_; }
 
-    bool operator==(const Program& p) const {
-        if (p.device() == this->device() &&
-            p.op()->layer_type() == this->op()->layer_type()) {
-            return true;
-        }
-        return false;
+  bool operator==(const Program& p) const {
+    if (p.device() == this->device() &&
+        p.op()->layer_type() == this->op()->layer_type()) {
+      return true;
     }
+    return false;
+  }
 
  private:
-    const Device* device_;
-    const layer* op_;
+  const Device* device_;
+  const layer* op_;
 };
 
 /* Hash function to store Programs in the register.
  */
 class ProgramHash {
  public:
-    size_t operator()(const Program& p) const {
-        // check there is a device and an op assigned
-        // to the input program.
-        if (p.device() == nullptr || p.op() == nullptr) {
-            throw nn_error("No Op or Device in Program.");
-        }
-
-        // Compute individual hash values for data members and combine
-        // them using XOR and bit shifting.
-        return (std::hash<int>()(static_cast<int>(p.device()->type())) ^
-                std::hash<bool>()(p.device()->hasCLCudaAPI()) ^
-                std::hash<int>()(p.device()->platformId()) ^
-                std::hash<int>()(p.device()->deviceId()) ^
-                std::hash<std::string>()(p.op()->layer_type()));
+  size_t operator()(const Program& p) const {
+    // check there is a device and an op assigned
+    // to the input program.
+    if (p.device() == nullptr || p.op() == nullptr) {
+      throw nn_error("No Op or Device in Program.");
     }
+
+    // Compute individual hash values for data members and combine
+    // them using XOR and bit shifting.
+    return (std::hash<int>()(static_cast<int>(p.device()->type())) ^
+            std::hash<bool>()(p.device()->hasCLCudaAPI()) ^
+            std::hash<int>()(p.device()->platformId()) ^
+            std::hash<int>()(p.device()->deviceId()) ^
+            std::hash<std::string>()(p.op()->layer_type()));
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/framework/program_manager.h
+++ b/tiny_dnn/core/framework/program_manager.h
@@ -6,8 +6,8 @@
 
 #include "tiny_dnn/layers/layer.h"
 
-#include "tiny_dnn/core/framework/program.h"
 #include "tiny_dnn/core/framework/device.fwd.h"
+#include "tiny_dnn/core/framework/program.h"
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
 #ifdef USE_OPENCL
@@ -25,30 +25,30 @@ namespace tiny_dnn {
  */
 class ProgramManager {
  public:
-    /* This function is called to create an instance of the class.
-     * Calling the constructor publicly is not allowed.
-     * The constructor is private and is only called by this Instance function.
-	 */
-    static ProgramManager& getInstance() {
-        static ProgramManager instance;
-        return instance;
-    }
+  /* This function is called to create an instance of the class.
+   * Calling the constructor publicly is not allowed.
+   * The constructor is private and is only called by this Instance function.
+       */
+  static ProgramManager& getInstance() {
+    static ProgramManager instance;
+    return instance;
+  }
 
-    /* Registers and compiles a kernel source code.
-     *
-     * Creates a new program based on the kernel string.
-     * Note that the kernel string is moved-out when constructing the
-     * program to save copying: it should no longer be used in the
-     * remainder of this function.
-     */
-    void registerOp(const Device& device, layer& layer) {
+  /* Registers and compiles a kernel source code.
+   *
+   * Creates a new program based on the kernel string.
+   * Note that the kernel string is moved-out when constructing the
+   * program to save copying: it should no longer be used in the
+   * remainder of this function.
+   */
+  void registerOp(const Device& device, layer& layer) {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-        // Register device to layer
-        layer.setDevice(device);
-        layer.createOp();
+    // Register device to layer
+    layer.setDevice(device);
+    layer.createOp();
 
 /*
-        // retrieve incoming device an layer 
+        // retrieve incoming device an layer
         CLCudaAPI::Device  device_  = device.device();
         CLCudaAPI::Context context_ = device.context();
 
@@ -64,8 +64,8 @@ class ProgramManager {
 
         // Define op kernel string and instantiate program
         // TODO(edgar): load from `cl_kernels` dir.
-		// std::ifstream cl_file("opencl_hello_world.cl");
-		std::ifstream cl_file(layer.kernel_file());
+                // std::ifstream cl_file("opencl_hello_world.cl");
+                std::ifstream cl_file(layer.kernel_file());
         std::string program_tail{std::istreambuf_iterator<char>(cl_file),
                                  std::istreambuf_iterator<char>()};
         // fixed kernel params
@@ -81,13 +81,14 @@ class ProgramManager {
 
         std::cout << layer.kernel_header() << std::endl;
 
-        std::string program_string = std::string{program_head} + std::string{program_tail};
+        std::string program_string = std::string{program_head} +
+   std::string{program_tail};
         auto program = CLCudaAPI::Program(context_, std::move(program_string));
 */
-        /*
-         * Builds this program and checks for any compilation errors.
-         * If there are any, they are printed and execution is halted.
-         */
+/*
+ * Builds this program and checks for any compilation errors.
+ * If there are any, they are printed and execution is halted.
+ */
 /*        nn_info("Compiling the kernel ...");
         auto compiler_options = std::vector<std::string>{};
         auto build_status = program.Build(device_, compiler_options);
@@ -106,44 +107,44 @@ class ProgramManager {
         programs_.insert({ key_program, program });
 */
 #endif  // USE_OPENCL OR USE_CUDA
-    }
+  }
 
-    // Returns the number of registered programs
-    cnn_size_t num_programs() const {
+  // Returns the number of registered programs
+  cnn_size_t num_programs() const {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-        return programs_.size();
+    return programs_.size();
 #else
-        return cnn_size_t(0);
+    return cnn_size_t(0);
 #endif
-    }
+  }
 
-    // Returns a CLCudaProgram given a key Program
-    // based on internal device and op.
+// Returns a CLCudaProgram given a key Program
+// based on internal device and op.
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    CLCudaAPI::Program program(const Program& program) {
-        auto p = programs_.find(program);
-        if (p == programs_.end()) {
-            throw nn_error("Cannot retrieve program.");
-        }
-        return p->second;
+  CLCudaAPI::Program program(const Program& program) {
+    auto p = programs_.find(program);
+    if (p == programs_.end()) {
+      throw nn_error("Cannot retrieve program.");
     }
+    return p->second;
+  }
 #endif
 
-    // Removes the current programs from the general state
-    void reset() {
+  // Removes the current programs from the general state
+  void reset() {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-        programs_.clear();
+    programs_.clear();
 #endif
-    }
+  }
 
  protected:
-    ProgramManager() = default;
-    ProgramManager(const ProgramManager&) = delete;
-    ProgramManager& operator=(const ProgramManager&) = delete;
-    
+  ProgramManager() = default;
+  ProgramManager(const ProgramManager&) = delete;
+  ProgramManager& operator=(const ProgramManager&) = delete;
+
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    /* Container holding compiled kernels */
-    std::unordered_map<Program, CLCudaAPI::Program, ProgramHash> programs_;
+  /* Container holding compiled kernels */
+  std::unordered_map<Program, CLCudaAPI::Program, ProgramHash> programs_;
 #endif
 };
 

--- a/tiny_dnn/core/framework/program_manager.h
+++ b/tiny_dnn/core/framework/program_manager.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/core/kernels/avx_conv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/avx_conv2d_back_kernel.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <vector>
-#include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/kernels/avx_kernel_common.h"
 #include "tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h"
+#include "tiny_dnn/core/params/conv_params.h"
 
 namespace tiny_dnn {
 namespace core {
@@ -18,506 +18,493 @@ template <typename Allocator>
 void avx_conv2d_5x5_back_kernel(const conv_params& params,
                                 const std::vector<float, Allocator>& prev_out,
                                 const std::vector<float, Allocator>& W,
-                                std::vector<float, Allocator>&       dW,
-                                std::vector<float, Allocator>&       db,
-                                std::vector<float, Allocator>&       curr_delta,
-                                std::vector<float, Allocator>*       prev_delta) {
-    auto& in        = params.in;
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    const size_t in_padded_area = in_padded.area();
-    float* pdelta_dst_org = &(*prev_delta)[0];
-    const size_t  h_stride2 = params.h_stride * in_padded.width_;
-    static const __m256 mask = _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
-    // propagate delta to previous layer
-    if (w_stride == 1 && out.width_ >= 4) {
-        const cnn_size_t nblocks = out.width_ / 4;
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                if (!tbl.is_connected(outc, inc)) continue;
-                const float* pw = &W[25 * (in.depth_ * outc + inc)];
-                const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
-                float* pdelta_dst = pdelta_dst_org;
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                __m256 w0b = leftShift<4>(w0a);
-                __m256 w1b = leftShift<4>(w1a);
-                __m256 w2b = leftShift<4>(w2a);
-                __m256 w3b = leftShift<4>(w3a);
-                __m256 w4b = leftShift<4>(w4a);
-                __m256 w0c = leftShift<8>(w0a);
-                __m256 w1c = leftShift<8>(w1a);
-                __m256 w2c = leftShift<8>(w2a);
-                __m256 w3c = leftShift<8>(w3a);
-                __m256 w4c = leftShift<8>(w4a);
-                __m256 w0d = leftShift<12>(w0a);
-                __m256 w1d = leftShift<12>(w1a);
-                __m256 w2d = leftShift<12>(w2a);
-                __m256 w3d = leftShift<12>(w3a);
-                __m256 w4d = leftShift<12>(w4a);
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    const float* pdelta_src2 = pdelta_src;
-                    float* delta_dst0 = pdelta_dst;
-                    float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
-                    float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
-                    float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
-                    float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
-                    for (cnn_size_t n = 0; n < nblocks; ++n) {
-                        __m256 delta_src = _mm256_broadcast_ps((const __m128*)pdelta_src2);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0 + 4 * n);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1 + 4 * n);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2 + 4 * n);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3 + 4 * n);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4 + 4 * n);
-                        __m256 delta_src0 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(0, 0, 0, 0));
-                        __m256 delta_src1 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(1, 1, 1, 1));
-                        __m256 delta_src2 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(2, 2, 2, 2));
-                        __m256 delta_src3 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(3, 3, 3, 3));
-                        dst0 = madd256_ps(w0a, delta_src0, dst0);
-                        dst1 = madd256_ps(w1a, delta_src0, dst1);
-                        dst2 = madd256_ps(w2a, delta_src0, dst2);
-                        dst3 = madd256_ps(w3a, delta_src0, dst3);
-                        dst4 = madd256_ps(w4a, delta_src0, dst4);
-                        dst0 = madd256_ps(w0b, delta_src1, dst0);
-                        dst1 = madd256_ps(w1b, delta_src1, dst1);
-                        dst2 = madd256_ps(w2b, delta_src1, dst2);
-                        dst3 = madd256_ps(w3b, delta_src1, dst3);
-                        dst4 = madd256_ps(w4b, delta_src1, dst4);
-                        dst0 = madd256_ps(w0c, delta_src2, dst0);
-                        dst1 = madd256_ps(w1c, delta_src2, dst1);
-                        dst2 = madd256_ps(w2c, delta_src2, dst2);
-                        dst3 = madd256_ps(w3c, delta_src2, dst3);
-                        dst4 = madd256_ps(w4c, delta_src2, dst4);
-                        dst0 = madd256_ps(w0d, delta_src3, dst0);
-                        _mm256_storeu_ps(delta_dst0 + 4 * n, dst0);
-                        dst1 = madd256_ps(w1d, delta_src3, dst1);
-                        _mm256_storeu_ps(delta_dst1 + 4 * n, dst1);
-                        dst2 = madd256_ps(w2d, delta_src3, dst2);
-                        _mm256_storeu_ps(delta_dst2 + 4 * n, dst2);
-                        dst3 = madd256_ps(w3d, delta_src3, dst3);
-                        _mm256_storeu_ps(delta_dst3 + 4 * n, dst3);
-                        dst4 = madd256_ps(w4d, delta_src3, dst4);
-                        _mm256_storeu_ps(delta_dst4 + 4 * n, dst4);
-                        pdelta_src2 += 4;
-                    }
-                    for (cnn_size_t x = nblocks * 4; x < out.width_; x++) {
-                        __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0 + x);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1 + x);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2 + x);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3 + x);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4 + x);
-                        dst0 = madd256_ps(w0a, delta_src, dst0);
-                        dst1 = madd256_ps(w1a, delta_src, dst1);
-                        dst2 = madd256_ps(w2a, delta_src, dst2);
-                        dst3 = madd256_ps(w3a, delta_src, dst3);
-                        dst4 = madd256_ps(w4a, delta_src, dst4);
-                        _mm256_storeu_ps(delta_dst0 + x, dst0);
-                        _mm256_storeu_ps(delta_dst1 + x, dst1);
-                        _mm256_storeu_ps(delta_dst2 + x, dst2);
-                        _mm256_storeu_ps(delta_dst3 + x, dst3);
-                        _mm256_storeu_ps(delta_dst4 + x, dst4);
-                    }
-                    pdelta_src += out.width_;
-                    pdelta_dst += h_stride2;
-                }
-            }
+                                std::vector<float, Allocator>& dW,
+                                std::vector<float, Allocator>& db,
+                                std::vector<float, Allocator>& curr_delta,
+                                std::vector<float, Allocator>* prev_delta) {
+  auto& in = params.in;
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+  const size_t in_padded_area = in_padded.area();
+  float* pdelta_dst_org = &(*prev_delta)[0];
+  const size_t h_stride2 = params.h_stride * in_padded.width_;
+  static const __m256 mask =
+      _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
+  // propagate delta to previous layer
+  if (w_stride == 1 && out.width_ >= 4) {
+    const cnn_size_t nblocks = out.width_ / 4;
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+        const float* pw = &W[25 * (in.depth_ * outc + inc)];
+        const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
+        float* pdelta_dst = pdelta_dst_org;
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        __m256 w0b = leftShift<4>(w0a);
+        __m256 w1b = leftShift<4>(w1a);
+        __m256 w2b = leftShift<4>(w2a);
+        __m256 w3b = leftShift<4>(w3a);
+        __m256 w4b = leftShift<4>(w4a);
+        __m256 w0c = leftShift<8>(w0a);
+        __m256 w1c = leftShift<8>(w1a);
+        __m256 w2c = leftShift<8>(w2a);
+        __m256 w3c = leftShift<8>(w3a);
+        __m256 w4c = leftShift<8>(w4a);
+        __m256 w0d = leftShift<12>(w0a);
+        __m256 w1d = leftShift<12>(w1a);
+        __m256 w2d = leftShift<12>(w2a);
+        __m256 w3d = leftShift<12>(w3a);
+        __m256 w4d = leftShift<12>(w4a);
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          const float* pdelta_src2 = pdelta_src;
+          float* delta_dst0 = pdelta_dst;
+          float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
+          float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
+          float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
+          float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
+          for (cnn_size_t n = 0; n < nblocks; ++n) {
+            __m256 delta_src = _mm256_broadcast_ps((const __m128*)pdelta_src2);
+            __m256 dst0 = _mm256_loadu_ps(delta_dst0 + 4 * n);
+            __m256 dst1 = _mm256_loadu_ps(delta_dst1 + 4 * n);
+            __m256 dst2 = _mm256_loadu_ps(delta_dst2 + 4 * n);
+            __m256 dst3 = _mm256_loadu_ps(delta_dst3 + 4 * n);
+            __m256 dst4 = _mm256_loadu_ps(delta_dst4 + 4 * n);
+            __m256 delta_src0 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(0, 0, 0, 0));
+            __m256 delta_src1 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(1, 1, 1, 1));
+            __m256 delta_src2 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(2, 2, 2, 2));
+            __m256 delta_src3 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(3, 3, 3, 3));
+            dst0 = madd256_ps(w0a, delta_src0, dst0);
+            dst1 = madd256_ps(w1a, delta_src0, dst1);
+            dst2 = madd256_ps(w2a, delta_src0, dst2);
+            dst3 = madd256_ps(w3a, delta_src0, dst3);
+            dst4 = madd256_ps(w4a, delta_src0, dst4);
+            dst0 = madd256_ps(w0b, delta_src1, dst0);
+            dst1 = madd256_ps(w1b, delta_src1, dst1);
+            dst2 = madd256_ps(w2b, delta_src1, dst2);
+            dst3 = madd256_ps(w3b, delta_src1, dst3);
+            dst4 = madd256_ps(w4b, delta_src1, dst4);
+            dst0 = madd256_ps(w0c, delta_src2, dst0);
+            dst1 = madd256_ps(w1c, delta_src2, dst1);
+            dst2 = madd256_ps(w2c, delta_src2, dst2);
+            dst3 = madd256_ps(w3c, delta_src2, dst3);
+            dst4 = madd256_ps(w4c, delta_src2, dst4);
+            dst0 = madd256_ps(w0d, delta_src3, dst0);
+            _mm256_storeu_ps(delta_dst0 + 4 * n, dst0);
+            dst1 = madd256_ps(w1d, delta_src3, dst1);
+            _mm256_storeu_ps(delta_dst1 + 4 * n, dst1);
+            dst2 = madd256_ps(w2d, delta_src3, dst2);
+            _mm256_storeu_ps(delta_dst2 + 4 * n, dst2);
+            dst3 = madd256_ps(w3d, delta_src3, dst3);
+            _mm256_storeu_ps(delta_dst3 + 4 * n, dst3);
+            dst4 = madd256_ps(w4d, delta_src3, dst4);
+            _mm256_storeu_ps(delta_dst4 + 4 * n, dst4);
+            pdelta_src2 += 4;
+          }
+          for (cnn_size_t x = nblocks * 4; x < out.width_; x++) {
+            __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
+            __m256 dst0 = _mm256_loadu_ps(delta_dst0 + x);
+            __m256 dst1 = _mm256_loadu_ps(delta_dst1 + x);
+            __m256 dst2 = _mm256_loadu_ps(delta_dst2 + x);
+            __m256 dst3 = _mm256_loadu_ps(delta_dst3 + x);
+            __m256 dst4 = _mm256_loadu_ps(delta_dst4 + x);
+            dst0 = madd256_ps(w0a, delta_src, dst0);
+            dst1 = madd256_ps(w1a, delta_src, dst1);
+            dst2 = madd256_ps(w2a, delta_src, dst2);
+            dst3 = madd256_ps(w3a, delta_src, dst3);
+            dst4 = madd256_ps(w4a, delta_src, dst4);
+            _mm256_storeu_ps(delta_dst0 + x, dst0);
+            _mm256_storeu_ps(delta_dst1 + x, dst1);
+            _mm256_storeu_ps(delta_dst2 + x, dst2);
+            _mm256_storeu_ps(delta_dst3 + x, dst3);
+            _mm256_storeu_ps(delta_dst4 + x, dst4);
+          }
+          pdelta_src += out.width_;
+          pdelta_dst += h_stride2;
         }
-    } else if (out.height_ == 1 && out.width_ == 1) {
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            float* delta_dst0 = pdelta_dst_org;
-            float* delta_dst1 = &pdelta_dst_org[in_padded.width_ * 1];
-            float* delta_dst2 = &pdelta_dst_org[in_padded.width_ * 2];
-            float* delta_dst3 = &pdelta_dst_org[in_padded.width_ * 3];
-            float* delta_dst4 = &pdelta_dst_org[in_padded.width_ * 4];
+      }
+    }
+  } else if (out.height_ == 1 && out.width_ == 1) {
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      float* delta_dst0 = pdelta_dst_org;
+      float* delta_dst1 = &pdelta_dst_org[in_padded.width_ * 1];
+      float* delta_dst2 = &pdelta_dst_org[in_padded.width_ * 2];
+      float* delta_dst3 = &pdelta_dst_org[in_padded.width_ * 3];
+      float* delta_dst4 = &pdelta_dst_org[in_padded.width_ * 4];
+      __m256 dst0 = _mm256_loadu_ps(delta_dst0);
+      __m256 dst1 = _mm256_loadu_ps(delta_dst1);
+      __m256 dst2 = _mm256_loadu_ps(delta_dst2);
+      __m256 dst3 = _mm256_loadu_ps(delta_dst3);
+      __m256 dst4 = _mm256_loadu_ps(delta_dst4);
+
+      // *FROM
+      // ---0 0000
+      // ---1 1111
+      // ---2 2222
+      // ---3 3333
+      // ---4 4444
+      //
+      // *TO
+      // 1110 0000
+      // 3222 2211
+      // 4444 3333
+      // ---- ---4
+      __m256 sum0 =
+          _mm256_blend_ps(dst0, leftShift<20>(dst1), 0xE0 /* 0b11100000 */
+                          );
+      __m256 sum1 = _mm256_blend_ps(
+          leftShift<28>(dst3),
+          _mm256_blend_ps(leftShift<8>(dst2), rightShift<12>(dst1),
+                          0x03 /* 0b00000011 */),
+          0x7F /* 0b01111111 */
+          );
+      __m256 sum2 = _mm256_blend_ps(
+          leftShift<16>(dst4), rightShift<4>(dst3), 0x0F /* 0b00001111 */
+          );
+      __m128 sum3 = _mm256_extractf128_ps(dst4, 1);
+
+      size_t widx = 25 * inc;
+      size_t wstep = 25 * in.depth_;
+      const __m256 mask2 = mask;
+      if (tbl.is_empty()) {
+        for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
+          __m256 delta_src =
+              _mm256_and_ps(_mm256_broadcast_ss(&curr_delta[outc]), mask2);
+          const float* pw = (const float*)&W[widx];
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 8);
+          __m256 w2 = _mm256_loadu_ps(pw + 16);
+          __m128 w3 = _mm_load_ss(pw + 24);
+          sum0 = madd256_ps(w0, delta_src, sum0);
+          sum1 = madd256_ps(w1, delta_src, sum1);
+          sum2 = madd256_ps(w2, delta_src, sum2);
+          sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
+        }
+      } else {
+        for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
+          if (!tbl.is_connected(outc, inc)) {
+            continue;
+          }
+          __m256 delta_src =
+              _mm256_and_ps(_mm256_broadcast_ss(&curr_delta[outc]), mask2);
+          const float* pw = (const float*)&W[widx];
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 8);
+          __m256 w2 = _mm256_loadu_ps(pw + 16);
+          __m128 w3 = _mm_load_ss(pw + 24);
+          sum0 = madd256_ps(w0, delta_src, sum0);
+          sum1 = madd256_ps(w1, delta_src, sum1);
+          sum2 = madd256_ps(w2, delta_src, sum2);
+          sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
+        }
+      }
+
+      // *FROM
+      // 1110 0000
+      // 3222 2211
+      // 4444 3333
+      // ---- ---4
+      //
+      // *TO
+      // ---0 0000
+      // ---1 1111
+      // ---2 2222
+      // ---3 3333
+      // ---4 4444
+      dst0 = _mm256_blend_ps(dst0, sum0, 0x1F /* 0b00011111 */
+                             );
+      dst1 = _mm256_blend_ps(
+          dst1, _mm256_or_ps(rightShift<20>(sum0), leftShift<12>(sum1)),
+          0x1F /* 0b00011111 */
+          );
+      dst2 = _mm256_blend_ps(dst2, rightShift<8>(sum1), 0x1F /* 0b00011111 */
+                             );
+      dst3 = _mm256_blend_ps(
+          dst3, _mm256_or_ps(rightShift<28>(sum1), leftShift<4>(sum2)),
+          0x1F /* 0b00011111 */
+          );
+      dst4 = _mm256_blend_ps(
+          dst4, _mm256_set_m128(sum3, _mm256_extractf128_ps(sum2, 1)),
+          0x1F /* 0b00011111 */
+          );
+
+      _mm256_storeu_ps(delta_dst0, dst0);
+      _mm256_storeu_ps(delta_dst1, dst1);
+      _mm256_storeu_ps(delta_dst2, dst2);
+      _mm256_storeu_ps(delta_dst3, dst3);
+      _mm256_storeu_ps(delta_dst4, dst4);
+    }  // for
+  } else {
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+
+        const float* pw = &W[25 * (in.depth_ * outc + inc)];
+        const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
+        float* pdelta_dst = pdelta_dst_org;
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          float* delta_dst0 = pdelta_dst;
+          float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
+          float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
+          float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
+          float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
+          for (cnn_size_t x = 0; x < out.width_; x++) {
+            __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
             __m256 dst0 = _mm256_loadu_ps(delta_dst0);
             __m256 dst1 = _mm256_loadu_ps(delta_dst1);
             __m256 dst2 = _mm256_loadu_ps(delta_dst2);
             __m256 dst3 = _mm256_loadu_ps(delta_dst3);
             __m256 dst4 = _mm256_loadu_ps(delta_dst4);
-
-            // *FROM
-            // ---0 0000
-            // ---1 1111
-            // ---2 2222
-            // ---3 3333
-            // ---4 4444
-            //
-            // *TO
-            // 1110 0000
-            // 3222 2211
-            // 4444 3333
-            // ---- ---4
-            __m256 sum0 = _mm256_blend_ps(
-                dst0,
-                leftShift<20>(dst1),
-                0xE0 /* 0b11100000 */
-            );
-            __m256 sum1 = _mm256_blend_ps(
-                leftShift<28>(dst3),
-                _mm256_blend_ps(leftShift<8>(dst2), rightShift<12>(dst1), 0x03 /* 0b00000011 */),
-                0x7F /* 0b01111111 */
-            );
-            __m256 sum2 = _mm256_blend_ps(
-                leftShift<16>(dst4),
-                rightShift<4>(dst3),
-                0x0F /* 0b00001111 */
-            );
-            __m128 sum3 = _mm256_extractf128_ps(dst4, 1);
-
-            size_t widx = 25 * inc;
-            size_t wstep = 25 * in.depth_;
-            const __m256 mask2 = mask;
-            if (tbl.is_empty()) {
-                for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx+=wstep) {
-                    __m256 delta_src = _mm256_and_ps(_mm256_broadcast_ss(&curr_delta[outc]), mask2);
-                    const float* pw = (const float*)&W[widx];
-                    __m256 w0 = _mm256_loadu_ps(pw+0);
-                    __m256 w1 = _mm256_loadu_ps(pw + 8);
-                    __m256 w2 = _mm256_loadu_ps(pw + 16);
-                    __m128 w3 = _mm_load_ss(pw + 24);
-                    sum0 = madd256_ps(w0, delta_src, sum0);
-                    sum1 = madd256_ps(w1, delta_src, sum1);
-                    sum2 = madd256_ps(w2, delta_src, sum2);
-                    sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
-                }
-            }
-            else {
-                for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
-                    if (!tbl.is_connected(outc, inc)) {
-                        continue;
-                    }
-                    __m256 delta_src = _mm256_and_ps(_mm256_broadcast_ss(&curr_delta[outc]), mask2);
-                    const float* pw = (const float*)&W[widx];
-                    __m256 w0 = _mm256_loadu_ps(pw + 0);
-                    __m256 w1 = _mm256_loadu_ps(pw + 8);
-                    __m256 w2 = _mm256_loadu_ps(pw + 16);
-                    __m128 w3 = _mm_load_ss(pw + 24);
-                    sum0 = madd256_ps(w0, delta_src, sum0);
-                    sum1 = madd256_ps(w1, delta_src, sum1);
-                    sum2 = madd256_ps(w2, delta_src, sum2);
-                    sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
-                }
-            }
-
-            // *FROM
-            // 1110 0000
-            // 3222 2211
-            // 4444 3333
-            // ---- ---4
-            //
-            // *TO
-            // ---0 0000
-            // ---1 1111
-            // ---2 2222
-            // ---3 3333
-            // ---4 4444
-            dst0 = _mm256_blend_ps(
-                dst0,
-                sum0,
-                0x1F /* 0b00011111 */
-            );
-            dst1 = _mm256_blend_ps(
-                dst1,
-                _mm256_or_ps(
-                    rightShift<20>(sum0),
-                    leftShift<12>(sum1)
-                ),
-                0x1F /* 0b00011111 */
-            );
-            dst2 = _mm256_blend_ps(
-                dst2,
-                rightShift<8>(sum1),
-                0x1F /* 0b00011111 */
-            );
-            dst3 = _mm256_blend_ps(
-                dst3,
-                _mm256_or_ps(
-                    rightShift<28>(sum1),
-                    leftShift<4>(sum2)
-                ),
-                0x1F /* 0b00011111 */
-            );
-            dst4 = _mm256_blend_ps(
-                dst4,
-                _mm256_set_m128(
-                    sum3,
-                    _mm256_extractf128_ps(sum2, 1)
-                ),
-                0x1F /* 0b00011111 */
-            );
-
+            dst0 = madd256_ps(w0a, delta_src, dst0);
+            dst1 = madd256_ps(w1a, delta_src, dst1);
+            dst2 = madd256_ps(w2a, delta_src, dst2);
+            dst3 = madd256_ps(w3a, delta_src, dst3);
+            dst4 = madd256_ps(w4a, delta_src, dst4);
             _mm256_storeu_ps(delta_dst0, dst0);
             _mm256_storeu_ps(delta_dst1, dst1);
             _mm256_storeu_ps(delta_dst2, dst2);
             _mm256_storeu_ps(delta_dst3, dst3);
             _mm256_storeu_ps(delta_dst4, dst4);
-        } // for
-    } else {
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                if (!tbl.is_connected(outc, inc)) continue;
+            delta_dst0 += w_stride;
+            delta_dst1 += w_stride;
+            delta_dst2 += w_stride;
+            delta_dst3 += w_stride;
+            delta_dst4 += w_stride;
+          }  // for x
+          pdelta_src += out.width_;
+          pdelta_dst += h_stride2;
+        }  // for y
+      }    // for outc
+    }      // for inc
+  }
 
-                const float* pw = &W[25 * (in.depth_ * outc + inc)];
-                const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
-                float* pdelta_dst = pdelta_dst_org;
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    float* delta_dst0 = pdelta_dst;
-                    float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
-                    float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
-                    float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
-                    float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
-                    for (cnn_size_t x = 0; x < out.width_; x++) {
-                        __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4);
-                        dst0 = madd256_ps(w0a, delta_src, dst0);
-                        dst1 = madd256_ps(w1a, delta_src, dst1);
-                        dst2 = madd256_ps(w2a, delta_src, dst2);
-                        dst3 = madd256_ps(w3a, delta_src, dst3);
-                        dst4 = madd256_ps(w4a, delta_src, dst4);
-                        _mm256_storeu_ps(delta_dst0, dst0);
-                        _mm256_storeu_ps(delta_dst1, dst1);
-                        _mm256_storeu_ps(delta_dst2, dst2);
-                        _mm256_storeu_ps(delta_dst3, dst3);
-                        _mm256_storeu_ps(delta_dst4, dst4);
-                        delta_dst0 += w_stride;
-                        delta_dst1 += w_stride;
-                        delta_dst2 += w_stride;
-                        delta_dst3 += w_stride;
-                        delta_dst4 += w_stride;
-                    } // for x
-                    pdelta_src += out.width_;
-                    pdelta_dst += h_stride2;
-                } // for y
-            } // for outc
-        } // for inc
+  // accumulate dw
+  if (out.width_ == 1 && out.height_ == 1) {
+    const float* pprev_out = &prev_out[0];
+    for (size_t inc = 0; inc < in.depth_; ++inc, pprev_out += in_padded_area) {
+      VECTORIZE_ALIGN(32) float floats[28];
+      size_t in_padded_width = in_padded.width_;
+      _mm256_store_ps(&floats[0],
+                      _mm256_loadu_ps(pprev_out + in_padded_width * 0));
+      _mm256_storeu_ps(&floats[5],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 1));
+      _mm256_storeu_ps(&floats[10],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 2));
+      _mm256_storeu_ps(&floats[15],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 3));
+      _mm256_storeu_ps(&floats[20],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 4));
+      __m256 prevos0 = _mm256_load_ps(&floats[0]);
+      __m256 prevos1 = _mm256_load_ps(&floats[8]);
+      __m256 prevos2 = _mm256_load_ps(&floats[16]);
+      __m128 prevos3 = _mm_load_ss(&floats[24]);
+      cnn_size_t widx = 25 * inc;
+      cnn_size_t widx_delta = 25 * in.depth_;
+      float* pdW = &dW[widx];
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++, pdW += widx_delta) {
+        if (!tbl.is_connected(outc, inc)) {
+          continue;
+        }
+        __m256 delta = _mm256_broadcast_ss(&curr_delta[outc]);
+        __m256 w0 = _mm256_loadu_ps(pdW + 0);
+        __m256 w1 = _mm256_loadu_ps(pdW + 8);
+        __m256 w2 = _mm256_loadu_ps(pdW + 16);
+        __m128 w3 = _mm_load_ss(pdW + 24);
+        w0 = madd256_ps(prevos0, delta, w0);
+        w1 = madd256_ps(prevos1, delta, w1);
+        w2 = madd256_ps(prevos2, delta, w2);
+        w3 = madd128_ss(prevos3, _mm256_castps256_ps128(delta), w3);
+        _mm256_storeu_ps(pdW + 0, w0);
+        _mm256_storeu_ps(pdW + 8, w1);
+        _mm256_storeu_ps(pdW + 16, w2);
+        _mm_store_ss(pdW + 24, w3);
+      }
     }
+  } else {
+    // prepare load-mask beforehand
+    const size_t nblocks = out.width_ >> 3;
+    static const int32_t masks[] = {
+        -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+    const size_t remainder = out.width_ & 7;
+    __m256i mask = _mm256_loadu_si256((const __m256i*)(masks + 8 - remainder));
+    auto& weight = params.weight;
+    for (size_t inc = 0; inc < in.depth_; ++inc) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+        const float* delta = &curr_delta[out.get_index(0, 0, outc)];
 
-    // accumulate dw
+        cnn_size_t widx = weight.get_index(0, 0, in.depth_ * outc + inc);
+        for (cnn_size_t wy = 0; wy < 5 /* weight.height_ */; wy++) {
+          for (cnn_size_t wx = 0; wx < 5 /* weight.width_ */; wx++) {
+            const float* prevo = &prev_out[in_padded.get_index(wx, wy, inc)];
+            __m128 prev_sum = _mm_load_ss(&dW[widx]);
+            __m256 sum0 = _mm256_setzero_ps();
+            __m256 sum1 = _mm256_setzero_ps();
+            for (cnn_size_t y = 0; y < out.height_; y++) {
+              // vectorize::dot
+              const float* pa = prevo + y * in_padded.width_;
+              const float* pb = delta + y * out.width_;
+              for (size_t i = 0; i < nblocks; ++i) {
+                __m256 a = _mm256_loadu_ps(pa + 8 * i);
+                __m256 b = _mm256_loadu_ps(pb + 8 * i);
+                sum0 = madd256_ps(a, b, sum0);
+              }
+              if (remainder) {
+                __m256 a = _mm256_loadu_ps(pa + 8 * nblocks);
+                __m256 b = _mm256_loadu_ps(pb + 8 * nblocks);
+                sum1 = madd256_ps(a, b, sum1);
+              }
+            }
+            sum1 = _mm256_and_ps(sum1, _mm256_castsi256_ps(mask));
+            __m256 sum = _mm256_add_ps(sum0, sum1);
+            _mm_store_ss(&dW[widx], _mm_add_ps(prev_sum, hsum256_ps(sum)));
+            ++widx;
+          }
+        }
+      }
+    }
+  }
+
+  // accumulate db
+  if (params.has_bias) {
+    // fvec_t& db = *in_grad[2];
+
     if (out.width_ == 1 && out.height_ == 1) {
-        const float* pprev_out = &prev_out[0];
-        for (size_t inc = 0; inc < in.depth_; ++inc, pprev_out += in_padded_area) {
-            VECTORIZE_ALIGN(32) float floats[28];
-            size_t in_padded_width = in_padded.width_;
-            _mm256_store_ps(&floats[0], _mm256_loadu_ps(pprev_out + in_padded_width * 0));
-            _mm256_storeu_ps(&floats[5], _mm256_loadu_ps(pprev_out + in_padded_width * 1));
-            _mm256_storeu_ps(&floats[10], _mm256_loadu_ps(pprev_out + in_padded_width * 2));
-            _mm256_storeu_ps(&floats[15], _mm256_loadu_ps(pprev_out + in_padded_width * 3));
-            _mm256_storeu_ps(&floats[20], _mm256_loadu_ps(pprev_out + in_padded_width * 4));
-            __m256 prevos0 = _mm256_load_ps(&floats[0]);
-            __m256 prevos1 = _mm256_load_ps(&floats[8]);
-            __m256 prevos2 = _mm256_load_ps(&floats[16]);
-            __m128 prevos3 = _mm_load_ss(&floats[24]);
-            cnn_size_t widx = 25 * inc;
-            cnn_size_t widx_delta = 25 * in.depth_;
-            float* pdW = &dW[widx];
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++, pdW += widx_delta) {
-                if (!tbl.is_connected(outc, inc)) {
-                    continue;
-                }
-                __m256 delta = _mm256_broadcast_ss(&curr_delta[outc]);
-                __m256 w0 = _mm256_loadu_ps(pdW+0);
-                __m256 w1 = _mm256_loadu_ps(pdW+8);
-                __m256 w2 = _mm256_loadu_ps(pdW + 16);
-                __m128 w3 = _mm_load_ss(pdW + 24);
-                w0 = madd256_ps(prevos0, delta, w0);
-                w1 = madd256_ps(prevos1, delta, w1);
-                w2 = madd256_ps(prevos2, delta, w2);
-                w3 = madd128_ss(prevos3, _mm256_castps256_ps128(delta), w3);
-                _mm256_storeu_ps(pdW + 0, w0);
-                _mm256_storeu_ps(pdW + 8, w1);
-                _mm256_storeu_ps(pdW+16, w2);
-                _mm_store_ss(pdW+24, w3);
-            }
-        }
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        db[outc] += curr_delta[outc];
+      }
     } else {
-        // prepare load-mask beforehand
-        const size_t nblocks = out.width_ >> 3;
-        static const int32_t masks[] = {
-            -1, -1, -1, -1,
-            -1, -1, -1, -1,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-        };
-        const size_t remainder = out.width_ & 7;
-        __m256i mask = _mm256_loadu_si256((const __m256i*)(masks + 8 - remainder));
-        auto& weight = params.weight;
-        for (size_t inc = 0; inc < in.depth_; ++inc) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-
-                if (!tbl.is_connected(outc, inc)) continue;
-                const float* delta = &curr_delta[out.get_index(0, 0, outc)];
-
-                cnn_size_t widx = weight.get_index(0, 0, in.depth_ * outc + inc);
-                for (cnn_size_t wy = 0; wy < 5 /* weight.height_ */; wy++) {
-                    for (cnn_size_t wx = 0; wx < 5 /* weight.width_ */; wx++) {
-                        const float* prevo = &prev_out[in_padded.get_index(wx, wy, inc)];
-                        __m128 prev_sum = _mm_load_ss(&dW[widx]);
-                        __m256 sum0 = _mm256_setzero_ps();
-                        __m256 sum1 = _mm256_setzero_ps();
-                        for (cnn_size_t y = 0; y < out.height_; y++) {
-                            // vectorize::dot
-                            const float* pa = prevo + y * in_padded.width_;
-                            const float* pb = delta + y * out.width_;
-                            for (size_t i = 0; i < nblocks; ++i) {
-                                __m256 a = _mm256_loadu_ps(pa + 8 * i);
-                                __m256 b = _mm256_loadu_ps(pb + 8 * i);
-                                sum0 = madd256_ps(a, b, sum0);
-                            }
-                            if (remainder) {
-                                __m256 a = _mm256_loadu_ps(pa + 8 * nblocks);
-                                __m256 b = _mm256_loadu_ps(pb + 8 * nblocks);
-                                sum1 = madd256_ps(a, b, sum1);
-                            }
-                        }
-                        sum1 = _mm256_and_ps(sum1, _mm256_castsi256_ps(mask));
-                        __m256 sum = _mm256_add_ps(sum0, sum1);
-                        _mm_store_ss(&dW[widx], _mm_add_ps(prev_sum, hsum256_ps(sum)));
-                        ++widx;
-                    }
-                }
-            }
-        }
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        const float* delta = &curr_delta[out.get_index(0, 0, outc)];
+        db[outc] +=
+            std::accumulate(delta, delta + out.width_ * out.height_, float(0));
+      }
     }
-
-    // accumulate db
-    if (params.has_bias) {
-        //fvec_t& db = *in_grad[2];
-        
-        if (out.width_ == 1 && out.height_ == 1) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                db[outc] += curr_delta[outc];
-            }
-        } else {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                const float *delta = &curr_delta[out.get_index(0, 0, outc)];
-                db[outc] += std::accumulate(delta, delta + out.width_ * out.height_, float(0));
-            }
-        }
-    }
-} // avx_conv2d_5x5_back_kernel float ver
+  }
+}  // avx_conv2d_5x5_back_kernel float ver
 
 // double ver
 template <typename Allocator>
 void avx_conv2d_5x5_back_kernel(const conv_params& params,
                                 const std::vector<double, Allocator>& prev_out,
                                 const std::vector<double, Allocator>& W,
-                                std::vector<double, Allocator>&       dW,
-                                std::vector<double, Allocator>&       db,
-                                std::vector<double, Allocator>&       curr_delta,
-                                std::vector<double, Allocator>*       prev_delta) {
-    // propagate delta to previous layer
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
+                                std::vector<double, Allocator>& dW,
+                                std::vector<double, Allocator>& db,
+                                std::vector<double, Allocator>& curr_delta,
+                                std::vector<double, Allocator>* prev_delta) {
+  // propagate delta to previous layer
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * outc + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const float_t *pw = &W[idx];
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * outc + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const float_t* pw = &W[idx];
 
-            idx = params.out.get_index(0, 0, outc);
-            const float_t *pdelta_src = &curr_delta[idx];
+      idx = params.out.get_index(0, 0, outc);
+      const float_t* pdelta_src = &curr_delta[idx];
 
-            idx = params.in_padded.get_index(0, 0, inc);
-            float_t *pdelta_dst = &(*prev_delta)[idx];
+      idx = params.in_padded.get_index(0, 0, inc);
+      float_t* pdelta_dst = &(*prev_delta)[idx];
 
-            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                    const float_t * ppw = pw;
+      for (cnn_size_t y = 0; y < params.out.height_; y++) {
+        for (cnn_size_t x = 0; x < params.out.width_; x++) {
+          const float_t* ppw = pw;
 
-                    idx = y * params.out.width_ + x;
-                    const float_t ppdelta_src = pdelta_src[idx];
+          idx = y * params.out.width_ + x;
+          const float_t ppdelta_src = pdelta_src[idx];
 
-                    float_t * ppdelta_dst = pdelta_dst +
-                          y * params.h_stride * params.in_padded.width_ +
-                          x * params.w_stride;
+          float_t* ppdelta_dst = pdelta_dst +
+                                 y * params.h_stride * params.in_padded.width_ +
+                                 x * params.w_stride;
 
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                            idx = wy * params.in_padded.width_ + wx;
-                            ppdelta_dst[idx] += *ppw++ * ppdelta_src;
-                        }
-                    }
-                }
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {  // NOLINT
+            for (cnn_size_t wx = 0; wx < params.weight.width_;
+                 wx++) {  // NOLINT
+              idx = wy * params.in_padded.width_ + wx;
+              ppdelta_dst[idx] += *ppw++ * ppdelta_src;
             }
+          }
         }
-    });
-
-    // accumulate dw
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
-
-            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                    float_t dst = float_t(0);
-
-                    cnn_size_t idx = 0;
-                    idx = params.in_padded.get_index(wx, wy, inc);
-                    const float_t * prevo = &prev_out[idx];
-
-                    idx = params.out.get_index(0, 0, outc);
-                    const float_t * delta = &curr_delta[idx];
-
-                    for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                        dst += vectorize::dot(
-                            prevo + y * params.in_padded.width_,
-                            delta + y * params.out.width_,
-                            params.out.width_);
-                    }
-
-                    idx = params.in.depth_ * outc + inc;
-                    dW[params.weight.get_index(wx, wy, idx)] += dst;
-                }
-            }
-        }
-    });
-
-    // accumulate db
-    if (params.has_bias) {
-        //vec_t& db = *in_grad[2];
-
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            cnn_size_t idx = params.out.get_index(0, 0, outc);
-            const float_t * delta = &curr_delta[idx];
-            const float_t * deltaa = delta + params.out.width_ *
-                                             params.out.height_;
-            db[outc] += std::accumulate(delta, deltaa, float_t(0));
-        }
+      }
     }
-} // avx_conv2d_5x5_back_kernel double ver
+  });
+
+  // accumulate dw
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
+
+      for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+          float_t dst = float_t(0);
+
+          cnn_size_t idx = 0;
+          idx = params.in_padded.get_index(wx, wy, inc);
+          const float_t* prevo = &prev_out[idx];
+
+          idx = params.out.get_index(0, 0, outc);
+          const float_t* delta = &curr_delta[idx];
+
+          for (cnn_size_t y = 0; y < params.out.height_; y++) {
+            dst += vectorize::dot(prevo + y * params.in_padded.width_,
+                                  delta + y * params.out.width_,
+                                  params.out.width_);
+          }
+
+          idx = params.in.depth_ * outc + inc;
+          dW[params.weight.get_index(wx, wy, idx)] += dst;
+        }
+      }
+    }
+  });
+
+  // accumulate db
+  if (params.has_bias) {
+    // vec_t& db = *in_grad[2];
+
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      cnn_size_t idx = params.out.get_index(0, 0, outc);
+      const float_t* delta = &curr_delta[idx];
+      const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+      db[outc] += std::accumulate(delta, deltaa, float_t(0));
+    }
+  }
+}  // avx_conv2d_5x5_back_kernel double ver
 
 inline void avx_conv2d_back_kernel(const conv_params& params,
                                    const std::vector<const vec_t*>& prev_out,
-                                   const vec_t&       W,
-                                   tensor_t&          dW,
-                                   tensor_t&          db,
-                                   tensor_t&          curr_delta,
-                                   tensor_t*          prev_delta) {
-                             
-    if (params.weight.height_ == 5 && params.weight.width_ == 5) {
-        for_i(prev_out.size(), [&](int sample) {
-            avx_conv2d_5x5_back_kernel(params, *prev_out[sample], W, dW[sample], db[sample], curr_delta[sample], &(*prev_delta)[sample]);
-        });
-        return;
-    }
+                                   const vec_t& W, tensor_t& dW, tensor_t& db,
+                                   tensor_t& curr_delta, tensor_t* prev_delta) {
+  if (params.weight.height_ == 5 && params.weight.width_ == 5) {
+    for_i(prev_out.size(), [&](int sample) {
+      avx_conv2d_5x5_back_kernel(params, *prev_out[sample], W, dW[sample],
+                                 db[sample], curr_delta[sample],
+                                 &(*prev_delta)[sample]);
+    });
+    return;
+  }
 
-    tiny_conv2d_back_kernel(params, prev_out, W, dW, db, curr_delta, prev_delta);
+  tiny_conv2d_back_kernel(params, prev_out, W, dW, db, curr_delta, prev_delta);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/avx_conv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/avx_conv2d_back_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/core/kernels/avx_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/avx_conv2d_kernel.h
@@ -5,9 +5,9 @@
 #pragma once
 
 #include <vector>
-#include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/kernels/avx_kernel_common.h"
 #include "tiny_dnn/core/kernels/tiny_conv2d_kernel.h"
+#include "tiny_dnn/core/params/conv_params.h"
 
 namespace tiny_dnn {
 namespace core {
@@ -19,229 +19,233 @@ void avx_conv2d_5x5_kernel(const conv_params& params,
                            const std::vector<float, Allocator>& in,
                            const std::vector<float, Allocator>& W,
                            const std::vector<float, Allocator>& bias,
-                           std::vector<float, Allocator>&       a,
+                           std::vector<float, Allocator>& a,
                            const bool layer_parallelize) {
-    assert(params.weight.height_ == 5 && params.weight.width_ == 5);
-    
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    
-    const size_t out_area = out.area();
-    cnn_size_t oidx = 0;
-    float bias_scale = params.has_bias ? 1.0f : 0.0f;
-    const size_t stride = params.h_stride * in_padded.width_;
-    const size_t inarea = in_padded.area();
+  assert(params.weight.height_ == 5 && params.weight.width_ == 5);
 
-    static const __m256 mask = _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
-    const __m128 y_bias_scale = _mm_set_ss(bias_scale);
-    if (out.height_ == 1 && out.width_ == 1) {
-        if (stride == 5) {
-            const float* pw = (const float*) &W[0];
-            for (size_t o=0; o<out.depth_; ++o) {
-                __m256 sum0 = _mm256_setzero_ps();
-                __m256 sum1 = _mm256_setzero_ps();
-                __m256 sum2 = _mm256_setzero_ps();
-                __m128 sum3 = _mm_setzero_ps();
-                const float* pi = (const float*) &in[0];
-                for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, pi += inarea) {
-                    if (!tbl.is_connected(o, inc)) {
-                        continue;
-                    }
-                    __m256 w0 = _mm256_loadu_ps(pw+0);
-                    __m256 w1 = _mm256_loadu_ps(pw+8);
-                    __m256 w2 = _mm256_loadu_ps(pw+16);
-                    __m256 i0 = _mm256_loadu_ps(pi+0);
-                    __m256 i1 = _mm256_loadu_ps(pi+8);
-                    __m256 i2 = _mm256_loadu_ps(pi+16);
-                    __m128 w3 = _mm_load_ss(pw+24);
-                    __m128 i3 = _mm_load_ss(pi+24);
-                    __m256 tmp0 = _mm256_mul_ps(w0, i0);
-                    __m256 tmp1 = _mm256_mul_ps(w1, i1);
-                    __m256 tmp2 = _mm256_mul_ps(w2, i2);
-                    __m128 tmp3 = _mm_mul_ps(w3, i3);
-                    sum0 = _mm256_add_ps(tmp0, sum0);
-                    sum1 = _mm256_add_ps(tmp1, sum1);
-                    sum2 = _mm256_add_ps(tmp2, sum2);
-                    sum3 = _mm_add_ps(tmp3, sum3);
-                }
-                __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), sum2);
-                __m128 b = _mm_load_ss(&bias[o]);
-                __m128 hsum = hsum256_ps(sum);
-                b = madd128_ss(b, y_bias_scale, sum3);
-                _mm_store_ss(&a[o], _mm_add_ss(hsum, b));
-            }
-        } else {
-            for (size_t o = 0; o < out.depth_; ++o) {
-                __m256 sum = _mm256_setzero_ps();
-                size_t widx = 25/* weight_.area() */ * params.in.depth_ * o;
-                size_t inidx = 0;
-                for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, widx += 25, inidx += inarea) {
-                    if (!tbl.is_connected(o, inc)) {
-                        continue;
-                    }
-                    const float* pw = (const float*) &W[widx];
-                    __m256 w0 = _mm256_loadu_ps(pw+0);
-                    __m256 w1 = _mm256_loadu_ps(pw+5);
-                    __m256 w2 = _mm256_loadu_ps(pw+10);
-                    __m256 w3 = _mm256_loadu_ps(pw+15);
-                    __m256 w4 = _mm256_loadu_ps(pw+20);
-                    w0 = _mm256_and_ps(w0, mask);
-                    w1 = _mm256_and_ps(w1, mask);
-                    w2 = _mm256_and_ps(w2, mask);
-                    w3 = _mm256_and_ps(w3, mask);
-                    w4 = _mm256_and_ps(w4, mask);
-                    const float* pi = (const float*) &in[inidx];
-                    __m256 i0 = _mm256_loadu_ps(pi + 0 * stride);
-                    __m256 i1 = _mm256_loadu_ps(pi + 1 * stride);
-                    __m256 i2 = _mm256_loadu_ps(pi + 2 * stride);
-                    __m256 i3 = _mm256_loadu_ps(pi + 3 * stride);
-                    __m256 i4 = _mm256_loadu_ps(pi + 4 * stride);
-                    __m256 sum0 = madd256_ps(w0, i0, sum);
-                    __m256 sum1 = _mm256_mul_ps(w1, i1);
-                    sum0 = madd256_ps(w2, i2, sum0);
-                    sum1 = madd256_ps(w3, i3, sum1);
-                    sum0 = madd256_ps(w4, i4, sum0);
-                    sum = _mm256_add_ps(sum0, sum1);
-                }
-                __m128 b = _mm_load_ss(&bias[o]);
-                __m128 hsum = hsum256_ps(sum);
-                hsum = madd128_ps(b, y_bias_scale, hsum);
-                _mm_store_ss(&a[o], hsum);
-            }
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+
+  const size_t out_area = out.area();
+  cnn_size_t oidx = 0;
+  float bias_scale = params.has_bias ? 1.0f : 0.0f;
+  const size_t stride = params.h_stride * in_padded.width_;
+  const size_t inarea = in_padded.area();
+
+  static const __m256 mask =
+      _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
+  const __m128 y_bias_scale = _mm_set_ss(bias_scale);
+  if (out.height_ == 1 && out.width_ == 1) {
+    if (stride == 5) {
+      const float* pw = (const float*)&W[0];
+      for (size_t o = 0; o < out.depth_; ++o) {
+        __m256 sum0 = _mm256_setzero_ps();
+        __m256 sum1 = _mm256_setzero_ps();
+        __m256 sum2 = _mm256_setzero_ps();
+        __m128 sum3 = _mm_setzero_ps();
+        const float* pi = (const float*)&in[0];
+        for (cnn_size_t inc = 0; inc < params.in.depth_;
+             ++inc, pw += 25, pi += inarea) {
+          if (!tbl.is_connected(o, inc)) {
+            continue;
+          }
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 8);
+          __m256 w2 = _mm256_loadu_ps(pw + 16);
+          __m256 i0 = _mm256_loadu_ps(pi + 0);
+          __m256 i1 = _mm256_loadu_ps(pi + 8);
+          __m256 i2 = _mm256_loadu_ps(pi + 16);
+          __m128 w3 = _mm_load_ss(pw + 24);
+          __m128 i3 = _mm_load_ss(pi + 24);
+          __m256 tmp0 = _mm256_mul_ps(w0, i0);
+          __m256 tmp1 = _mm256_mul_ps(w1, i1);
+          __m256 tmp2 = _mm256_mul_ps(w2, i2);
+          __m128 tmp3 = _mm_mul_ps(w3, i3);
+          sum0 = _mm256_add_ps(tmp0, sum0);
+          sum1 = _mm256_add_ps(tmp1, sum1);
+          sum2 = _mm256_add_ps(tmp2, sum2);
+          sum3 = _mm_add_ps(tmp3, sum3);
         }
+        __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), sum2);
+        __m128 b = _mm_load_ss(&bias[o]);
+        __m128 hsum = hsum256_ps(sum);
+        b = madd128_ss(b, y_bias_scale, sum3);
+        _mm_store_ss(&a[o], _mm_add_ss(hsum, b));
+      }
     } else {
-        const size_t nblocks = out.width_ / 4;
-        for (size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
-            float* pa = &a[oidx];
-            // init to bias value
-            float b = bias[o] * bias_scale;
-            {
-                size_t headSize = 0;
-                __m256 b2 = _mm256_set1_ps(b);
-                if (oidx & 7) {
-                    headSize = 8 - (oidx & 7);
-                    assert(headSize < out_area);
-                    for (size_t i=0; i<headSize; ++i) {
-                        _mm_store_ss(&pa[i], _mm256_castps256_ps128(b2));
-                    }
-                }
-                size_t cnt = (out_area - headSize) / 16;
-                float* pa2 = pa + headSize;
-                for (size_t i=0; i<cnt; ++i) {
-                    _mm256_store_ps(&pa2[i*16+0], b2);
-                    _mm256_store_ps(&pa2[i*16+8], b2);
-                }
-                for (size_t i=headSize+cnt*16; i<out_area; ++i) {
-                    pa[i] = b;
-                }
+      for (size_t o = 0; o < out.depth_; ++o) {
+        __m256 sum = _mm256_setzero_ps();
+        size_t widx = 25 /* weight_.area() */ * params.in.depth_ * o;
+        size_t inidx = 0;
+        for (cnn_size_t inc = 0; inc < params.in.depth_;
+             ++inc, widx += 25, inidx += inarea) {
+          if (!tbl.is_connected(o, inc)) {
+            continue;
+          }
+          const float* pw = (const float*)&W[widx];
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 5);
+          __m256 w2 = _mm256_loadu_ps(pw + 10);
+          __m256 w3 = _mm256_loadu_ps(pw + 15);
+          __m256 w4 = _mm256_loadu_ps(pw + 20);
+          w0 = _mm256_and_ps(w0, mask);
+          w1 = _mm256_and_ps(w1, mask);
+          w2 = _mm256_and_ps(w2, mask);
+          w3 = _mm256_and_ps(w3, mask);
+          w4 = _mm256_and_ps(w4, mask);
+          const float* pi = (const float*)&in[inidx];
+          __m256 i0 = _mm256_loadu_ps(pi + 0 * stride);
+          __m256 i1 = _mm256_loadu_ps(pi + 1 * stride);
+          __m256 i2 = _mm256_loadu_ps(pi + 2 * stride);
+          __m256 i3 = _mm256_loadu_ps(pi + 3 * stride);
+          __m256 i4 = _mm256_loadu_ps(pi + 4 * stride);
+          __m256 sum0 = madd256_ps(w0, i0, sum);
+          __m256 sum1 = _mm256_mul_ps(w1, i1);
+          sum0 = madd256_ps(w2, i2, sum0);
+          sum1 = madd256_ps(w3, i3, sum1);
+          sum0 = madd256_ps(w4, i4, sum0);
+          sum = _mm256_add_ps(sum0, sum1);
+        }
+        __m128 b = _mm_load_ss(&bias[o]);
+        __m128 hsum = hsum256_ps(sum);
+        hsum = madd128_ps(b, y_bias_scale, hsum);
+        _mm_store_ss(&a[o], hsum);
+      }
+    }
+  } else {
+    const size_t nblocks = out.width_ / 4;
+    for (size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
+      float* pa = &a[oidx];
+      // init to bias value
+      float b = bias[o] * bias_scale;
+      {
+        size_t headSize = 0;
+        __m256 b2 = _mm256_set1_ps(b);
+        if (oidx & 7) {
+          headSize = 8 - (oidx & 7);
+          assert(headSize < out_area);
+          for (size_t i = 0; i < headSize; ++i) {
+            _mm_store_ss(&pa[i], _mm256_castps256_ps128(b2));
+          }
+        }
+        size_t cnt = (out_area - headSize) / 16;
+        float* pa2 = pa + headSize;
+        for (size_t i = 0; i < cnt; ++i) {
+          _mm256_store_ps(&pa2[i * 16 + 0], b2);
+          _mm256_store_ps(&pa2[i * 16 + 8], b2);
+        }
+        for (size_t i = headSize + cnt * 16; i < out_area; ++i) {
+          pa[i] = b;
+        }
+      }
+      for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc) {
+        if (!tbl.is_connected(o, inc)) continue;
+
+        const float* pw = (const float*)&W[25 * (params.in.depth_ * o + inc)];
+        const float* pi = (const float*)&in[in_padded.get_index(0, 0, inc)];
+
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        __m256 w0b = leftShift<4>(w0a);
+        __m256 w1b = leftShift<4>(w1a);
+        __m256 w2b = leftShift<4>(w2a);
+        __m256 w3b = leftShift<4>(w3a);
+        __m256 w4b = leftShift<4>(w4a);
+        __m256 w0c = leftShift<8>(w0a);
+        __m256 w1c = leftShift<8>(w1a);
+        __m256 w2c = leftShift<8>(w2a);
+        __m256 w3c = leftShift<8>(w3a);
+        __m256 w4c = leftShift<8>(w4a);
+        __m256 w0d = leftShift<12>(w0a);
+        __m256 w1d = leftShift<12>(w1a);
+        __m256 w2d = leftShift<12>(w2a);
+        __m256 w3d = leftShift<12>(w3a);
+        __m256 w4d = leftShift<12>(w4a);
+        float* ppa = pa;
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          const float* pi0 = (pi + y * stride);
+          const float* pi1 = pi0 + 1 * stride;
+          const float* pi2 = pi0 + 2 * stride;
+          const float* pi3 = pi0 + 3 * stride;
+          const float* pi4 = pi0 + 4 * stride;
+          cnn_size_t x = 0;
+          if (w_stride == 1) {
+            __m256 dst0, dst1, dst2, dst3;
+            float* ppa2 = ppa;
+            for (size_t i = 0; i < nblocks; ++i) {
+              __m256 i0 = _mm256_loadu_ps(pi0);
+              __m256 i1 = _mm256_loadu_ps(pi1);
+              __m256 i2 = _mm256_loadu_ps(pi2);
+              __m256 i3 = _mm256_loadu_ps(pi3);
+              __m256 i4 = _mm256_loadu_ps(pi4);
+              __m128 sum = _mm_loadu_ps(ppa2);
+              dst0 = _mm256_mul_ps(w0a, i0);
+              dst1 = _mm256_mul_ps(w0b, i0);
+              dst2 = _mm256_mul_ps(w0c, i0);
+              dst3 = _mm256_mul_ps(w0d, i0);
+              dst0 = madd256_ps(w1a, i1, dst0);
+              dst1 = madd256_ps(w1b, i1, dst1);
+              dst2 = madd256_ps(w1c, i1, dst2);
+              dst3 = madd256_ps(w1d, i1, dst3);
+              dst0 = madd256_ps(w2a, i2, dst0);
+              dst1 = madd256_ps(w2b, i2, dst1);
+              dst2 = madd256_ps(w2c, i2, dst2);
+              dst3 = madd256_ps(w2d, i2, dst3);
+              dst0 = madd256_ps(w3a, i3, dst0);
+              dst1 = madd256_ps(w3b, i3, dst1);
+              dst2 = madd256_ps(w3c, i3, dst2);
+              dst3 = madd256_ps(w3d, i3, dst3);
+              dst0 = madd256_ps(w4a, i4, dst0);
+              dst1 = madd256_ps(w4b, i4, dst1);
+              __m128 hsum01 = hsum2x256_ps(dst0, dst1);
+              dst2 = madd256_ps(w4c, i4, dst2);
+              dst3 = madd256_ps(w4d, i4, dst3);
+              __m128 hsum23 = hsum2x256_ps(dst2, dst3);
+              __m128 sum2 = _mm_castpd_ps(_mm_unpacklo_pd(
+                  _mm_castps_pd(hsum01), _mm_castps_pd(hsum23)));
+              sum = _mm_add_ps(sum, sum2);
+              _mm_storeu_ps(ppa2, sum);
+              pi0 += 4;
+              pi1 += 4;
+              pi2 += 4;
+              pi3 += 4;
+              pi4 += 4;
+              ppa2 += 4;
             }
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc) {
-                if (!tbl.is_connected(o, inc)) continue;
-
-                const float* pw = (const float*) &W[25 * (params.in.depth_ * o + inc)];
-                const float* pi = (const float*) &in[in_padded.get_index(0, 0, inc)];
-
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                __m256 w0b = leftShift<4>(w0a);
-                __m256 w1b = leftShift<4>(w1a);
-                __m256 w2b = leftShift<4>(w2a);
-                __m256 w3b = leftShift<4>(w3a);
-                __m256 w4b = leftShift<4>(w4a);
-                __m256 w0c = leftShift<8>(w0a);
-                __m256 w1c = leftShift<8>(w1a);
-                __m256 w2c = leftShift<8>(w2a);
-                __m256 w3c = leftShift<8>(w3a);
-                __m256 w4c = leftShift<8>(w4a);
-                __m256 w0d = leftShift<12>(w0a);
-                __m256 w1d = leftShift<12>(w1a);
-                __m256 w2d = leftShift<12>(w2a);
-                __m256 w3d = leftShift<12>(w3a);
-                __m256 w4d = leftShift<12>(w4a);
-                float* ppa = pa;
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    const float* pi0 = (pi + y * stride);
-                    const float* pi1 = pi0 + 1 * stride;
-                    const float* pi2 = pi0 + 2 * stride;
-                    const float* pi3 = pi0 + 3 * stride;
-                    const float* pi4 = pi0 + 4 * stride;
-                    cnn_size_t x = 0;
-                    if (w_stride == 1) {
-                        __m256 dst0, dst1, dst2, dst3;
-                        float* ppa2 = ppa;
-                        for (size_t i = 0; i < nblocks; ++i) {
-                            __m256 i0 = _mm256_loadu_ps(pi0);
-                            __m256 i1 = _mm256_loadu_ps(pi1);
-                            __m256 i2 = _mm256_loadu_ps(pi2);
-                            __m256 i3 = _mm256_loadu_ps(pi3);
-                            __m256 i4 = _mm256_loadu_ps(pi4);
-                            __m128 sum = _mm_loadu_ps(ppa2);
-                            dst0 = _mm256_mul_ps(w0a, i0);
-                            dst1 = _mm256_mul_ps(w0b, i0);
-                            dst2 = _mm256_mul_ps(w0c, i0);
-                            dst3 = _mm256_mul_ps(w0d, i0);
-                            dst0 = madd256_ps(w1a, i1, dst0);
-                            dst1 = madd256_ps(w1b, i1, dst1);
-                            dst2 = madd256_ps(w1c, i1, dst2);
-                            dst3 = madd256_ps(w1d, i1, dst3);
-                            dst0 = madd256_ps(w2a, i2, dst0);
-                            dst1 = madd256_ps(w2b, i2, dst1);
-                            dst2 = madd256_ps(w2c, i2, dst2);
-                            dst3 = madd256_ps(w2d, i2, dst3);
-                            dst0 = madd256_ps(w3a, i3, dst0);
-                            dst1 = madd256_ps(w3b, i3, dst1);
-                            dst2 = madd256_ps(w3c, i3, dst2);
-                            dst3 = madd256_ps(w3d, i3, dst3);
-                            dst0 = madd256_ps(w4a, i4, dst0);
-                            dst1 = madd256_ps(w4b, i4, dst1);
-                            __m128 hsum01 = hsum2x256_ps(dst0, dst1);
-                            dst2 = madd256_ps(w4c, i4, dst2);
-                            dst3 = madd256_ps(w4d, i4, dst3);
-                            __m128 hsum23 = hsum2x256_ps(dst2, dst3);
-                            __m128 sum2 = _mm_castpd_ps(_mm_unpacklo_pd(_mm_castps_pd(hsum01), _mm_castps_pd(hsum23)));
-                            sum = _mm_add_ps(sum, sum2);
-                            _mm_storeu_ps(ppa2, sum);
-                            pi0 += 4;
-                            pi1 += 4;
-                            pi2 += 4;
-                            pi3 += 4;
-                            pi4 += 4;
-                            ppa2 += 4;
-                        }
-                        x = nblocks * 4;
-                    }
-                    for (; x < out.width_; ++x) {
-                        __m128 sum = _mm_load_ss(&ppa[x]);
-                        __m256 i0 = _mm256_loadu_ps(pi0);
-                        __m256 i1 = _mm256_loadu_ps(pi1);
-                        __m256 i2 = _mm256_loadu_ps(pi2);
-                        __m256 i3 = _mm256_loadu_ps(pi3);
-                        __m256 i4 = _mm256_loadu_ps(pi4);
-                        __m256 sum0 = _mm256_mul_ps(w0a, i0);
-                        __m256 sum1 = _mm256_mul_ps(w1a, i1);
-                        sum0 = madd256_ps(w2a, i2, sum0);
-                        sum1 = madd256_ps(w3a, i3, sum1);
-                        sum0 = madd256_ps(w4a, i4, sum0);
-                        sum0 = _mm256_add_ps(sum0, sum1);
-                        _mm_store_ss(&ppa[x], _mm_add_ss(sum, hsum256_ps(sum0)));
-//                      printf("%d %d %d %f\n", inc, y, x, ppa[x]);
-                        pi0 += w_stride;
-                        pi1 += w_stride;
-                        pi2 += w_stride;
-                        pi3 += w_stride;
-                        pi4 += w_stride;
-                    } // x loop
-                    ppa += out.width_;
-                } // y loop
-            } // in depth loop
-        } // out depth loop
-    } // else
-} // avx_conv2d_5x5_kernel float ver
+            x = nblocks * 4;
+          }
+          for (; x < out.width_; ++x) {
+            __m128 sum = _mm_load_ss(&ppa[x]);
+            __m256 i0 = _mm256_loadu_ps(pi0);
+            __m256 i1 = _mm256_loadu_ps(pi1);
+            __m256 i2 = _mm256_loadu_ps(pi2);
+            __m256 i3 = _mm256_loadu_ps(pi3);
+            __m256 i4 = _mm256_loadu_ps(pi4);
+            __m256 sum0 = _mm256_mul_ps(w0a, i0);
+            __m256 sum1 = _mm256_mul_ps(w1a, i1);
+            sum0 = madd256_ps(w2a, i2, sum0);
+            sum1 = madd256_ps(w3a, i3, sum1);
+            sum0 = madd256_ps(w4a, i4, sum0);
+            sum0 = _mm256_add_ps(sum0, sum1);
+            _mm_store_ss(&ppa[x], _mm_add_ss(sum, hsum256_ps(sum0)));
+            //                      printf("%d %d %d %f\n", inc, y, x, ppa[x]);
+            pi0 += w_stride;
+            pi1 += w_stride;
+            pi2 += w_stride;
+            pi3 += w_stride;
+            pi4 += w_stride;
+          }  // x loop
+          ppa += out.width_;
+        }  // y loop
+      }    // in depth loop
+    }      // out depth loop
+  }        // else
+}  // avx_conv2d_5x5_kernel float ver
 
 // double ver
 template <typename Allocator>
@@ -249,222 +253,225 @@ void avx_conv2d_5x5_kernel(const conv_params& params,
                            const std::vector<double, Allocator>& in,
                            const std::vector<double, Allocator>& W,
                            const std::vector<double, Allocator>& bias,
-                           std::vector<double, Allocator>&       a,
+                           std::vector<double, Allocator>& a,
                            const bool layer_parallelize) {
-    assert(params.weight.height_ == 5 && params.weight.width_ == 5);
-    
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    
-    const size_t out_area = out.area();
-    double bias_scale = params.has_bias ? 1.0 : 0.0;
-    const __m128d y_bias_scale = _mm_set_sd(bias_scale);
-    cnn_size_t oidx = 0;
+  assert(params.weight.height_ == 5 && params.weight.width_ == 5);
 
-    const double* pw = &W[0];
-    const size_t in_stride = params.h_stride * in_padded.width_;
-    const size_t in_padded_area = in_padded.area();
-    if (out.height_ == 1 && out.width_ == 1) {
-        if (in_stride == 5) {
-            for (size_t o = 0; o < out.depth_; ++o) {
-                __m256d sum0 = _mm256_setzero_pd();
-                __m256d sum1 = _mm256_setzero_pd();
-                __m256d sum2 = _mm256_setzero_pd();
-                __m256d sum3 = _mm256_setzero_pd();
-                __m256d sum4 = _mm256_setzero_pd();
-                __m256d sum5 = _mm256_setzero_pd();
-                __m128d sum6 = _mm_setzero_pd();
-                size_t inidx = 0;
-                for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, inidx += in_padded_area) {
-                    if (!tbl.is_connected(o, inc)) {
-                        continue;
-                    }
-                    __m256d w0 = _mm256_loadu_pd(pw+0);
-                    __m256d w1 = _mm256_loadu_pd(pw+4);
-                    __m256d w2 = _mm256_loadu_pd(pw+8);
-                    __m256d w3 = _mm256_loadu_pd(pw+12);
-                    __m256d w4 = _mm256_loadu_pd(pw+16);
-                    __m256d w5 = _mm256_loadu_pd(pw+20);
-                    __m128d w6 = _mm_load_sd(pw+24);
-                    const double* pi = (const double*) &in[inidx];
-                    __m256d i0 = _mm256_loadu_pd(pi+0);
-                    __m256d i1 = _mm256_loadu_pd(pi+4);
-                    __m256d i2 = _mm256_loadu_pd(pi+8);
-                    __m256d i3 = _mm256_loadu_pd(pi+12);
-                    __m256d i4 = _mm256_loadu_pd(pi+16);
-                    __m256d i5 = _mm256_loadu_pd(pi+20);
-                    __m128d i6 = _mm_load_sd(pi+24);
-                    __m256d tmp0 = _mm256_mul_pd(w0, i0);
-                    __m256d tmp1 = _mm256_mul_pd(w1, i1);
-                    __m256d tmp2 = _mm256_mul_pd(w2, i2);
-                    __m256d tmp3 = _mm256_mul_pd(w3, i3);
-                    __m256d tmp4 = _mm256_mul_pd(w4, i4);
-                    __m256d tmp5 = _mm256_mul_pd(w5, i5);
-                    __m128d tmp6 = _mm_mul_pd(w6, i6);
-                    sum0 = _mm256_add_pd(tmp0, sum0);
-                    sum1 = _mm256_add_pd(tmp1, sum1);
-                    sum2 = _mm256_add_pd(tmp2, sum2);
-                    sum3 = _mm256_add_pd(tmp3, sum3);
-                    sum4 = _mm256_add_pd(tmp4, sum4);
-                    sum5 = _mm256_add_pd(tmp5, sum5);
-                    sum6 = _mm_add_pd(tmp6, sum6);
-                }
-                sum0 = _mm256_add_pd(sum0, sum1);
-                sum2 = _mm256_add_pd(sum2, sum3);
-                sum4 = _mm256_add_pd(sum4, sum5);
-                sum0 = _mm256_add_pd(sum0, sum2);
-                __m256d sum = _mm256_add_pd(sum0, sum4);
-                __m128d b = _mm_load_sd(&bias[o]);
-                __m128d hsum = hsum256_pd(sum);
-                b = madd128_sd(b, y_bias_scale, sum6);
-                _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
-            }
-        } else {
-            for (size_t o=0; o<out.depth_; ++o) {
-                __m256d sum_a = _mm256_setzero_pd();
-                __m128d sum_b = _mm_setzero_pd();
-                size_t inidx = 0;
-                for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, inidx += in_padded_area) {
-                    if (!tbl.is_connected(o, inc)) {
-                        continue;
-                    }
-                    __m256d w0a = _mm256_loadu_pd(pw+0);
-                    __m128d w0b = _mm_load_sd(pw+4);
-                    __m256d w1a = _mm256_loadu_pd(pw+5);
-                    __m128d w1b = _mm_load_sd(pw+9);
-                    __m256d w2a = _mm256_loadu_pd(pw+10);
-                    __m128d w2b = _mm_load_sd(pw+14);
-                    __m256d w3a = _mm256_loadu_pd(pw+15);
-                    __m128d w3b = _mm_load_sd(pw+19);
-                    __m256d w4a = _mm256_loadu_pd(pw+20);
-                    __m128d w4b = _mm_load_sd(pw+24);
-                    const double* pi = (const double*) &in[inidx];
-                    __m256d i0a = _mm256_loadu_pd(pi + 0 * in_stride);
-                    __m128d i0b = _mm_load_sd(pi + 0 * in_stride + 4);
-                    __m256d i1a = _mm256_loadu_pd(pi + 1 * in_stride);
-                    __m128d i1b = _mm_load_sd(pi + 1 * in_stride + 4);
-                    __m256d i2a = _mm256_loadu_pd(pi + 2 * in_stride);
-                    __m128d i2b = _mm_load_sd(pi + 2 * in_stride + 4);
-                    __m256d i3a = _mm256_loadu_pd(pi + 3 * in_stride);
-                    __m128d i3b = _mm_load_sd(pi + 3 * in_stride + 4);
-                    __m256d i4a = _mm256_loadu_pd(pi + 4 * in_stride);
-                    __m128d i4b = _mm_load_sd(pi + 4 * in_stride + 4);
-                    sum_a = madd256_pd(w0a, i0a, sum_a);
-                    sum_b = madd128_pd(w0b, i0b, sum_b);
-                    sum_a = madd256_pd(w1a, i1a, sum_a);
-                    sum_b = madd128_pd(w1b, i1b, sum_b);
-                    sum_a = madd256_pd(w2a, i2a, sum_a);
-                    sum_b = madd128_pd(w2b, i2b, sum_b);
-                    sum_a = madd256_pd(w3a, i3a, sum_a);
-                    sum_b = madd128_pd(w3b, i3b, sum_b);
-                    sum_a = madd256_pd(w4a, i4a, sum_a);
-                    sum_b = madd128_pd(w4b, i4b, sum_b);
-                }
-                __m128d b = _mm_load_sd(&bias[o]);
-                __m128d hsum = hsum256_pd(sum_a);
-                b = _mm_fmadd_sd(b, y_bias_scale, sum_b);
-                _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
-            }
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+
+  const size_t out_area = out.area();
+  double bias_scale = params.has_bias ? 1.0 : 0.0;
+  const __m128d y_bias_scale = _mm_set_sd(bias_scale);
+  cnn_size_t oidx = 0;
+
+  const double* pw = &W[0];
+  const size_t in_stride = params.h_stride * in_padded.width_;
+  const size_t in_padded_area = in_padded.area();
+  if (out.height_ == 1 && out.width_ == 1) {
+    if (in_stride == 5) {
+      for (size_t o = 0; o < out.depth_; ++o) {
+        __m256d sum0 = _mm256_setzero_pd();
+        __m256d sum1 = _mm256_setzero_pd();
+        __m256d sum2 = _mm256_setzero_pd();
+        __m256d sum3 = _mm256_setzero_pd();
+        __m256d sum4 = _mm256_setzero_pd();
+        __m256d sum5 = _mm256_setzero_pd();
+        __m128d sum6 = _mm_setzero_pd();
+        size_t inidx = 0;
+        for (cnn_size_t inc = 0; inc < params.in.depth_;
+             ++inc, pw += 25, inidx += in_padded_area) {
+          if (!tbl.is_connected(o, inc)) {
+            continue;
+          }
+          __m256d w0 = _mm256_loadu_pd(pw + 0);
+          __m256d w1 = _mm256_loadu_pd(pw + 4);
+          __m256d w2 = _mm256_loadu_pd(pw + 8);
+          __m256d w3 = _mm256_loadu_pd(pw + 12);
+          __m256d w4 = _mm256_loadu_pd(pw + 16);
+          __m256d w5 = _mm256_loadu_pd(pw + 20);
+          __m128d w6 = _mm_load_sd(pw + 24);
+          const double* pi = (const double*)&in[inidx];
+          __m256d i0 = _mm256_loadu_pd(pi + 0);
+          __m256d i1 = _mm256_loadu_pd(pi + 4);
+          __m256d i2 = _mm256_loadu_pd(pi + 8);
+          __m256d i3 = _mm256_loadu_pd(pi + 12);
+          __m256d i4 = _mm256_loadu_pd(pi + 16);
+          __m256d i5 = _mm256_loadu_pd(pi + 20);
+          __m128d i6 = _mm_load_sd(pi + 24);
+          __m256d tmp0 = _mm256_mul_pd(w0, i0);
+          __m256d tmp1 = _mm256_mul_pd(w1, i1);
+          __m256d tmp2 = _mm256_mul_pd(w2, i2);
+          __m256d tmp3 = _mm256_mul_pd(w3, i3);
+          __m256d tmp4 = _mm256_mul_pd(w4, i4);
+          __m256d tmp5 = _mm256_mul_pd(w5, i5);
+          __m128d tmp6 = _mm_mul_pd(w6, i6);
+          sum0 = _mm256_add_pd(tmp0, sum0);
+          sum1 = _mm256_add_pd(tmp1, sum1);
+          sum2 = _mm256_add_pd(tmp2, sum2);
+          sum3 = _mm256_add_pd(tmp3, sum3);
+          sum4 = _mm256_add_pd(tmp4, sum4);
+          sum5 = _mm256_add_pd(tmp5, sum5);
+          sum6 = _mm_add_pd(tmp6, sum6);
         }
+        sum0 = _mm256_add_pd(sum0, sum1);
+        sum2 = _mm256_add_pd(sum2, sum3);
+        sum4 = _mm256_add_pd(sum4, sum5);
+        sum0 = _mm256_add_pd(sum0, sum2);
+        __m256d sum = _mm256_add_pd(sum0, sum4);
+        __m128d b = _mm_load_sd(&bias[o]);
+        __m128d hsum = hsum256_pd(sum);
+        b = madd128_sd(b, y_bias_scale, sum6);
+        _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
+      }
     } else {
-        for (cnn_size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
-            double* pa = &a[oidx];
-            double b = bias[o] * bias_scale;
-            {
-                size_t headSize = 0;
-                __m256d b2 = _mm256_set1_pd(b);
-                if (oidx & 3) {
-                    headSize = 4 - (oidx & 3);
-                    assert(headSize < out_area);
-                    for (size_t i = 0; i < headSize; ++i) {
-                        _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
-                    }
-                }
-                size_t cnt = (out_area - headSize) / 8;
-                double* pa2 = pa + headSize;
-                for (size_t i = 0; i < cnt; ++i) {
-                    _mm256_store_pd(&pa2[i*8+0], b2);
-                    _mm256_store_pd(&pa2[i*8+4], b2);
-                }
-                for (size_t i = headSize + cnt*8; i < out_area; ++i) {
-                    _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
-                }
-            }
-            const double* pi0 = &in[0];
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, pi0 += in_padded_area) {
-                if (!tbl.is_connected(o, inc)) continue;
-                __m256d w0a = _mm256_loadu_pd(pw+0);
-                __m128d w0b = _mm_load_sd(pw+4);
-                __m256d w1a = _mm256_loadu_pd(pw+5);
-                __m128d w1b = _mm_load_sd(pw+9);
-                __m256d w2a = _mm256_loadu_pd(pw+10);
-                __m128d w2b = _mm_load_sd(pw+14);
-                __m256d w3a = _mm256_loadu_pd(pw+15);
-                __m128d w3b = _mm_load_sd(pw+19);
-                __m256d w4a = _mm256_loadu_pd(pw+20);
-                __m128d w4b = _mm_load_sd(pw+24);
-                const double* pi = pi0;
-                double* pa2 = pa;
-                for (cnn_size_t y = 0; y < out.height_; ++y, pi += in_stride, pa2 += out.width_) {
-                    const double* pi1 = pi + 1 * in_stride;
-                    const double* pi2 = pi + 2 * in_stride;
-                    const double* pi3 = pi + 3 * in_stride;
-                    const double* pi4 = pi + 4 * in_stride;
-                    for (cnn_size_t x = 0; x < out.width_; ++x) {
-                        __m128d sum = _mm_load_sd(&pa2[x]);
-                        __m256d i0a = _mm256_loadu_pd(pi);
-                        __m128d i0b = _mm_load_sd(pi + 4);
-                        __m256d i1a = _mm256_loadu_pd(pi1);
-                        __m128d i1b = _mm_load_sd(pi1 + 4);
-                        __m256d i2a = _mm256_loadu_pd(pi2);
-                        __m128d i2b = _mm_load_sd(pi2 + 4);
-                        __m256d i3a = _mm256_loadu_pd(pi3);
-                        __m128d i3b = _mm_load_sd(pi3 + 4);
-                        __m256d i4a = _mm256_loadu_pd(pi4);
-                        __m128d i4b = _mm_load_sd(pi4 + 4);
-                        __m256d sum_a = _mm256_mul_pd(w0a, i0a);
-                        __m128d sum_b = _mm_mul_sd(w0b, i0b);
-                        sum_a = madd256_pd(w1a, i1a, sum_a);
-                        sum_b = madd128_pd(w1b, i1b, sum_b);
-                        sum_a = madd256_pd(w2a, i2a, sum_a);
-                        sum_b = madd128_pd(w2b, i2b, sum_b);
-                        sum_a = madd256_pd(w3a, i3a, sum_a);
-                        sum_b = madd128_pd(w3b, i3b, sum_b);
-                        sum_a = madd256_pd(w4a, i4a, sum_a);
-                        sum_b = madd128_pd(w4b, i4b, sum_b);
-                        __m128d sum_c = hsum256_pd(sum_a);
-                        sum = _mm_add_sd(sum, sum_b);
-                        _mm_store_sd(&pa2[x], _mm_add_sd(sum, sum_c));
-                        pi0 += w_stride;
-                        pi1 += w_stride;
-                        pi2 += w_stride;
-                        pi3 += w_stride;
-                        pi4 += w_stride;
-                    } // x loop
-                } // y loop
-            } // in depth loop
-        } // out depth loop
-    } // else
-} // avx_conv2d_5x5_kernel double ver
+      for (size_t o = 0; o < out.depth_; ++o) {
+        __m256d sum_a = _mm256_setzero_pd();
+        __m128d sum_b = _mm_setzero_pd();
+        size_t inidx = 0;
+        for (cnn_size_t inc = 0; inc < params.in.depth_;
+             ++inc, pw += 25, inidx += in_padded_area) {
+          if (!tbl.is_connected(o, inc)) {
+            continue;
+          }
+          __m256d w0a = _mm256_loadu_pd(pw + 0);
+          __m128d w0b = _mm_load_sd(pw + 4);
+          __m256d w1a = _mm256_loadu_pd(pw + 5);
+          __m128d w1b = _mm_load_sd(pw + 9);
+          __m256d w2a = _mm256_loadu_pd(pw + 10);
+          __m128d w2b = _mm_load_sd(pw + 14);
+          __m256d w3a = _mm256_loadu_pd(pw + 15);
+          __m128d w3b = _mm_load_sd(pw + 19);
+          __m256d w4a = _mm256_loadu_pd(pw + 20);
+          __m128d w4b = _mm_load_sd(pw + 24);
+          const double* pi = (const double*)&in[inidx];
+          __m256d i0a = _mm256_loadu_pd(pi + 0 * in_stride);
+          __m128d i0b = _mm_load_sd(pi + 0 * in_stride + 4);
+          __m256d i1a = _mm256_loadu_pd(pi + 1 * in_stride);
+          __m128d i1b = _mm_load_sd(pi + 1 * in_stride + 4);
+          __m256d i2a = _mm256_loadu_pd(pi + 2 * in_stride);
+          __m128d i2b = _mm_load_sd(pi + 2 * in_stride + 4);
+          __m256d i3a = _mm256_loadu_pd(pi + 3 * in_stride);
+          __m128d i3b = _mm_load_sd(pi + 3 * in_stride + 4);
+          __m256d i4a = _mm256_loadu_pd(pi + 4 * in_stride);
+          __m128d i4b = _mm_load_sd(pi + 4 * in_stride + 4);
+          sum_a = madd256_pd(w0a, i0a, sum_a);
+          sum_b = madd128_pd(w0b, i0b, sum_b);
+          sum_a = madd256_pd(w1a, i1a, sum_a);
+          sum_b = madd128_pd(w1b, i1b, sum_b);
+          sum_a = madd256_pd(w2a, i2a, sum_a);
+          sum_b = madd128_pd(w2b, i2b, sum_b);
+          sum_a = madd256_pd(w3a, i3a, sum_a);
+          sum_b = madd128_pd(w3b, i3b, sum_b);
+          sum_a = madd256_pd(w4a, i4a, sum_a);
+          sum_b = madd128_pd(w4b, i4b, sum_b);
+        }
+        __m128d b = _mm_load_sd(&bias[o]);
+        __m128d hsum = hsum256_pd(sum_a);
+        b = _mm_fmadd_sd(b, y_bias_scale, sum_b);
+        _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
+      }
+    }
+  } else {
+    for (cnn_size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
+      double* pa = &a[oidx];
+      double b = bias[o] * bias_scale;
+      {
+        size_t headSize = 0;
+        __m256d b2 = _mm256_set1_pd(b);
+        if (oidx & 3) {
+          headSize = 4 - (oidx & 3);
+          assert(headSize < out_area);
+          for (size_t i = 0; i < headSize; ++i) {
+            _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
+          }
+        }
+        size_t cnt = (out_area - headSize) / 8;
+        double* pa2 = pa + headSize;
+        for (size_t i = 0; i < cnt; ++i) {
+          _mm256_store_pd(&pa2[i * 8 + 0], b2);
+          _mm256_store_pd(&pa2[i * 8 + 4], b2);
+        }
+        for (size_t i = headSize + cnt * 8; i < out_area; ++i) {
+          _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
+        }
+      }
+      const double* pi0 = &in[0];
+      for (cnn_size_t inc = 0; inc < params.in.depth_;
+           ++inc, pw += 25, pi0 += in_padded_area) {
+        if (!tbl.is_connected(o, inc)) continue;
+        __m256d w0a = _mm256_loadu_pd(pw + 0);
+        __m128d w0b = _mm_load_sd(pw + 4);
+        __m256d w1a = _mm256_loadu_pd(pw + 5);
+        __m128d w1b = _mm_load_sd(pw + 9);
+        __m256d w2a = _mm256_loadu_pd(pw + 10);
+        __m128d w2b = _mm_load_sd(pw + 14);
+        __m256d w3a = _mm256_loadu_pd(pw + 15);
+        __m128d w3b = _mm_load_sd(pw + 19);
+        __m256d w4a = _mm256_loadu_pd(pw + 20);
+        __m128d w4b = _mm_load_sd(pw + 24);
+        const double* pi = pi0;
+        double* pa2 = pa;
+        for (cnn_size_t y = 0; y < out.height_;
+             ++y, pi += in_stride, pa2 += out.width_) {
+          const double* pi1 = pi + 1 * in_stride;
+          const double* pi2 = pi + 2 * in_stride;
+          const double* pi3 = pi + 3 * in_stride;
+          const double* pi4 = pi + 4 * in_stride;
+          for (cnn_size_t x = 0; x < out.width_; ++x) {
+            __m128d sum = _mm_load_sd(&pa2[x]);
+            __m256d i0a = _mm256_loadu_pd(pi);
+            __m128d i0b = _mm_load_sd(pi + 4);
+            __m256d i1a = _mm256_loadu_pd(pi1);
+            __m128d i1b = _mm_load_sd(pi1 + 4);
+            __m256d i2a = _mm256_loadu_pd(pi2);
+            __m128d i2b = _mm_load_sd(pi2 + 4);
+            __m256d i3a = _mm256_loadu_pd(pi3);
+            __m128d i3b = _mm_load_sd(pi3 + 4);
+            __m256d i4a = _mm256_loadu_pd(pi4);
+            __m128d i4b = _mm_load_sd(pi4 + 4);
+            __m256d sum_a = _mm256_mul_pd(w0a, i0a);
+            __m128d sum_b = _mm_mul_sd(w0b, i0b);
+            sum_a = madd256_pd(w1a, i1a, sum_a);
+            sum_b = madd128_pd(w1b, i1b, sum_b);
+            sum_a = madd256_pd(w2a, i2a, sum_a);
+            sum_b = madd128_pd(w2b, i2b, sum_b);
+            sum_a = madd256_pd(w3a, i3a, sum_a);
+            sum_b = madd128_pd(w3b, i3b, sum_b);
+            sum_a = madd256_pd(w4a, i4a, sum_a);
+            sum_b = madd128_pd(w4b, i4b, sum_b);
+            __m128d sum_c = hsum256_pd(sum_a);
+            sum = _mm_add_sd(sum, sum_b);
+            _mm_store_sd(&pa2[x], _mm_add_sd(sum, sum_c));
+            pi0 += w_stride;
+            pi1 += w_stride;
+            pi2 += w_stride;
+            pi3 += w_stride;
+            pi4 += w_stride;
+          }  // x loop
+        }    // y loop
+      }      // in depth loop
+    }        // out depth loop
+  }          // else
+}  // avx_conv2d_5x5_kernel double ver
 
 inline void avx_conv2d_kernel(const conv_params& params,
                               const std::vector<const vec_t*>& in_data,
-                              const vec_t& W,
-                              const vec_t& bias,
-                              tensor_t&    out_data,
-                              const bool   layer_parallelize) {
-    
-    if (params.weight.height_ == 5 && params.weight.width_ == 5) {
-        // @todo consider better parallelization
-        for_i(layer_parallelize, in_data.size(), [&](int i) {
-            avx_conv2d_5x5_kernel(params, *in_data[i], W, bias, out_data[i], layer_parallelize);
-        });
-        return;
-    }
+                              const vec_t& W, const vec_t& bias,
+                              tensor_t& out_data,
+                              const bool layer_parallelize) {
+  if (params.weight.height_ == 5 && params.weight.width_ == 5) {
+    // @todo consider better parallelization
+    for_i(layer_parallelize, in_data.size(), [&](int i) {
+      avx_conv2d_5x5_kernel(params, *in_data[i], W, bias, out_data[i],
+                            layer_parallelize);
+    });
+    return;
+  }
 
-    tiny_conv2d_kernel(params, in_data, W, bias, out_data, layer_parallelize);
+  tiny_conv2d_kernel(params, in_data, W, bias, out_data, layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/avx_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/avx_conv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/core/kernels/avx_deconv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/avx_deconv2d_back_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/avx_deconv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/avx_deconv2d_back_kernel.h
@@ -11,14 +11,13 @@ namespace core {
 namespace kernels {
 
 inline void avx_deconv2d_back_kernel(const deconv_params& params,
-                                     const tensor_t& prev_out,
-                                     const vec_t& W,
-                                     tensor_t&       dW,
-                                     tensor_t&       db,
-                                     tensor_t&       curr_delta,
-                                     tensor_t*       prev_delta) {
-    // fallback to non-avx version
-    tiny_deconv2d_back_kernel(params, prev_out, W, dW, db, curr_delta, prev_delta);
+                                     const tensor_t& prev_out, const vec_t& W,
+                                     tensor_t& dW, tensor_t& db,
+                                     tensor_t& curr_delta,
+                                     tensor_t* prev_delta) {
+  // fallback to non-avx version
+  tiny_deconv2d_back_kernel(params, prev_out, W, dW, db, curr_delta,
+                            prev_delta);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/avx_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/avx_deconv2d_kernel.h
@@ -4,21 +4,18 @@
 
 #pragma once
 
-#include "tiny_dnn/core/params/deconv_params.h"
 #include "tiny_dnn/core/kernels/tiny_deconv2d_kernel.h"
+#include "tiny_dnn/core/params/deconv_params.h"
 
 namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-inline void avx_deconv2d_kernel(const deconv_params& params,
-                                const tensor_t& in,
-                                const vec_t& W,
-                                const vec_t& bias,
-                                tensor_t&    a,
-                                const bool   layer_parallelize) {
-    // fallback to non-avx version
-    tiny_deconv2d_kernel(params, in, W, bias, a, layer_parallelize);
+inline void avx_deconv2d_kernel(const deconv_params& params, const tensor_t& in,
+                                const vec_t& W, const vec_t& bias, tensor_t& a,
+                                const bool layer_parallelize) {
+  // fallback to non-avx version
+  tiny_deconv2d_kernel(params, in, W, bias, a, layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/avx_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/avx_deconv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/avx_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/avx_fully_connected_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/avx_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/avx_fully_connected_kernel.h
@@ -4,31 +4,28 @@
 
 #pragma once
 
-#include "tiny_dnn/core/params/fully_params.h"
 #include "tiny_dnn/core/kernels/tiny_fully_connected_kernel.h"
+#include "tiny_dnn/core/params/fully_params.h"
 
 namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
 inline void avx_fully_connected_kernel(const fully_params& params,
-                                       const tensor_t& in,
-                                       const vec_t&    W,
-                                       const vec_t&    b,
-                                       tensor_t&       a,
-                                       const bool      layer_parallelize) {
-    tiny_fully_connected_kernel(params, in, W, b, a, layer_parallelize);
+                                       const tensor_t& in, const vec_t& W,
+                                       const vec_t& b, tensor_t& a,
+                                       const bool layer_parallelize) {
+  tiny_fully_connected_kernel(params, in, W, b, a, layer_parallelize);
 }
 
 inline void avx_fully_connected_back_kernel(const fully_params& params,
                                             const tensor_t& prev_out,
-                                            const vec_t&    W,
-                                            tensor_t&       dW,
-                                            tensor_t&       prev_delta,
-                                            tensor_t&       curr_delta,
-                                            tensor_t&       db,
-                                            const bool      layer_parallelize) {
-    tiny_fully_connected_back_kernel(params, prev_out, W, dW, prev_delta, curr_delta, db, layer_parallelize);
+                                            const vec_t& W, tensor_t& dW,
+                                            tensor_t& prev_delta,
+                                            tensor_t& curr_delta, tensor_t& db,
+                                            const bool layer_parallelize) {
+  tiny_fully_connected_back_kernel(params, prev_out, W, dW, prev_delta,
+                                   curr_delta, db, layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/avx_kernel_common.h
+++ b/tiny_dnn/core/kernels/avx_kernel_common.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #ifndef CNN_USE_AVX

--- a/tiny_dnn/core/kernels/avx_kernel_common.h
+++ b/tiny_dnn/core/kernels/avx_kernel_common.h
@@ -10,302 +10,298 @@
 
 #ifndef _mm256_set_m128
 #define _mm256_set_m128(va, vb) \
-        _mm256_insertf128_ps(_mm256_castps128_ps256(vb), va, 1)
+  _mm256_insertf128_ps(_mm256_castps128_ps256(vb), va, 1)
 #endif
 
 inline __m256 madd256_ps(__m256 a, __m256 b, __m256 c) {
-    return _mm256_add_ps(_mm256_mul_ps(a, b), c);
+  return _mm256_add_ps(_mm256_mul_ps(a, b), c);
 }
 inline __m128 madd128_ps(__m128 a, __m128 b, __m128 c) {
-    return _mm_add_ps(_mm_mul_ps(a, b), c);
+  return _mm_add_ps(_mm_mul_ps(a, b), c);
 }
 inline __m128 madd128_ss(__m128 a, __m128 b, __m128 c) {
-    return _mm_add_ss(_mm_mul_ss(a, b), c);
+  return _mm_add_ss(_mm_mul_ss(a, b), c);
 }
 inline __m256d madd256_pd(__m256d a, __m256d b, __m256d c) {
-    return _mm256_add_pd(_mm256_mul_pd(a, b), c);
+  return _mm256_add_pd(_mm256_mul_pd(a, b), c);
 }
 inline __m128d madd128_pd(__m128d a, __m128d b, __m128d c) {
-    return _mm_add_pd(_mm_mul_pd(a, b), c);
+  return _mm_add_pd(_mm_mul_pd(a, b), c);
 }
 inline __m128d madd128_sd(__m128d a, __m128d b, __m128d c) {
-    return _mm_add_sd(_mm_mul_sd(a, b), c);
+  return _mm_add_sd(_mm_mul_sd(a, b), c);
 }
 
-// Horizontally add elements of __m256 type argument (sadly, _mm256_hadd_ps isn't good enough)
+// Horizontally add elements of __m256 type argument (sadly, _mm256_hadd_ps
+// isn't good enough)
 // http://stackoverflow.com/a/13222410/4699324
 // x = ( x7, x6, x5, x4, x3, x2, x1, x0 )
 inline __m128 hsum256_ps(__m256 x) {
-    // hiQuad = ( x7, x6, x5, x4 )
-    const __m128 hiQuad = _mm256_extractf128_ps(x, 1);
-    // loQuad = ( x3, x2, x1, x0 )
-    const __m128 loQuad = _mm256_castps256_ps128(x);
-    // sumQuad = ( x3+x7, x2+x6, x1+x5, x0+x4 )
-    const __m128 sumQuad = _mm_add_ps(loQuad, hiQuad);
-    // loDual = ( -, -, x1+x5, x0+x4 )
-    const __m128 loDual = sumQuad;
-    // hiDual = ( -, -, x3+x7, x2+x6 )
-    const __m128 hiDual = _mm_movehl_ps(sumQuad, sumQuad);
-    // sumDual = ( -, -, x1+x3 + x5+x7, x0+x2 + x4+x6 )
-    const __m128 sumDual = _mm_add_ps(loDual, hiDual);
-    // lo = ( -, -, -, x0+x2 + x4+x6 )
-    const __m128 lo = sumDual;
-    // hi = ( -, -, -, x1+x3 + x5+x7 )
-    const __m128 hi = _mm_shuffle_ps(sumDual, sumDual, 0x1);
-    // sum = ( -, -, -, x0+x1+x2+x3 + x4+x5+x6+x7 )
-    const __m128 sum = _mm_add_ss(lo, hi);
-    return sum;
+  // hiQuad = ( x7, x6, x5, x4 )
+  const __m128 hiQuad = _mm256_extractf128_ps(x, 1);
+  // loQuad = ( x3, x2, x1, x0 )
+  const __m128 loQuad = _mm256_castps256_ps128(x);
+  // sumQuad = ( x3+x7, x2+x6, x1+x5, x0+x4 )
+  const __m128 sumQuad = _mm_add_ps(loQuad, hiQuad);
+  // loDual = ( -, -, x1+x5, x0+x4 )
+  const __m128 loDual = sumQuad;
+  // hiDual = ( -, -, x3+x7, x2+x6 )
+  const __m128 hiDual = _mm_movehl_ps(sumQuad, sumQuad);
+  // sumDual = ( -, -, x1+x3 + x5+x7, x0+x2 + x4+x6 )
+  const __m128 sumDual = _mm_add_ps(loDual, hiDual);
+  // lo = ( -, -, -, x0+x2 + x4+x6 )
+  const __m128 lo = sumDual;
+  // hi = ( -, -, -, x1+x3 + x5+x7 )
+  const __m128 hi = _mm_shuffle_ps(sumDual, sumDual, 0x1);
+  // sum = ( -, -, -, x0+x1+x2+x3 + x4+x5+x6+x7 )
+  const __m128 sum = _mm_add_ss(lo, hi);
+  return sum;
 }
 
 // Horizontally add elements of each __m256 type arguments at once
 inline __m128 hsum2x256_ps(__m256 a, __m256 b) {
-    // (b3, b2, b1, b0, a3, a2, a1, a0)
-    __m256 x = _mm256_permute2f128_ps(a, b, 0x20);
-    // (b7, b6, b5, b4, a7, a6, a5, a4)
-    __m256 y = _mm256_permute2f128_ps(a, b, 0x31);
-    // (b3+b7, b2+b6, b1+b5, b0+b4, a3+a7, a2+a6, a1+a5, a0+a4)
-    x = _mm256_add_ps(x, y);
-    // (-, -, b3+b7, b2+b6, -, -, a3+a7, a2+a6)
-    y = _mm256_permute_ps(x, _MM_SHUFFLE(3, 2, 3, 2));
-    // (-, -, b1+b5+b3+b7, b0+b4+b2+b6, -, -, a1+a5+a3+a7, a0+a4+a2+a6)
-    x = _mm256_add_ps(x, y);
-    // (-, -, -, b1+b5+b3+b7, -, -, -, a1+a5+a3+a7)
-    y = _mm256_permute_ps(x, _MM_SHUFFLE(1, 1, 1, 1));
-    // (-, -, -, b1+b5+b3+b7+b0+b4+b2+b6, -, -, -, a1+a5+a3+a7+a0+a4+a2+a6)
-    x = _mm256_add_ps(x, y);
-    // (-, -, -, b1+b5+b3+b7+b0+b4+b2+b6)
-    __m128 upper = _mm256_extractf128_ps(x, 1);
-    // (-, -, -, -, -, -, b1+b5+b3+b7+b0+b4+b2+b6, a1+a5+a3+a7+a0+a4+a2+a6)
-    __m128 ret = _mm_unpacklo_ps(_mm256_castps256_ps128(x), upper);
-    return ret;
+  // (b3, b2, b1, b0, a3, a2, a1, a0)
+  __m256 x = _mm256_permute2f128_ps(a, b, 0x20);
+  // (b7, b6, b5, b4, a7, a6, a5, a4)
+  __m256 y = _mm256_permute2f128_ps(a, b, 0x31);
+  // (b3+b7, b2+b6, b1+b5, b0+b4, a3+a7, a2+a6, a1+a5, a0+a4)
+  x = _mm256_add_ps(x, y);
+  // (-, -, b3+b7, b2+b6, -, -, a3+a7, a2+a6)
+  y = _mm256_permute_ps(x, _MM_SHUFFLE(3, 2, 3, 2));
+  // (-, -, b1+b5+b3+b7, b0+b4+b2+b6, -, -, a1+a5+a3+a7, a0+a4+a2+a6)
+  x = _mm256_add_ps(x, y);
+  // (-, -, -, b1+b5+b3+b7, -, -, -, a1+a5+a3+a7)
+  y = _mm256_permute_ps(x, _MM_SHUFFLE(1, 1, 1, 1));
+  // (-, -, -, b1+b5+b3+b7+b0+b4+b2+b6, -, -, -, a1+a5+a3+a7+a0+a4+a2+a6)
+  x = _mm256_add_ps(x, y);
+  // (-, -, -, b1+b5+b3+b7+b0+b4+b2+b6)
+  __m128 upper = _mm256_extractf128_ps(x, 1);
+  // (-, -, -, -, -, -, b1+b5+b3+b7+b0+b4+b2+b6, a1+a5+a3+a7+a0+a4+a2+a6)
+  __m128 ret = _mm_unpacklo_ps(_mm256_castps256_ps128(x), upper);
+  return ret;
 }
 
 inline __m128d hsum256_pd(__m256d x) {
-    // hiDual = ( x3, x2 )
-    const __m128d hiDual = _mm256_extractf128_pd(x, 1);
-    // loDual = ( x1, x0 )
-    const __m128d loDual = _mm256_castpd256_pd128(x);
-    // sumQuad = ( x2+x3, x0+x1 )
-    const __m128d sumDual = _mm_add_pd(loDual, hiDual);
-    // sum = ( 0, x0+x1+x2+x3 );
-    const __m128d sum = _mm_hadd_pd(sumDual, _mm_setzero_pd());
-    return sum;
+  // hiDual = ( x3, x2 )
+  const __m128d hiDual = _mm256_extractf128_pd(x, 1);
+  // loDual = ( x1, x0 )
+  const __m128d loDual = _mm256_castpd256_pd128(x);
+  // sumQuad = ( x2+x3, x0+x1 )
+  const __m128d sumDual = _mm_add_pd(loDual, hiDual);
+  // sum = ( 0, x0+x1+x2+x3 );
+  const __m128d sum = _mm_hadd_pd(sumDual, _mm_setzero_pd());
+  return sum;
 }
 
-template<int n>
-struct foobar : std::false_type
-{ };
-
+template <int n>
+struct foobar : std::false_type {};
 
 // Byte Shift YMM Register Across 128-bit Lanes
 // limitation : shift amount is immediate and is multiples of 4
 
 template <int n>
 inline __m256 leftShift(__m256 a) {
-    static_assert(foobar<n>::value, "unsupported shift amount");
-    return a;
+  static_assert(foobar<n>::value, "unsupported shift amount");
+  return a;
 }
 
 // http://stackoverflow.com/q/19516585
 template <>
 inline __m256 leftShift<4>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
-    // t1 = (x2, x1, x0, x3, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x6, x5, x4, x3, x2, x1, x0, 0)
-    __m256 y = _mm256_blend_ps(t0, t1, 0x11);
-    return y;
+  // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
+  // t1 = (x2, x1, x0, x3, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x6, x5, x4, x3, x2, x1, x0, 0)
+  __m256 y = _mm256_blend_ps(t0, t1, 0x11);
+  return y;
 }
 
 // http://stackoverflow.com/q/19516585
 template <>
 inline __m256 leftShift<8>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
-    // t1 = (x1, x0, x3, x2, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x5, x4, x3, x2, x1, x0, 0, 0)
-    __m256 y = _mm256_blend_ps(t0, t1, 0x33 /* 0b00110011 */ );
-    return y;
+  // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
+  // t1 = (x1, x0, x3, x2, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x5, x4, x3, x2, x1, x0, 0, 0)
+  __m256 y = _mm256_blend_ps(t0, t1, 0x33 /* 0b00110011 */);
+  return y;
 }
 
 template <>
 inline __m256 leftShift<12>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
-    // t1 = (x0, x3, x2, x1, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x4, x3, x2, x1, x0, 0, 0, 0)
-    __m256 y = _mm256_blend_ps(t0, t1, 0x77 /* 0b01110111 */ );
-    return y;
+  // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
+  // t1 = (x0, x3, x2, x1, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x4, x3, x2, x1, x0, 0, 0, 0)
+  __m256 y = _mm256_blend_ps(t0, t1, 0x77 /* 0b01110111 */);
+  return y;
 }
 
 template <>
 inline __m256 leftShift<16>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // y  = (x3, x2, x1, x0, 0, 0, 0, 0)
-    __m256 y = _mm256_permute2f128_ps(x, x, 0x08);
-    return y;
+  // y  = (x3, x2, x1, x0, 0, 0, 0, 0)
+  __m256 y = _mm256_permute2f128_ps(x, x, 0x08);
+  return y;
 }
 
 template <>
 inline __m256 leftShift<20>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
-    // t1 = (x2, x1, x0, x3, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x2, x1, x0, 0, 0, 0, 0, 0)
-    __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0x10 /* 0b00010000 */ );
-    return y;
+  // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
+  // t1 = (x2, x1, x0, x3, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x2, x1, x0, 0, 0, 0, 0, 0)
+  __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0x10 /* 0b00010000 */);
+  return y;
 }
 
 template <>
 inline __m256 leftShift<24>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
-    // t1 = (x1, x0, x3, x2, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x1, x0, 0, 0, 0, 0, 0, 0)
-    __m256 y = _mm256_blend_ps(_mm256_setzero_ps(), t1, 0xC0 /* 0b11000000 */ );
-    return y;
+  // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
+  // t1 = (x1, x0, x3, x2, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x1, x0, 0, 0, 0, 0, 0, 0)
+  __m256 y = _mm256_blend_ps(_mm256_setzero_ps(), t1, 0xC0 /* 0b11000000 */);
+  return y;
 }
 
 template <>
 inline __m256 leftShift<28>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
-    // t1 = (x0, x3, x2, x1, 0, 0, 0, 0)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
-    // y  = (x0, 0, 0, 0, 0, 0, 0, 0)
-    __m256 y = _mm256_blend_ps(_mm256_setzero_ps(), t1, 0x80 /* 0b10000000 */ );
-    return y;
+  // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
+  // t1 = (x0, x3, x2, x1, 0, 0, 0, 0)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x08);
+  // y  = (x0, 0, 0, 0, 0, 0, 0, 0)
+  __m256 y = _mm256_blend_ps(_mm256_setzero_ps(), t1, 0x80 /* 0b10000000 */);
+  return y;
 }
 
 template <int n>
-inline __m256 rightShift(__m256 a)
-{
-    static_assert(foobar<n>::value, "unsupported shift amount");
-    return a;
+inline __m256 rightShift(__m256 a) {
+  static_assert(foobar<n>::value, "unsupported shift amount");
+  return a;
 }
 
 // http://stackoverflow.com/a/19532415/4699324
 template <>
 inline __m256 rightShift<4>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
-    // t1 = (0, 0, 0, 0, x4, x7, x6, x5)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
+  // t1 = (0, 0, 0, 0, x4, x7, x6, x5)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -, x7, x6, x5,  -, x3, x2, x1)
-    //      ( 0,  -,  -,  -, x4,  -,  -,  -)
-    // y  = ( 0, x7, x6, x5, x4, x3, x2, x1)
-    __m256 y = _mm256_blend_ps(t0, t1, 0x88 /* 0b10001000 */ );
-    return y;
+  //      ( -, x7, x6, x5,  -, x3, x2, x1)
+  //      ( 0,  -,  -,  -, x4,  -,  -,  -)
+  // y  = ( 0, x7, x6, x5, x4, x3, x2, x1)
+  __m256 y = _mm256_blend_ps(t0, t1, 0x88 /* 0b10001000 */);
+  return y;
 }
 
 template <>
 inline __m256 rightShift<8>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
-    // t1 = (0, 0, 0, 0, x5, x4, x7, x6)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
+  // t1 = (0, 0, 0, 0, x5, x4, x7, x6)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -,  -, x7, x6,  -,  -, x3, x2)
-    //      ( 0,  0,  -,  -, x5, x4,  -,  -)
-    // y  = ( 0,  0, x7, x6, x5, x4, x3, x2)
-    __m256 y = _mm256_blend_ps(t0, t1, 0xCC /* 0b11001100 */ );
-    return y;
+  //      ( -,  -, x7, x6,  -,  -, x3, x2)
+  //      ( 0,  0,  -,  -, x5, x4,  -,  -)
+  // y  = ( 0,  0, x7, x6, x5, x4, x3, x2)
+  __m256 y = _mm256_blend_ps(t0, t1, 0xCC /* 0b11001100 */);
+  return y;
 }
 
 template <>
 inline __m256 rightShift<12>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
-    // t1 = ( 0,  0,  0,  0, x6, x5, x4, x7)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
+  // t1 = ( 0,  0,  0,  0, x6, x5, x4, x7)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -,  -,  -, x7,  -,  -,  -, x3)
-    //      ( 0,  0,  0,  -, x6, x5, x4,  -)
-    // y  = ( 0,  0,  0, x7, x6, x5, x4, x3)
-    __m256 y = _mm256_blend_ps(t0, t1, 0xEE /* 0b11101110 */ );
-    return y;
+  //      ( -,  -,  -, x7,  -,  -,  -, x3)
+  //      ( 0,  0,  0,  -, x6, x5, x4,  -)
+  // y  = ( 0,  0,  0, x7, x6, x5, x4, x3)
+  __m256 y = _mm256_blend_ps(t0, t1, 0xEE /* 0b11101110 */);
+  return y;
 }
 
 template <>
-inline __m256 rightShift<16>(__m256 x)
-{
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+inline __m256 rightShift<16>(__m256 x) {
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // y  = ( 0,  0,  0,  0, x7, x6, x5, x4)
-    __m256 y = _mm256_permute2f128_ps(x, x, 0x81);
-    return y;
+  // y  = ( 0,  0,  0,  0, x7, x6, x5, x4)
+  __m256 y = _mm256_permute2f128_ps(x, x, 0x81);
+  return y;
 }
 
 template <>
 inline __m256 rightShift<20>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
-    // t1 = ( 0,  0,  0,  0, x4, x7, x6, x5)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x4, x7, x6, x5, x0, x3, x2, x1)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(0, 3, 2, 1));
+  // t1 = ( 0,  0,  0,  0, x4, x7, x6, x5)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -,  -,  -,  -,  -, x7, x6, x5)
-    //      ( 0,  0,  0,  0,  0,  -,  -,  -)
-    // y  = ( 0,  0,  0,  0,  0, x7, x6, x5)
-    __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xF8 /* 0b11111000 */ );
-    return y;
+  //      ( -,  -,  -,  -,  -, x7, x6, x5)
+  //      ( 0,  0,  0,  0,  0,  -,  -,  -)
+  // y  = ( 0,  0,  0,  0,  0, x7, x6, x5)
+  __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xF8 /* 0b11111000 */);
+  return y;
 }
 
 template <>
 inline __m256 rightShift<24>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
-    // t1 = ( 0,  0,  0,  0, x5, x4, x7, x6)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x5, x4, x7, x6, x1, x0, x3, x2)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(1, 0, 3, 2));
+  // t1 = ( 0,  0,  0,  0, x5, x4, x7, x6)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -,  -,  -,  -,  -,  -, x7, x6)
-    //      ( 0,  0,  0,  0,  0,  0,  -,  -)
-    // y  = ( 0,  0,  0,  0,  0,  0, x7, x6)
-    __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xFC /* 0b11111100 */ );
-    return y;
+  //      ( -,  -,  -,  -,  -,  -, x7, x6)
+  //      ( 0,  0,  0,  0,  0,  0,  -,  -)
+  // y  = ( 0,  0,  0,  0,  0,  0, x7, x6)
+  __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xFC /* 0b11111100 */);
+  return y;
 }
 
 template <>
 inline __m256 rightShift<28>(__m256 x) {
-    // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
+  // x  = (x7, x6, x5, x4, x3, x2, x1, x0)
 
-    // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
-    __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
-    // t1 = ( 0,  0,  0,  0, x6, x5, x4, x7)
-    __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
+  // t0 = (x6, x5, x4, x7, x2, x1, x0, x3)
+  __m256 t0 = _mm256_permute_ps(x, _MM_SHUFFLE(2, 1, 0, 3));
+  // t1 = ( 0,  0,  0,  0, x6, x5, x4, x7)
+  __m256 t1 = _mm256_permute2f128_ps(t0, t0, 0x81);
 
-    //      ( -,  -,  -,  -,  -,  -,  -, x7)
-    //      ( 0,  0,  0,  0,  0,  0,  0,  -)
-    // y  = ( 0,  0,  0,  0,  0,  0,  0, x7)
-    __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xFE /* 0b11111110 */ );
-    return y;
+  //      ( -,  -,  -,  -,  -,  -,  -, x7)
+  //      ( 0,  0,  0,  0,  0,  0,  0,  -)
+  // y  = ( 0,  0,  0,  0,  0,  0,  0, x7)
+  __m256 y = _mm256_blend_ps(t1, _mm256_setzero_ps(), 0xFE /* 0b11111110 */);
+  return y;
 }
-

--- a/tiny_dnn/core/kernels/avx_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/avx_maxpool_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/core/kernels/tiny_maxpool_kernel.h"
 

--- a/tiny_dnn/core/kernels/avx_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/avx_maxpool_kernel.h
@@ -9,20 +9,20 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-inline void avx_maxpool_kernel(const tensor_t& in_data,
-                               tensor_t&       out_data,
-                               std::vector<std::vector<cnn_size_t>>& max_idx,
-                               const std::vector<std::vector<cnn_size_t>>& out2in,
-                               const bool layer_parallelize) {
-    tiny_maxpool_kernel(in_data, out_data, max_idx, out2in, layer_parallelize);
+inline void avx_maxpool_kernel(
+    const tensor_t& in_data, tensor_t& out_data,
+    std::vector<std::vector<cnn_size_t>>& max_idx,
+    const std::vector<std::vector<cnn_size_t>>& out2in,
+    const bool layer_parallelize) {
+  tiny_maxpool_kernel(in_data, out_data, max_idx, out2in, layer_parallelize);
 }
 
-inline void avx_maxpool_back_kernel(tensor_t& prev_delta,
-                                    const tensor_t&  curr_delta,
-                                    std::vector<std::vector<cnn_size_t>>& max_idx,
-                                    const std::vector<cnn_size_t>& in2out,
-                                    const bool layer_parallelize) {
-    tiny_maxpool_back_kernel(prev_delta, curr_delta, max_idx, in2out, layer_parallelize);
+inline void avx_maxpool_back_kernel(
+    tensor_t& prev_delta, const tensor_t& curr_delta,
+    std::vector<std::vector<cnn_size_t>>& max_idx,
+    const std::vector<cnn_size_t>& in2out, const bool layer_parallelize) {
+  tiny_maxpool_back_kernel(prev_delta, curr_delta, max_idx, in2out,
+                           layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/conv2d.h
+++ b/tiny_dnn/core/kernels/conv2d.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/conv_params.h"

--- a/tiny_dnn/core/kernels/conv2d_grad_op.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op.h
@@ -14,60 +14,44 @@ namespace tiny_dnn {
 
 class Conv2dGradOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dGradOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit Conv2dGradOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        // incoming/outcoming data
-        const tensor_t& prev_out = context.input(0);
-        const vec_t& W  = context.input(1)[0];
-        tensor_t&    dW = context.input_grad(1);
-        tensor_t&    db = context.input_grad(2);
-        tensor_t&    prev_delta = context.input_grad(0);
-        tensor_t&    curr_delta = context.output_grad(1);
+  void compute(const core::OpKernelContext& context) override {
+    // incoming/outcoming data
+    const tensor_t& prev_out = context.input(0);
+    const vec_t& W = context.input(1)[0];
+    tensor_t& dW = context.input_grad(1);
+    tensor_t& db = context.input_grad(2);
+    tensor_t& prev_delta = context.input_grad(0);
+    tensor_t& curr_delta = context.output_grad(1);
 
-        // set an cast the convolutional parameters
-        Conv2d::setParams(OpKernel::params_);
+    // set an cast the convolutional parameters
+    Conv2d::setParams(OpKernel::params_);
 
-        // TODO(nyanp): Why we only need to initialize prev_delta ?
+    // TODO(nyanp): Why we only need to initialize prev_delta ?
 
-        // initalize outputs
-        //fill_tensor(dW, float_t(0));
-        //fill_tensor(db, float_t(0));
-        fill_tensor(prev_delta, float_t(0));
-        //fill_tensor(curr_delta, float_t(0));
-        
-        // call convolution algorithm depending
-        // on the selected engine type
+    // initalize outputs
+    // fill_tensor(dW, float_t(0));
+    // fill_tensor(db, float_t(0));
+    fill_tensor(prev_delta, float_t(0));
+    // fill_tensor(curr_delta, float_t(0));
 
-        const core::backend_t engine = context.engine();
-        
-        if (engine == core::backend_t::tiny_dnn) {
-            kernels::conv2d_op_custom(
-                prev_out,
-                W,
-                dW,
-                db,
-                curr_delta,
-                prev_delta,
-                Conv2d::params(),
-                context.parallelize());
-        }
-        else if (engine == core::backend_t::avx) {
-            kernels::conv2d_grad_op_avx(
-                prev_out,
-                W,
-                dW,
-                db,
-                curr_delta,
-                prev_delta,
-                Conv2d::params(),
-                context.parallelize());
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(engine));
-        }
+    // call convolution algorithm depending
+    // on the selected engine type
+
+    const core::backend_t engine = context.engine();
+
+    if (engine == core::backend_t::tiny_dnn) {
+      kernels::conv2d_op_custom(prev_out, W, dW, db, curr_delta, prev_delta,
+                                Conv2d::params(), context.parallelize());
+    } else if (engine == core::backend_t::avx) {
+      kernels::conv2d_grad_op_avx(prev_out, W, dW, db, curr_delta, prev_delta,
+                                  Conv2d::params(), context.parallelize());
+    } else {
+      throw nn_error("Not supported engine: " + to_string(engine));
     }
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/conv2d_grad_op.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/op_kernel.h"

--- a/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <vector>
-#include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/kernels/conv2d_op_custom.h"
+#include "tiny_dnn/core/params/conv_params.h"
 
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/kernels/avx_kernel_common.h"
@@ -22,529 +22,515 @@ template <typename Allocator>
 void avx_conv2d_5x5_back_kernel(const core::conv_params& params,
                                 const std::vector<float, Allocator>& prev_out,
                                 const std::vector<float, Allocator>& W,
-                                std::vector<float, Allocator>&       dW,
-                                std::vector<float, Allocator>&       db,
-                                std::vector<float, Allocator>&       curr_delta,
-                                std::vector<float, Allocator>*       prev_delta) {
-    auto& in        = params.in;
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    const size_t in_padded_area = in_padded.area();
-    float* pdelta_dst_org = &(*prev_delta)[0];
-    const size_t  h_stride2 = params.h_stride * in_padded.width_;
-    static const __m256 mask = _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
-    // propagate delta to previous layer
-    if (w_stride == 1 && out.width_ >= 4) {
-        const cnn_size_t nblocks = out.width_ / 4;
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                if (!tbl.is_connected(outc, inc)) continue;
-                const float* pw = &W[25 * (in.depth_ * outc + inc)];
-                const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
-                float* pdelta_dst = pdelta_dst_org;
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                __m256 w0b = leftShift<4>(w0a);
-                __m256 w1b = leftShift<4>(w1a);
-                __m256 w2b = leftShift<4>(w2a);
-                __m256 w3b = leftShift<4>(w3a);
-                __m256 w4b = leftShift<4>(w4a);
-                __m256 w0c = leftShift<8>(w0a);
-                __m256 w1c = leftShift<8>(w1a);
-                __m256 w2c = leftShift<8>(w2a);
-                __m256 w3c = leftShift<8>(w3a);
-                __m256 w4c = leftShift<8>(w4a);
-                __m256 w0d = leftShift<12>(w0a);
-                __m256 w1d = leftShift<12>(w1a);
-                __m256 w2d = leftShift<12>(w2a);
-                __m256 w3d = leftShift<12>(w3a);
-                __m256 w4d = leftShift<12>(w4a);
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    const float* pdelta_src2 = pdelta_src;
-                    float* delta_dst0 = pdelta_dst;
-                    float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
-                    float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
-                    float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
-                    float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
-                    for (cnn_size_t n = 0; n < nblocks; ++n) {
-                        __m256 delta_src = _mm256_broadcast_ps((const __m128*)pdelta_src2);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0 + 4 * n);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1 + 4 * n);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2 + 4 * n);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3 + 4 * n);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4 + 4 * n);
-                        __m256 delta_src0 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(0, 0, 0, 0));
-                        __m256 delta_src1 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(1, 1, 1, 1));
-                        __m256 delta_src2 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(2, 2, 2, 2));
-                        __m256 delta_src3 = _mm256_permute_ps(delta_src, _MM_SHUFFLE(3, 3, 3, 3));
-                        dst0 = madd256_ps(w0a, delta_src0, dst0);
-                        dst1 = madd256_ps(w1a, delta_src0, dst1);
-                        dst2 = madd256_ps(w2a, delta_src0, dst2);
-                        dst3 = madd256_ps(w3a, delta_src0, dst3);
-                        dst4 = madd256_ps(w4a, delta_src0, dst4);
-                        dst0 = madd256_ps(w0b, delta_src1, dst0);
-                        dst1 = madd256_ps(w1b, delta_src1, dst1);
-                        dst2 = madd256_ps(w2b, delta_src1, dst2);
-                        dst3 = madd256_ps(w3b, delta_src1, dst3);
-                        dst4 = madd256_ps(w4b, delta_src1, dst4);
-                        dst0 = madd256_ps(w0c, delta_src2, dst0);
-                        dst1 = madd256_ps(w1c, delta_src2, dst1);
-                        dst2 = madd256_ps(w2c, delta_src2, dst2);
-                        dst3 = madd256_ps(w3c, delta_src2, dst3);
-                        dst4 = madd256_ps(w4c, delta_src2, dst4);
-                        dst0 = madd256_ps(w0d, delta_src3, dst0);
-                        _mm256_storeu_ps(delta_dst0 + 4 * n, dst0);
-                        dst1 = madd256_ps(w1d, delta_src3, dst1);
-                        _mm256_storeu_ps(delta_dst1 + 4 * n, dst1);
-                        dst2 = madd256_ps(w2d, delta_src3, dst2);
-                        _mm256_storeu_ps(delta_dst2 + 4 * n, dst2);
-                        dst3 = madd256_ps(w3d, delta_src3, dst3);
-                        _mm256_storeu_ps(delta_dst3 + 4 * n, dst3);
-                        dst4 = madd256_ps(w4d, delta_src3, dst4);
-                        _mm256_storeu_ps(delta_dst4 + 4 * n, dst4);
-                        pdelta_src2 += 4;
-                    }
-                    for (cnn_size_t x = nblocks * 4; x < out.width_; x++) {
-                        __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0 + x);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1 + x);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2 + x);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3 + x);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4 + x);
-                        dst0 = madd256_ps(w0a, delta_src, dst0);
-                        dst1 = madd256_ps(w1a, delta_src, dst1);
-                        dst2 = madd256_ps(w2a, delta_src, dst2);
-                        dst3 = madd256_ps(w3a, delta_src, dst3);
-                        dst4 = madd256_ps(w4a, delta_src, dst4);
-                        _mm256_storeu_ps(delta_dst0 + x, dst0);
-                        _mm256_storeu_ps(delta_dst1 + x, dst1);
-                        _mm256_storeu_ps(delta_dst2 + x, dst2);
-                        _mm256_storeu_ps(delta_dst3 + x, dst3);
-                        _mm256_storeu_ps(delta_dst4 + x, dst4);
-                    }
-                    pdelta_src += out.width_;
-                    pdelta_dst += h_stride2;
-                }
-            }
+                                std::vector<float, Allocator>& dW,
+                                std::vector<float, Allocator>& db,
+                                std::vector<float, Allocator>& curr_delta,
+                                std::vector<float, Allocator>* prev_delta) {
+  auto& in = params.in;
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+  const size_t in_padded_area = in_padded.area();
+  float* pdelta_dst_org = &(*prev_delta)[0];
+  const size_t h_stride2 = params.h_stride * in_padded.width_;
+  static const __m256 mask =
+      _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
+  // propagate delta to previous layer
+  if (w_stride == 1 && out.width_ >= 4) {
+    const cnn_size_t nblocks = out.width_ / 4;
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+        const float* pw = &W[25 * (in.depth_ * outc + inc)];
+        const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
+        float* pdelta_dst = pdelta_dst_org;
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        __m256 w0b = leftShift<4>(w0a);
+        __m256 w1b = leftShift<4>(w1a);
+        __m256 w2b = leftShift<4>(w2a);
+        __m256 w3b = leftShift<4>(w3a);
+        __m256 w4b = leftShift<4>(w4a);
+        __m256 w0c = leftShift<8>(w0a);
+        __m256 w1c = leftShift<8>(w1a);
+        __m256 w2c = leftShift<8>(w2a);
+        __m256 w3c = leftShift<8>(w3a);
+        __m256 w4c = leftShift<8>(w4a);
+        __m256 w0d = leftShift<12>(w0a);
+        __m256 w1d = leftShift<12>(w1a);
+        __m256 w2d = leftShift<12>(w2a);
+        __m256 w3d = leftShift<12>(w3a);
+        __m256 w4d = leftShift<12>(w4a);
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          const float* pdelta_src2 = pdelta_src;
+          float* delta_dst0 = pdelta_dst;
+          float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
+          float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
+          float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
+          float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
+          for (cnn_size_t n = 0; n < nblocks; ++n) {
+            __m256 delta_src = _mm256_broadcast_ps((const __m128*)pdelta_src2);
+            __m256 dst0 = _mm256_loadu_ps(delta_dst0 + 4 * n);
+            __m256 dst1 = _mm256_loadu_ps(delta_dst1 + 4 * n);
+            __m256 dst2 = _mm256_loadu_ps(delta_dst2 + 4 * n);
+            __m256 dst3 = _mm256_loadu_ps(delta_dst3 + 4 * n);
+            __m256 dst4 = _mm256_loadu_ps(delta_dst4 + 4 * n);
+            __m256 delta_src0 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(0, 0, 0, 0));
+            __m256 delta_src1 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(1, 1, 1, 1));
+            __m256 delta_src2 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(2, 2, 2, 2));
+            __m256 delta_src3 =
+                _mm256_permute_ps(delta_src, _MM_SHUFFLE(3, 3, 3, 3));
+            dst0 = madd256_ps(w0a, delta_src0, dst0);
+            dst1 = madd256_ps(w1a, delta_src0, dst1);
+            dst2 = madd256_ps(w2a, delta_src0, dst2);
+            dst3 = madd256_ps(w3a, delta_src0, dst3);
+            dst4 = madd256_ps(w4a, delta_src0, dst4);
+            dst0 = madd256_ps(w0b, delta_src1, dst0);
+            dst1 = madd256_ps(w1b, delta_src1, dst1);
+            dst2 = madd256_ps(w2b, delta_src1, dst2);
+            dst3 = madd256_ps(w3b, delta_src1, dst3);
+            dst4 = madd256_ps(w4b, delta_src1, dst4);
+            dst0 = madd256_ps(w0c, delta_src2, dst0);
+            dst1 = madd256_ps(w1c, delta_src2, dst1);
+            dst2 = madd256_ps(w2c, delta_src2, dst2);
+            dst3 = madd256_ps(w3c, delta_src2, dst3);
+            dst4 = madd256_ps(w4c, delta_src2, dst4);
+            dst0 = madd256_ps(w0d, delta_src3, dst0);
+            _mm256_storeu_ps(delta_dst0 + 4 * n, dst0);
+            dst1 = madd256_ps(w1d, delta_src3, dst1);
+            _mm256_storeu_ps(delta_dst1 + 4 * n, dst1);
+            dst2 = madd256_ps(w2d, delta_src3, dst2);
+            _mm256_storeu_ps(delta_dst2 + 4 * n, dst2);
+            dst3 = madd256_ps(w3d, delta_src3, dst3);
+            _mm256_storeu_ps(delta_dst3 + 4 * n, dst3);
+            dst4 = madd256_ps(w4d, delta_src3, dst4);
+            _mm256_storeu_ps(delta_dst4 + 4 * n, dst4);
+            pdelta_src2 += 4;
+          }
+          for (cnn_size_t x = nblocks * 4; x < out.width_; x++) {
+            __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
+            __m256 dst0 = _mm256_loadu_ps(delta_dst0 + x);
+            __m256 dst1 = _mm256_loadu_ps(delta_dst1 + x);
+            __m256 dst2 = _mm256_loadu_ps(delta_dst2 + x);
+            __m256 dst3 = _mm256_loadu_ps(delta_dst3 + x);
+            __m256 dst4 = _mm256_loadu_ps(delta_dst4 + x);
+            dst0 = madd256_ps(w0a, delta_src, dst0);
+            dst1 = madd256_ps(w1a, delta_src, dst1);
+            dst2 = madd256_ps(w2a, delta_src, dst2);
+            dst3 = madd256_ps(w3a, delta_src, dst3);
+            dst4 = madd256_ps(w4a, delta_src, dst4);
+            _mm256_storeu_ps(delta_dst0 + x, dst0);
+            _mm256_storeu_ps(delta_dst1 + x, dst1);
+            _mm256_storeu_ps(delta_dst2 + x, dst2);
+            _mm256_storeu_ps(delta_dst3 + x, dst3);
+            _mm256_storeu_ps(delta_dst4 + x, dst4);
+          }
+          pdelta_src += out.width_;
+          pdelta_dst += h_stride2;
         }
-    } else if (out.height_ == 1 && out.width_ == 1) {
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            float* delta_dst0 = pdelta_dst_org;
-            float* delta_dst1 = &pdelta_dst_org[in_padded.width_ * 1];
-            float* delta_dst2 = &pdelta_dst_org[in_padded.width_ * 2];
-            float* delta_dst3 = &pdelta_dst_org[in_padded.width_ * 3];
-            float* delta_dst4 = &pdelta_dst_org[in_padded.width_ * 4];
+      }
+    }
+  } else if (out.height_ == 1 && out.width_ == 1) {
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      float* delta_dst0 = pdelta_dst_org;
+      float* delta_dst1 = &pdelta_dst_org[in_padded.width_ * 1];
+      float* delta_dst2 = &pdelta_dst_org[in_padded.width_ * 2];
+      float* delta_dst3 = &pdelta_dst_org[in_padded.width_ * 3];
+      float* delta_dst4 = &pdelta_dst_org[in_padded.width_ * 4];
+      __m256 dst0 = _mm256_loadu_ps(delta_dst0);
+      __m256 dst1 = _mm256_loadu_ps(delta_dst1);
+      __m256 dst2 = _mm256_loadu_ps(delta_dst2);
+      __m256 dst3 = _mm256_loadu_ps(delta_dst3);
+      __m256 dst4 = _mm256_loadu_ps(delta_dst4);
+
+      // *FROM
+      // ---0 0000
+      // ---1 1111
+      // ---2 2222
+      // ---3 3333
+      // ---4 4444
+      //
+      // *TO
+      // 1110 0000
+      // 3222 2211
+      // 4444 3333
+      // ---- ---4
+      __m256 sum0 =
+          _mm256_blend_ps(dst0, leftShift<20>(dst1), 0xE0 /* 0b11100000 */
+                          );
+      __m256 sum1 = _mm256_blend_ps(
+          leftShift<28>(dst3),
+          _mm256_blend_ps(leftShift<8>(dst2), rightShift<12>(dst1),
+                          0x03 /* 0b00000011 */),
+          0x7F /* 0b01111111 */
+          );
+      __m256 sum2 = _mm256_blend_ps(
+          leftShift<16>(dst4), rightShift<4>(dst3), 0x0F /* 0b00001111 */
+          );
+      __m128 sum3 = _mm256_extractf128_ps(dst4, 1);
+
+      size_t widx = 25 * inc;
+      size_t wstep = 25 * in.depth_;
+
+      if (tbl.is_empty()) {
+        for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
+          __m256 delta_src = _mm256_broadcast_ss(&curr_delta[outc]);
+          const float* pw = (const float*)&W[widx];
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 8);
+          __m256 w2 = _mm256_loadu_ps(pw + 16);
+          __m128 w3 = _mm_load_ss(pw + 24);
+          sum0 = madd256_ps(w0, delta_src, sum0);
+          sum1 = madd256_ps(w1, delta_src, sum1);
+          sum2 = madd256_ps(w2, delta_src, sum2);
+          sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
+        }
+      } else {
+        for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
+          if (!tbl.is_connected(outc, inc)) {
+            continue;
+          }
+          __m256 delta_src = _mm256_broadcast_ss(&curr_delta[outc]);
+          const float* pw = (const float*)&W[widx];
+          __m256 w0 = _mm256_loadu_ps(pw + 0);
+          __m256 w1 = _mm256_loadu_ps(pw + 8);
+          __m256 w2 = _mm256_loadu_ps(pw + 16);
+          __m128 w3 = _mm_load_ss(pw + 24);
+          sum0 = madd256_ps(w0, delta_src, sum0);
+          sum1 = madd256_ps(w1, delta_src, sum1);
+          sum2 = madd256_ps(w2, delta_src, sum2);
+          sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
+        }
+      }
+
+      // *FROM
+      // 1110 0000
+      // 3222 2211
+      // 4444 3333
+      // ---- ---4
+      //
+      // *TO
+      // ---0 0000
+      // ---1 1111
+      // ---2 2222
+      // ---3 3333
+      // ---4 4444
+      dst0 = _mm256_blend_ps(dst0, sum0, 0x1F /* 0b00011111 */
+                             );
+      dst1 = _mm256_blend_ps(
+          dst1, _mm256_or_ps(rightShift<20>(sum0), leftShift<12>(sum1)),
+          0x1F /* 0b00011111 */
+          );
+      dst2 = _mm256_blend_ps(dst2, rightShift<8>(sum1), 0x1F /* 0b00011111 */
+                             );
+      dst3 = _mm256_blend_ps(
+          dst3, _mm256_or_ps(rightShift<28>(sum1), leftShift<4>(sum2)),
+          0x1F /* 0b00011111 */
+          );
+      dst4 = _mm256_blend_ps(
+          dst4, _mm256_set_m128(sum3, _mm256_extractf128_ps(sum2, 1)),
+          0x1F /* 0b00011111 */
+          );
+
+      _mm256_storeu_ps(delta_dst0, dst0);
+      _mm256_storeu_ps(delta_dst1, dst1);
+      _mm256_storeu_ps(delta_dst2, dst2);
+      _mm256_storeu_ps(delta_dst3, dst3);
+      _mm256_storeu_ps(delta_dst4, dst4);
+    }  // for
+  } else {
+    for (size_t inc = 0; inc < in.depth_;
+         ++inc, pdelta_dst_org += in_padded_area) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+
+        const float* pw = &W[25 * (in.depth_ * outc + inc)];
+        const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
+        float* pdelta_dst = pdelta_dst_org;
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          float* delta_dst0 = pdelta_dst;
+          float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
+          float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
+          float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
+          float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
+          for (cnn_size_t x = 0; x < out.width_; x++) {
+            __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
             __m256 dst0 = _mm256_loadu_ps(delta_dst0);
             __m256 dst1 = _mm256_loadu_ps(delta_dst1);
             __m256 dst2 = _mm256_loadu_ps(delta_dst2);
             __m256 dst3 = _mm256_loadu_ps(delta_dst3);
             __m256 dst4 = _mm256_loadu_ps(delta_dst4);
-
-            // *FROM
-            // ---0 0000
-            // ---1 1111
-            // ---2 2222
-            // ---3 3333
-            // ---4 4444
-            //
-            // *TO
-            // 1110 0000
-            // 3222 2211
-            // 4444 3333
-            // ---- ---4
-            __m256 sum0 = _mm256_blend_ps(
-                dst0,
-                leftShift<20>(dst1),
-                0xE0 /* 0b11100000 */
-            );
-            __m256 sum1 = _mm256_blend_ps(
-                leftShift<28>(dst3),
-                _mm256_blend_ps(leftShift<8>(dst2), rightShift<12>(dst1), 0x03 /* 0b00000011 */),
-                0x7F /* 0b01111111 */
-            );
-            __m256 sum2 = _mm256_blend_ps(
-                leftShift<16>(dst4),
-                rightShift<4>(dst3),
-                0x0F /* 0b00001111 */
-            );
-            __m128 sum3 = _mm256_extractf128_ps(dst4, 1);
-
-            size_t widx = 25 * inc;
-            size_t wstep = 25 * in.depth_;
-
-            if (tbl.is_empty()) {
-                for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx+=wstep) {
-                    __m256 delta_src = _mm256_broadcast_ss(&curr_delta[outc]);
-                    const float* pw = (const float*)&W[widx];
-                    __m256 w0 = _mm256_loadu_ps(pw+0);
-                    __m256 w1 = _mm256_loadu_ps(pw + 8);
-                    __m256 w2 = _mm256_loadu_ps(pw + 16);
-                    __m128 w3 = _mm_load_ss(pw + 24);
-                    sum0 = madd256_ps(w0, delta_src, sum0);
-                    sum1 = madd256_ps(w1, delta_src, sum1);
-                    sum2 = madd256_ps(w2, delta_src, sum2);
-                    sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
-                }
-            }
-            else {
-                for (cnn_size_t outc = 0; outc < out.depth_; outc++, widx += wstep) {
-                    if (!tbl.is_connected(outc, inc)) {
-                        continue;
-                    }
-                    __m256 delta_src = _mm256_broadcast_ss(&curr_delta[outc]);
-                    const float* pw = (const float*)&W[widx];
-                    __m256 w0 = _mm256_loadu_ps(pw + 0);
-                    __m256 w1 = _mm256_loadu_ps(pw + 8);
-                    __m256 w2 = _mm256_loadu_ps(pw + 16);
-                    __m128 w3 = _mm_load_ss(pw + 24);
-                    sum0 = madd256_ps(w0, delta_src, sum0);
-                    sum1 = madd256_ps(w1, delta_src, sum1);
-                    sum2 = madd256_ps(w2, delta_src, sum2);
-                    sum3 = madd128_ss(w3, _mm256_castps256_ps128(delta_src), sum3);
-                }
-            }
-
-            // *FROM
-            // 1110 0000
-            // 3222 2211
-            // 4444 3333
-            // ---- ---4
-            //
-            // *TO
-            // ---0 0000
-            // ---1 1111
-            // ---2 2222
-            // ---3 3333
-            // ---4 4444
-            dst0 = _mm256_blend_ps(
-                dst0,
-                sum0,
-                0x1F /* 0b00011111 */
-            );
-            dst1 = _mm256_blend_ps(
-                dst1,
-                _mm256_or_ps(
-                    rightShift<20>(sum0),
-                    leftShift<12>(sum1)
-                ),
-                0x1F /* 0b00011111 */
-            );
-            dst2 = _mm256_blend_ps(
-                dst2,
-                rightShift<8>(sum1),
-                0x1F /* 0b00011111 */
-            );
-            dst3 = _mm256_blend_ps(
-                dst3,
-                _mm256_or_ps(
-                    rightShift<28>(sum1),
-                    leftShift<4>(sum2)
-                ),
-                0x1F /* 0b00011111 */
-            );
-            dst4 = _mm256_blend_ps(
-                dst4,
-                _mm256_set_m128(
-                    sum3,
-                    _mm256_extractf128_ps(sum2, 1)
-                ),
-                0x1F /* 0b00011111 */
-            );
-
+            dst0 = madd256_ps(w0a, delta_src, dst0);
+            dst1 = madd256_ps(w1a, delta_src, dst1);
+            dst2 = madd256_ps(w2a, delta_src, dst2);
+            dst3 = madd256_ps(w3a, delta_src, dst3);
+            dst4 = madd256_ps(w4a, delta_src, dst4);
             _mm256_storeu_ps(delta_dst0, dst0);
             _mm256_storeu_ps(delta_dst1, dst1);
             _mm256_storeu_ps(delta_dst2, dst2);
             _mm256_storeu_ps(delta_dst3, dst3);
             _mm256_storeu_ps(delta_dst4, dst4);
-        } // for
-    } else {
-        for (size_t inc = 0; inc < in.depth_; ++inc, pdelta_dst_org += in_padded_area) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                if (!tbl.is_connected(outc, inc)) continue;
+            delta_dst0 += w_stride;
+            delta_dst1 += w_stride;
+            delta_dst2 += w_stride;
+            delta_dst3 += w_stride;
+            delta_dst4 += w_stride;
+          }  // for x
+          pdelta_src += out.width_;
+          pdelta_dst += h_stride2;
+        }  // for y
+      }    // for outc
+    }      // for inc
+  }
 
-                const float* pw = &W[25 * (in.depth_ * outc + inc)];
-                const float* pdelta_src = &curr_delta[out.get_index(0, 0, outc)];
-                float* pdelta_dst = pdelta_dst_org;
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    float* delta_dst0 = pdelta_dst;
-                    float* delta_dst1 = &pdelta_dst[in_padded.width_ * 1];
-                    float* delta_dst2 = &pdelta_dst[in_padded.width_ * 2];
-                    float* delta_dst3 = &pdelta_dst[in_padded.width_ * 3];
-                    float* delta_dst4 = &pdelta_dst[in_padded.width_ * 4];
-                    for (cnn_size_t x = 0; x < out.width_; x++) {
-                        __m256 delta_src = _mm256_broadcast_ss(pdelta_src + x);
-                        __m256 dst0 = _mm256_loadu_ps(delta_dst0);
-                        __m256 dst1 = _mm256_loadu_ps(delta_dst1);
-                        __m256 dst2 = _mm256_loadu_ps(delta_dst2);
-                        __m256 dst3 = _mm256_loadu_ps(delta_dst3);
-                        __m256 dst4 = _mm256_loadu_ps(delta_dst4);
-                        dst0 = madd256_ps(w0a, delta_src, dst0);
-                        dst1 = madd256_ps(w1a, delta_src, dst1);
-                        dst2 = madd256_ps(w2a, delta_src, dst2);
-                        dst3 = madd256_ps(w3a, delta_src, dst3);
-                        dst4 = madd256_ps(w4a, delta_src, dst4);
-                        _mm256_storeu_ps(delta_dst0, dst0);
-                        _mm256_storeu_ps(delta_dst1, dst1);
-                        _mm256_storeu_ps(delta_dst2, dst2);
-                        _mm256_storeu_ps(delta_dst3, dst3);
-                        _mm256_storeu_ps(delta_dst4, dst4);
-                        delta_dst0 += w_stride;
-                        delta_dst1 += w_stride;
-                        delta_dst2 += w_stride;
-                        delta_dst3 += w_stride;
-                        delta_dst4 += w_stride;
-                    } // for x
-                    pdelta_src += out.width_;
-                    pdelta_dst += h_stride2;
-                } // for y
-            } // for outc
-        } // for inc
+  // accumulate dw
+  if (out.width_ == 1 && out.height_ == 1) {
+    const float* pprev_out = &prev_out[0];
+    for (size_t inc = 0; inc < in.depth_; ++inc, pprev_out += in_padded_area) {
+      VECTORIZE_ALIGN(32) float floats[28];
+      size_t in_padded_width = in_padded.width_;
+      _mm256_store_ps(&floats[0],
+                      _mm256_loadu_ps(pprev_out + in_padded_width * 0));
+      _mm256_storeu_ps(&floats[5],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 1));
+      _mm256_storeu_ps(&floats[10],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 2));
+      _mm256_storeu_ps(&floats[15],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 3));
+      _mm256_storeu_ps(&floats[20],
+                       _mm256_loadu_ps(pprev_out + in_padded_width * 4));
+      __m256 prevos0 = _mm256_load_ps(&floats[0]);
+      __m256 prevos1 = _mm256_load_ps(&floats[8]);
+      __m256 prevos2 = _mm256_load_ps(&floats[16]);
+      __m128 prevos3 = _mm_load_ss(&floats[24]);
+      cnn_size_t widx = 25 * inc;
+      cnn_size_t widx_delta = 25 * in.depth_;
+      float* pdW = &dW[widx];
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++, pdW += widx_delta) {
+        if (!tbl.is_connected(outc, inc)) {
+          continue;
+        }
+        __m256 delta = _mm256_broadcast_ss(&curr_delta[outc]);
+        __m256 w0 = _mm256_loadu_ps(pdW + 0);
+        __m256 w1 = _mm256_loadu_ps(pdW + 8);
+        __m256 w2 = _mm256_loadu_ps(pdW + 16);
+        __m128 w3 = _mm_load_ss(pdW + 24);
+        w0 = madd256_ps(prevos0, delta, w0);
+        w1 = madd256_ps(prevos1, delta, w1);
+        w2 = madd256_ps(prevos2, delta, w2);
+        w3 = madd128_ss(prevos3, _mm256_castps256_ps128(delta), w3);
+        _mm256_storeu_ps(pdW + 0, w0);
+        _mm256_storeu_ps(pdW + 8, w1);
+        _mm256_storeu_ps(pdW + 16, w2);
+        _mm_store_ss(pdW + 24, w3);
+      }
     }
+  } else {
+    // prepare load-mask beforehand
+    const size_t nblocks = out.width_ >> 3;
+    static const int32_t masks[] = {
+        -1, -1, -1, -1, -1, -1, -1, -1, 0, 0, 0, 0, 0, 0, 0, 0,
+    };
+    const size_t remainder = out.width_ & 7;
+    __m256i mask = _mm256_loadu_si256((const __m256i*)(masks + 8 - remainder));
+    auto& weight = params.weight;
+    for (size_t inc = 0; inc < in.depth_; ++inc) {
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        if (!tbl.is_connected(outc, inc)) continue;
+        const float* delta = &curr_delta[out.get_index(0, 0, outc)];
 
-    // accumulate dw
+        cnn_size_t widx = weight.get_index(0, 0, in.depth_ * outc + inc);
+        for (cnn_size_t wy = 0; wy < 5 /* weight.height_ */; wy++) {
+          for (cnn_size_t wx = 0; wx < 5 /* weight.width_ */; wx++) {
+            const float* prevo = &prev_out[in_padded.get_index(wx, wy, inc)];
+
+            if (w_stride > 1) {
+              float_t dst = float_t(0);
+
+              for (cnn_size_t y = 0; y < params.out.height_; y++) {
+                cnn_size_t prevo_idx =
+                    y * params.in_padded.width_ * params.h_stride;
+                cnn_size_t delta_idx = y * params.out.width_;
+
+                for (cnn_size_t x = 0; x < params.out.width_; x++) {
+                  dst += prevo[prevo_idx + x * params.w_stride] *
+                         delta[delta_idx + x];
+                }
+              }
+              dW[widx] += dst;
+            } else {
+              __m128 prev_sum = _mm_load_ss(&dW[widx]);
+              __m256 sum0 = _mm256_setzero_ps();
+              __m256 sum1 = _mm256_setzero_ps();
+              for (cnn_size_t y = 0; y < out.height_; y++) {
+                // vectorize::dot
+                const float* pa =
+                    prevo + y * in_padded.width_ * params.h_stride;
+                const float* pb = delta + y * out.width_;
+                for (size_t i = 0; i < nblocks; ++i) {
+                  __m256 a = _mm256_loadu_ps(pa + 8 * i);
+                  __m256 b = _mm256_loadu_ps(pb + 8 * i);
+                  sum0 = madd256_ps(a, b, sum0);
+                }
+                if (remainder) {
+                  __m256 a = _mm256_loadu_ps(pa + 8 * nblocks);
+                  __m256 b = _mm256_loadu_ps(pb + 8 * nblocks);
+                  sum1 = madd256_ps(a, b, sum1);
+                }
+              }
+              sum1 = _mm256_and_ps(sum1, _mm256_castsi256_ps(mask));
+              __m256 sum = _mm256_add_ps(sum0, sum1);
+              _mm_store_ss(&dW[widx], _mm_add_ps(prev_sum, hsum256_ps(sum)));
+            }
+            ++widx;
+          }
+        }
+      }
+    }
+  }
+
+  // accumulate db
+  if (params.has_bias) {
+    // fvec_t& db = *in_grad[2];
+
     if (out.width_ == 1 && out.height_ == 1) {
-        const float* pprev_out = &prev_out[0];
-        for (size_t inc = 0; inc < in.depth_; ++inc, pprev_out += in_padded_area) {
-            VECTORIZE_ALIGN(32) float floats[28];
-            size_t in_padded_width = in_padded.width_;
-            _mm256_store_ps(&floats[0], _mm256_loadu_ps(pprev_out + in_padded_width * 0));
-            _mm256_storeu_ps(&floats[5], _mm256_loadu_ps(pprev_out + in_padded_width * 1));
-            _mm256_storeu_ps(&floats[10], _mm256_loadu_ps(pprev_out + in_padded_width * 2));
-            _mm256_storeu_ps(&floats[15], _mm256_loadu_ps(pprev_out + in_padded_width * 3));
-            _mm256_storeu_ps(&floats[20], _mm256_loadu_ps(pprev_out + in_padded_width * 4));
-            __m256 prevos0 = _mm256_load_ps(&floats[0]);
-            __m256 prevos1 = _mm256_load_ps(&floats[8]);
-            __m256 prevos2 = _mm256_load_ps(&floats[16]);
-            __m128 prevos3 = _mm_load_ss(&floats[24]);
-            cnn_size_t widx = 25 * inc;
-            cnn_size_t widx_delta = 25 * in.depth_;
-            float* pdW = &dW[widx];
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++, pdW += widx_delta) {
-                if (!tbl.is_connected(outc, inc)) {
-                    continue;
-                }
-                __m256 delta = _mm256_broadcast_ss(&curr_delta[outc]);
-                __m256 w0 = _mm256_loadu_ps(pdW+0);
-                __m256 w1 = _mm256_loadu_ps(pdW+8);
-                __m256 w2 = _mm256_loadu_ps(pdW + 16);
-                __m128 w3 = _mm_load_ss(pdW + 24);
-                w0 = madd256_ps(prevos0, delta, w0);
-                w1 = madd256_ps(prevos1, delta, w1);
-                w2 = madd256_ps(prevos2, delta, w2);
-                w3 = madd128_ss(prevos3, _mm256_castps256_ps128(delta), w3);
-                _mm256_storeu_ps(pdW + 0, w0);
-                _mm256_storeu_ps(pdW + 8, w1);
-                _mm256_storeu_ps(pdW+16, w2);
-                _mm_store_ss(pdW+24, w3);
-            }
-        }
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        db[outc] += curr_delta[outc];
+      }
     } else {
-        // prepare load-mask beforehand
-        const size_t nblocks = out.width_ >> 3;
-        static const int32_t masks[] = {
-            -1, -1, -1, -1,
-            -1, -1, -1, -1,
-            0, 0, 0, 0,
-            0, 0, 0, 0,
-        };
-        const size_t remainder = out.width_ & 7;
-        __m256i mask = _mm256_loadu_si256((const __m256i*)(masks + 8 - remainder));
-        auto& weight = params.weight;
-        for (size_t inc = 0; inc < in.depth_; ++inc) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-
-                if (!tbl.is_connected(outc, inc)) continue;
-                const float* delta = &curr_delta[out.get_index(0, 0, outc)];
-
-                cnn_size_t widx = weight.get_index(0, 0, in.depth_ * outc + inc);
-                for (cnn_size_t wy = 0; wy < 5 /* weight.height_ */; wy++) {
-                    for (cnn_size_t wx = 0; wx < 5 /* weight.width_ */; wx++) {
-                        const float* prevo = &prev_out[in_padded.get_index(wx, wy, inc)];
-
-                        if (w_stride > 1) {
-                            float_t dst = float_t(0);
-
-                            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                                cnn_size_t prevo_idx = y * params.in_padded.width_ * params.h_stride;
-                                cnn_size_t delta_idx = y * params.out.width_;
-
-                                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                                    dst += prevo[prevo_idx + x * params.w_stride] * delta[delta_idx + x];
-                                }
-                            }
-                            dW[widx] += dst;
-                        }
-                        else {
-                            __m128 prev_sum = _mm_load_ss(&dW[widx]);
-                            __m256 sum0 = _mm256_setzero_ps();
-                            __m256 sum1 = _mm256_setzero_ps();
-                            for (cnn_size_t y = 0; y < out.height_; y++) {
-                                // vectorize::dot
-                                const float* pa = prevo + y * in_padded.width_ * params.h_stride;
-                                const float* pb = delta + y * out.width_;
-                                for (size_t i = 0; i < nblocks; ++i) {
-                                    __m256 a = _mm256_loadu_ps(pa + 8 * i);
-                                    __m256 b = _mm256_loadu_ps(pb + 8 * i);
-                                    sum0 = madd256_ps(a, b, sum0);
-                                }
-                                if (remainder) {
-                                    __m256 a = _mm256_loadu_ps(pa + 8 * nblocks);
-                                    __m256 b = _mm256_loadu_ps(pb + 8 * nblocks);
-                                    sum1 = madd256_ps(a, b, sum1);
-                                }
-                            }
-                            sum1 = _mm256_and_ps(sum1, _mm256_castsi256_ps(mask));
-                            __m256 sum = _mm256_add_ps(sum0, sum1);
-                            _mm_store_ss(&dW[widx], _mm_add_ps(prev_sum, hsum256_ps(sum)));
-                        }
-                        ++widx;
-                    }
-                }
-            }
-        }
+      for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
+        const float* delta = &curr_delta[out.get_index(0, 0, outc)];
+        db[outc] +=
+            std::accumulate(delta, delta + out.width_ * out.height_, float(0));
+      }
     }
-
-    // accumulate db
-    if (params.has_bias) {
-        //fvec_t& db = *in_grad[2];
-        
-        if (out.width_ == 1 && out.height_ == 1) {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                db[outc] += curr_delta[outc];
-            }
-        } else {
-            for (cnn_size_t outc = 0; outc < out.depth_; outc++) {
-                const float *delta = &curr_delta[out.get_index(0, 0, outc)];
-                db[outc] += std::accumulate(delta, delta + out.width_ * out.height_, float(0));
-            }
-        }
-    }
-} // avx_conv2d_5x5_back_kernel float ver
+  }
+}  // avx_conv2d_5x5_back_kernel float ver
 
 // double ver
 template <typename Allocator>
 void avx_conv2d_5x5_back_kernel(const core::conv_params& params,
                                 const std::vector<double, Allocator>& prev_out,
                                 const std::vector<double, Allocator>& W,
-                                std::vector<double, Allocator>&       dW,
-                                std::vector<double, Allocator>&       db,
-                                std::vector<double, Allocator>&       curr_delta,
-                                std::vector<double, Allocator>*       prev_delta) {
-    // propagate delta to previous layer
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
+                                std::vector<double, Allocator>& dW,
+                                std::vector<double, Allocator>& db,
+                                std::vector<double, Allocator>& curr_delta,
+                                std::vector<double, Allocator>* prev_delta) {
+  // propagate delta to previous layer
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * outc + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const float_t *pw = &W[idx];
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * outc + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const float_t* pw = &W[idx];
 
-            idx = params.out.get_index(0, 0, outc);
-            const float_t *pdelta_src = &curr_delta[idx];
+      idx = params.out.get_index(0, 0, outc);
+      const float_t* pdelta_src = &curr_delta[idx];
 
-            idx = params.in_padded.get_index(0, 0, inc);
-            float_t *pdelta_dst = &(*prev_delta)[idx];
+      idx = params.in_padded.get_index(0, 0, inc);
+      float_t* pdelta_dst = &(*prev_delta)[idx];
 
-            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                    const float_t * ppw = pw;
+      for (cnn_size_t y = 0; y < params.out.height_; y++) {
+        for (cnn_size_t x = 0; x < params.out.width_; x++) {
+          const float_t* ppw = pw;
 
-                    idx = y * params.out.width_ + x;
-                    const float_t ppdelta_src = pdelta_src[idx];
+          idx = y * params.out.width_ + x;
+          const float_t ppdelta_src = pdelta_src[idx];
 
-                    float_t * ppdelta_dst = pdelta_dst +
-                          y * params.h_stride * params.in_padded.width_ +
-                          x * params.w_stride;
+          float_t* ppdelta_dst = pdelta_dst +
+                                 y * params.h_stride * params.in_padded.width_ +
+                                 x * params.w_stride;
 
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                            idx = wy * params.in_padded.width_ + wx;
-                            ppdelta_dst[idx] += *ppw++ * ppdelta_src;
-                        }
-                    }
-                }
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {  // NOLINT
+            for (cnn_size_t wx = 0; wx < params.weight.width_;
+                 wx++) {  // NOLINT
+              idx = wy * params.in_padded.width_ + wx;
+              ppdelta_dst[idx] += *ppw++ * ppdelta_src;
             }
+          }
         }
-    });
-
-    // accumulate dw
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
-
-            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                    float_t dst = float_t(0);
-
-                    cnn_size_t idx = 0;
-                    idx = params.in_padded.get_index(wx, wy, inc);
-                    const float_t * prevo = &prev_out[idx];
-
-                    idx = params.out.get_index(0, 0, outc);
-                    const float_t * delta = &curr_delta[idx];
-
-                    for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                        dst += vectorize::dot(
-                            prevo + y * params.in_padded.width_,
-                            delta + y * params.out.width_,
-                            params.out.width_);
-                    }
-
-                    idx = params.in.depth_ * outc + inc;
-                    dW[params.weight.get_index(wx, wy, idx)] += dst;
-                }
-            }
-        }
-    });
-
-    // accumulate db
-    if (params.has_bias) {
-        //vec_t& db = *in_grad[2];
-
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            cnn_size_t idx = params.out.get_index(0, 0, outc);
-            const float_t * delta = &curr_delta[idx];
-            const float_t * deltaa = delta + params.out.width_ *
-                                             params.out.height_;
-            db[outc] += std::accumulate(delta, deltaa, float_t(0));
-        }
+      }
     }
-} // avx_conv2d_5x5_back_kernel double ver
+  });
 
-#endif // CNN_USE_AVX
+  // accumulate dw
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
 
-inline void
-conv2d_grad_op_avx(const tensor_t&        prev_out,
-                   const vec_t&                  W,
-                   tensor_t&                    dW,
-                   tensor_t&                    db,
-                   tensor_t&            curr_delta,
-                   tensor_t&            prev_delta,
-                   const core::conv_params& params,
-                   const bool    layer_parallelize) {
+      for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+          float_t dst = float_t(0);
+
+          cnn_size_t idx = 0;
+          idx = params.in_padded.get_index(wx, wy, inc);
+          const float_t* prevo = &prev_out[idx];
+
+          idx = params.out.get_index(0, 0, outc);
+          const float_t* delta = &curr_delta[idx];
+
+          for (cnn_size_t y = 0; y < params.out.height_; y++) {
+            dst += vectorize::dot(prevo + y * params.in_padded.width_,
+                                  delta + y * params.out.width_,
+                                  params.out.width_);
+          }
+
+          idx = params.in.depth_ * outc + inc;
+          dW[params.weight.get_index(wx, wy, idx)] += dst;
+        }
+      }
+    }
+  });
+
+  // accumulate db
+  if (params.has_bias) {
+    // vec_t& db = *in_grad[2];
+
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      cnn_size_t idx = params.out.get_index(0, 0, outc);
+      const float_t* delta = &curr_delta[idx];
+      const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+      db[outc] += std::accumulate(delta, deltaa, float_t(0));
+    }
+  }
+}  // avx_conv2d_5x5_back_kernel double ver
+
+#endif  // CNN_USE_AVX
+
+inline void conv2d_grad_op_avx(const tensor_t& prev_out, const vec_t& W,
+                               tensor_t& dW, tensor_t& db, tensor_t& curr_delta,
+                               tensor_t& prev_delta,
+                               const core::conv_params& params,
+                               const bool layer_parallelize) {
 #ifdef CNN_USE_AVX
-    if (params.weight.height_ == 5 && params.weight.width_ == 5) {
-        for_i(prev_out.size(), [&](int sample) {
-            avx_conv2d_5x5_back_kernel(params, prev_out[sample], W, dW[sample], db[sample],
-                                       curr_delta[sample], &prev_delta[sample]);
-        });
-        return;
-    }
+  if (params.weight.height_ == 5 && params.weight.width_ == 5) {
+    for_i(prev_out.size(), [&](int sample) {
+      avx_conv2d_5x5_back_kernel(params, prev_out[sample], W, dW[sample],
+                                 db[sample], curr_delta[sample],
+                                 &prev_delta[sample]);
+    });
+    return;
+  }
 #endif
 
-    conv2d_op_custom(prev_out, W, dW, db, curr_delta,
-                     prev_delta, params, layer_parallelize);
+  conv2d_op_custom(prev_out, W, dW, db, curr_delta, prev_delta, params,
+                   layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/core/kernels/conv2d_op.h
+++ b/tiny_dnn/core/kernels/conv2d_op.h
@@ -15,57 +15,39 @@ namespace tiny_dnn {
 
 class Conv2dOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit Conv2dOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        // incomimg/outcoming data 
-        const tensor_t& in_data = context.input(0);
-        const vec_t&          W = context.input(1)[0];
-        const vec_t&       bias = context.input(2)[0];
-        tensor_t&      out_data = context.output(1);
+  void compute(const core::OpKernelContext& context) override {
+    // incomimg/outcoming data
+    const tensor_t& in_data = context.input(0);
+    const vec_t& W = context.input(1)[0];
+    const vec_t& bias = context.input(2)[0];
+    tensor_t& out_data = context.output(1);
 
-        // initialize outputs
-        fill_tensor(out_data, float_t(0));
+    // initialize outputs
+    fill_tensor(out_data, float_t(0));
 
-        // set the convolution parameters
-        Conv2d::setParams(OpKernel::params_);
+    // set the convolution parameters
+    Conv2d::setParams(OpKernel::params_);
 
-        // call convolution algorithm depending
-        // on the selected engine type
+    // call convolution algorithm depending
+    // on the selected engine type
 
-        const core::backend_t engine = context.engine();
+    const core::backend_t engine = context.engine();
 
-        if (engine == core::backend_t::tiny_dnn) {
-            kernels::conv2d_op_custom(
-                in_data,
-                W,
-                bias,
-                out_data,
-                Conv2d::params(),
-                context.parallelize());
-        }
-        else if (engine == core::backend_t::nnpack) {
-            kernels::conv2d_op_nnpack(
-                in_data,
-                W,
-                bias,
-                out_data,
-                Conv2d::params());
-        }
-        else if (engine == core::backend_t::avx) {
-            kernels::conv2d_op_avx(
-                in_data,
-                W,
-                bias,
-                out_data,
-                Conv2d::params(),
-                context.parallelize());
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(engine));
-        }
+    if (engine == core::backend_t::tiny_dnn) {
+      kernels::conv2d_op_custom(in_data, W, bias, out_data, Conv2d::params(),
+                                context.parallelize());
+    } else if (engine == core::backend_t::nnpack) {
+      kernels::conv2d_op_nnpack(in_data, W, bias, out_data, Conv2d::params());
+    } else if (engine == core::backend_t::avx) {
+      kernels::conv2d_op_avx(in_data, W, bias, out_data, Conv2d::params(),
+                             context.parallelize());
+    } else {
+      throw nn_error("Not supported engine: " + to_string(engine));
     }
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/conv2d_op.h
+++ b/tiny_dnn/core/kernels/conv2d_op.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/op_kernel.h"

--- a/tiny_dnn/core/kernels/conv2d_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_op_avx.h
@@ -5,8 +5,8 @@
 #pragma once
 
 #include <vector>
-#include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/kernels/conv2d_op_custom.h"
+#include "tiny_dnn/core/params/conv_params.h"
 
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/kernels/avx_kernel_common.h"
@@ -23,189 +23,192 @@ void avx_conv2d_5x5_kernel(const core::conv_params& params,
                            const std::vector<float, Allocator>& in,
                            const std::vector<float, Allocator>& W,
                            const std::vector<float, Allocator>& bias,
-                           std::vector<float, Allocator>&       a,
+                           std::vector<float, Allocator>& a,
                            const bool layer_parallelize) {
-    assert(params.weight.height_ == 5 && params.weight.width_ == 5);
-    
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    
-    const size_t out_area = out.area();
-    cnn_size_t oidx = 0;
-    float bias_scale = params.has_bias ? 1.0f : 0.0f;
-    const size_t stride = params.h_stride * in_padded.width_;
-    const size_t inarea = in_padded.area();
+  assert(params.weight.height_ == 5 && params.weight.width_ == 5);
 
-    static const __m256 mask = _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
-    const __m128 y_bias_scale = _mm_set_ss(bias_scale);
-    if (out.height_ == 1 && out.width_ == 1) {
-        const float* pw = (const float*)&W[0];
-        for (size_t o = 0; o < out.depth_; ++o) {
-            __m256 sum0 = _mm256_setzero_ps();
-            __m256 sum1 = _mm256_setzero_ps();
-            __m256 sum2 = _mm256_setzero_ps();
-            __m128 sum3 = _mm_setzero_ps();
-            const float* pi = (const float*)&in[0];
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, pi += inarea) {
-                if (!tbl.is_connected(o, inc)) {
-                    continue;
-                }
-                __m256 w0 = _mm256_loadu_ps(pw + 0);
-                __m256 w1 = _mm256_loadu_ps(pw + 8);
-                __m256 w2 = _mm256_loadu_ps(pw + 16);
-                __m256 i0 = _mm256_loadu_ps(pi + 0);
-                __m256 i1 = _mm256_loadu_ps(pi + 8);
-                __m256 i2 = _mm256_loadu_ps(pi + 16);
-                __m128 w3 = _mm_load_ss(pw + 24);
-                __m128 i3 = _mm_load_ss(pi + 24);
-                __m256 tmp0 = _mm256_mul_ps(w0, i0);
-                __m256 tmp1 = _mm256_mul_ps(w1, i1);
-                __m256 tmp2 = _mm256_mul_ps(w2, i2);
-                __m128 tmp3 = _mm_mul_ps(w3, i3);
-                sum0 = _mm256_add_ps(tmp0, sum0);
-                sum1 = _mm256_add_ps(tmp1, sum1);
-                sum2 = _mm256_add_ps(tmp2, sum2);
-                sum3 = _mm_add_ps(tmp3, sum3);
-            }
-            __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), sum2);
-            __m128 b = _mm_load_ss(&bias[o]);
-            __m128 hsum = hsum256_ps(sum);
-            b = madd128_ss(b, y_bias_scale, sum3);
-            _mm_store_ss(&a[o], _mm_add_ss(hsum, b));
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+
+  const size_t out_area = out.area();
+  cnn_size_t oidx = 0;
+  float bias_scale = params.has_bias ? 1.0f : 0.0f;
+  const size_t stride = params.h_stride * in_padded.width_;
+  const size_t inarea = in_padded.area();
+
+  static const __m256 mask =
+      _mm256_castsi256_ps(_mm256_setr_epi32(-1, -1, -1, -1, -1, 0, 0, 0));
+  const __m128 y_bias_scale = _mm_set_ss(bias_scale);
+  if (out.height_ == 1 && out.width_ == 1) {
+    const float* pw = (const float*)&W[0];
+    for (size_t o = 0; o < out.depth_; ++o) {
+      __m256 sum0 = _mm256_setzero_ps();
+      __m256 sum1 = _mm256_setzero_ps();
+      __m256 sum2 = _mm256_setzero_ps();
+      __m128 sum3 = _mm_setzero_ps();
+      const float* pi = (const float*)&in[0];
+      for (cnn_size_t inc = 0; inc < params.in.depth_;
+           ++inc, pw += 25, pi += inarea) {
+        if (!tbl.is_connected(o, inc)) {
+          continue;
         }
-    } else {
-        const size_t nblocks = out.width_ / 4;
-        for (size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
-            float* pa = &a[oidx];
-            // init to bias value
-            float b = bias[o] * bias_scale;
-            {
-                size_t headSize = 0;
-                __m256 b2 = _mm256_set1_ps(b);
-                if (oidx & 7) {
-                    headSize = 8 - (oidx & 7);
-                    assert(headSize < out_area);
-                    for (size_t i=0; i<headSize; ++i) {
-                        _mm_store_ss(&pa[i], _mm256_castps256_ps128(b2));
-                    }
-                }
-                size_t cnt = (out_area - headSize) / 16;
-                float* pa2 = pa + headSize;
-                for (size_t i=0; i<cnt; ++i) {
-                    _mm256_store_ps(&pa2[i*16+0], b2);
-                    _mm256_store_ps(&pa2[i*16+8], b2);
-                }
-                for (size_t i=headSize+cnt*16; i<out_area; ++i) {
-                    pa[i] = b;
-                }
+        __m256 w0 = _mm256_loadu_ps(pw + 0);
+        __m256 w1 = _mm256_loadu_ps(pw + 8);
+        __m256 w2 = _mm256_loadu_ps(pw + 16);
+        __m256 i0 = _mm256_loadu_ps(pi + 0);
+        __m256 i1 = _mm256_loadu_ps(pi + 8);
+        __m256 i2 = _mm256_loadu_ps(pi + 16);
+        __m128 w3 = _mm_load_ss(pw + 24);
+        __m128 i3 = _mm_load_ss(pi + 24);
+        __m256 tmp0 = _mm256_mul_ps(w0, i0);
+        __m256 tmp1 = _mm256_mul_ps(w1, i1);
+        __m256 tmp2 = _mm256_mul_ps(w2, i2);
+        __m128 tmp3 = _mm_mul_ps(w3, i3);
+        sum0 = _mm256_add_ps(tmp0, sum0);
+        sum1 = _mm256_add_ps(tmp1, sum1);
+        sum2 = _mm256_add_ps(tmp2, sum2);
+        sum3 = _mm_add_ps(tmp3, sum3);
+      }
+      __m256 sum = _mm256_add_ps(_mm256_add_ps(sum0, sum1), sum2);
+      __m128 b = _mm_load_ss(&bias[o]);
+      __m128 hsum = hsum256_ps(sum);
+      b = madd128_ss(b, y_bias_scale, sum3);
+      _mm_store_ss(&a[o], _mm_add_ss(hsum, b));
+    }
+  } else {
+    const size_t nblocks = out.width_ / 4;
+    for (size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
+      float* pa = &a[oidx];
+      // init to bias value
+      float b = bias[o] * bias_scale;
+      {
+        size_t headSize = 0;
+        __m256 b2 = _mm256_set1_ps(b);
+        if (oidx & 7) {
+          headSize = 8 - (oidx & 7);
+          assert(headSize < out_area);
+          for (size_t i = 0; i < headSize; ++i) {
+            _mm_store_ss(&pa[i], _mm256_castps256_ps128(b2));
+          }
+        }
+        size_t cnt = (out_area - headSize) / 16;
+        float* pa2 = pa + headSize;
+        for (size_t i = 0; i < cnt; ++i) {
+          _mm256_store_ps(&pa2[i * 16 + 0], b2);
+          _mm256_store_ps(&pa2[i * 16 + 8], b2);
+        }
+        for (size_t i = headSize + cnt * 16; i < out_area; ++i) {
+          pa[i] = b;
+        }
+      }
+      for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc) {
+        if (!tbl.is_connected(o, inc)) continue;
+
+        const float* pw = (const float*)&W[25 * (params.in.depth_ * o + inc)];
+        const float* pi = (const float*)&in[in_padded.get_index(0, 0, inc)];
+
+        __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw + 0), mask);
+        __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw + 5), mask);
+        __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw + 10), mask);
+        __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw + 15), mask);
+        __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw + 20), mask);
+        __m256 w0b = leftShift<4>(w0a);
+        __m256 w1b = leftShift<4>(w1a);
+        __m256 w2b = leftShift<4>(w2a);
+        __m256 w3b = leftShift<4>(w3a);
+        __m256 w4b = leftShift<4>(w4a);
+        __m256 w0c = leftShift<8>(w0a);
+        __m256 w1c = leftShift<8>(w1a);
+        __m256 w2c = leftShift<8>(w2a);
+        __m256 w3c = leftShift<8>(w3a);
+        __m256 w4c = leftShift<8>(w4a);
+        __m256 w0d = leftShift<12>(w0a);
+        __m256 w1d = leftShift<12>(w1a);
+        __m256 w2d = leftShift<12>(w2a);
+        __m256 w3d = leftShift<12>(w3a);
+        __m256 w4d = leftShift<12>(w4a);
+        float* ppa = pa;
+        for (cnn_size_t y = 0; y < out.height_; y++) {
+          const float* pi0 = (pi + y * stride);
+          const float* pi1 = pi0 + 1 * in_padded.width_;
+          const float* pi2 = pi0 + 2 * in_padded.width_;
+          const float* pi3 = pi0 + 3 * in_padded.width_;
+          const float* pi4 = pi0 + 4 * in_padded.width_;
+          cnn_size_t x = 0;
+          if (w_stride == 1) {
+            __m256 dst0, dst1, dst2, dst3;
+            float* ppa2 = ppa;
+            for (size_t i = 0; i < nblocks; ++i) {
+              __m256 i0 = _mm256_loadu_ps(pi0);
+              __m256 i1 = _mm256_loadu_ps(pi1);
+              __m256 i2 = _mm256_loadu_ps(pi2);
+              __m256 i3 = _mm256_loadu_ps(pi3);
+              __m256 i4 = _mm256_loadu_ps(pi4);
+              __m128 sum = _mm_loadu_ps(ppa2);
+              dst0 = _mm256_mul_ps(w0a, i0);
+              dst1 = _mm256_mul_ps(w0b, i0);
+              dst2 = _mm256_mul_ps(w0c, i0);
+              dst3 = _mm256_mul_ps(w0d, i0);
+              dst0 = madd256_ps(w1a, i1, dst0);
+              dst1 = madd256_ps(w1b, i1, dst1);
+              dst2 = madd256_ps(w1c, i1, dst2);
+              dst3 = madd256_ps(w1d, i1, dst3);
+              dst0 = madd256_ps(w2a, i2, dst0);
+              dst1 = madd256_ps(w2b, i2, dst1);
+              dst2 = madd256_ps(w2c, i2, dst2);
+              dst3 = madd256_ps(w2d, i2, dst3);
+              dst0 = madd256_ps(w3a, i3, dst0);
+              dst1 = madd256_ps(w3b, i3, dst1);
+              dst2 = madd256_ps(w3c, i3, dst2);
+              dst3 = madd256_ps(w3d, i3, dst3);
+              dst0 = madd256_ps(w4a, i4, dst0);
+              dst1 = madd256_ps(w4b, i4, dst1);
+              __m128 hsum01 = hsum2x256_ps(dst0, dst1);
+              dst2 = madd256_ps(w4c, i4, dst2);
+              dst3 = madd256_ps(w4d, i4, dst3);
+              __m128 hsum23 = hsum2x256_ps(dst2, dst3);
+              __m128 sum2 = _mm_castpd_ps(_mm_unpacklo_pd(
+                  _mm_castps_pd(hsum01), _mm_castps_pd(hsum23)));
+              sum = _mm_add_ps(sum, sum2);
+              _mm_storeu_ps(ppa2, sum);
+              pi0 += 4;
+              pi1 += 4;
+              pi2 += 4;
+              pi3 += 4;
+              pi4 += 4;
+              ppa2 += 4;
             }
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc) {
-                if (!tbl.is_connected(o, inc)) continue;
-
-                const float* pw = (const float*) &W[25 * (params.in.depth_ * o + inc)];
-                const float* pi = (const float*) &in[in_padded.get_index(0, 0, inc)];
-
-                __m256 w0a = _mm256_and_ps(_mm256_loadu_ps(pw+0), mask);
-                __m256 w1a = _mm256_and_ps(_mm256_loadu_ps(pw+5), mask);
-                __m256 w2a = _mm256_and_ps(_mm256_loadu_ps(pw+10), mask);
-                __m256 w3a = _mm256_and_ps(_mm256_loadu_ps(pw+15), mask);
-                __m256 w4a = _mm256_and_ps(_mm256_loadu_ps(pw+20), mask);
-                __m256 w0b = leftShift<4>(w0a);
-                __m256 w1b = leftShift<4>(w1a);
-                __m256 w2b = leftShift<4>(w2a);
-                __m256 w3b = leftShift<4>(w3a);
-                __m256 w4b = leftShift<4>(w4a);
-                __m256 w0c = leftShift<8>(w0a);
-                __m256 w1c = leftShift<8>(w1a);
-                __m256 w2c = leftShift<8>(w2a);
-                __m256 w3c = leftShift<8>(w3a);
-                __m256 w4c = leftShift<8>(w4a);
-                __m256 w0d = leftShift<12>(w0a);
-                __m256 w1d = leftShift<12>(w1a);
-                __m256 w2d = leftShift<12>(w2a);
-                __m256 w3d = leftShift<12>(w3a);
-                __m256 w4d = leftShift<12>(w4a);
-                float* ppa = pa;
-                for (cnn_size_t y = 0; y < out.height_; y++) {
-                    const float* pi0 = (pi + y * stride);
-                    const float* pi1 = pi0 + 1 * in_padded.width_;
-                    const float* pi2 = pi0 + 2 * in_padded.width_;
-                    const float* pi3 = pi0 + 3 * in_padded.width_;
-                    const float* pi4 = pi0 + 4 * in_padded.width_;
-                    cnn_size_t x = 0;
-                    if (w_stride == 1) {
-                        __m256 dst0, dst1, dst2, dst3;
-                        float* ppa2 = ppa;
-                        for (size_t i = 0; i < nblocks; ++i) {
-                            __m256 i0 = _mm256_loadu_ps(pi0);
-                            __m256 i1 = _mm256_loadu_ps(pi1);
-                            __m256 i2 = _mm256_loadu_ps(pi2);
-                            __m256 i3 = _mm256_loadu_ps(pi3);
-                            __m256 i4 = _mm256_loadu_ps(pi4);
-                            __m128 sum = _mm_loadu_ps(ppa2);
-                            dst0 = _mm256_mul_ps(w0a, i0);
-                            dst1 = _mm256_mul_ps(w0b, i0);
-                            dst2 = _mm256_mul_ps(w0c, i0);
-                            dst3 = _mm256_mul_ps(w0d, i0);
-                            dst0 = madd256_ps(w1a, i1, dst0);
-                            dst1 = madd256_ps(w1b, i1, dst1);
-                            dst2 = madd256_ps(w1c, i1, dst2);
-                            dst3 = madd256_ps(w1d, i1, dst3);
-                            dst0 = madd256_ps(w2a, i2, dst0);
-                            dst1 = madd256_ps(w2b, i2, dst1);
-                            dst2 = madd256_ps(w2c, i2, dst2);
-                            dst3 = madd256_ps(w2d, i2, dst3);
-                            dst0 = madd256_ps(w3a, i3, dst0);
-                            dst1 = madd256_ps(w3b, i3, dst1);
-                            dst2 = madd256_ps(w3c, i3, dst2);
-                            dst3 = madd256_ps(w3d, i3, dst3);
-                            dst0 = madd256_ps(w4a, i4, dst0);
-                            dst1 = madd256_ps(w4b, i4, dst1);
-                            __m128 hsum01 = hsum2x256_ps(dst0, dst1);
-                            dst2 = madd256_ps(w4c, i4, dst2);
-                            dst3 = madd256_ps(w4d, i4, dst3);
-                            __m128 hsum23 = hsum2x256_ps(dst2, dst3);
-                            __m128 sum2 = _mm_castpd_ps(_mm_unpacklo_pd(_mm_castps_pd(hsum01), _mm_castps_pd(hsum23)));
-                            sum = _mm_add_ps(sum, sum2);
-                            _mm_storeu_ps(ppa2, sum);
-                            pi0 += 4;
-                            pi1 += 4;
-                            pi2 += 4;
-                            pi3 += 4;
-                            pi4 += 4;
-                            ppa2 += 4;
-                        }
-                        x = nblocks * 4;
-                    }
-                    for (; x < out.width_; ++x) {
-                        __m128 sum = _mm_load_ss(&ppa[x]);
-                        __m256 i0 = _mm256_loadu_ps(pi0);
-                        __m256 i1 = _mm256_loadu_ps(pi1);
-                        __m256 i2 = _mm256_loadu_ps(pi2);
-                        __m256 i3 = _mm256_loadu_ps(pi3);
-                        __m256 i4 = _mm256_loadu_ps(pi4);
-                        __m256 sum0 = _mm256_mul_ps(w0a, i0);
-                        __m256 sum1 = _mm256_mul_ps(w1a, i1);
-                        sum0 = madd256_ps(w2a, i2, sum0);
-                        sum1 = madd256_ps(w3a, i3, sum1);
-                        sum0 = madd256_ps(w4a, i4, sum0);
-                        sum0 = _mm256_add_ps(sum0, sum1);
-                        _mm_store_ss(&ppa[x], _mm_add_ss(sum, hsum256_ps(sum0)));
-//                      printf("%d %d %d %f\n", inc, y, x, ppa[x]);
-                        pi0 += w_stride;
-                        pi1 += w_stride;
-                        pi2 += w_stride;
-                        pi3 += w_stride;
-                        pi4 += w_stride;
-                    } // x loop
-                    ppa += out.width_;
-                } // y loop
-            } // in depth loop
-        } // out depth loop
-    } // else
-} // avx_conv2d_5x5_kernel float ver
+            x = nblocks * 4;
+          }
+          for (; x < out.width_; ++x) {
+            __m128 sum = _mm_load_ss(&ppa[x]);
+            __m256 i0 = _mm256_loadu_ps(pi0);
+            __m256 i1 = _mm256_loadu_ps(pi1);
+            __m256 i2 = _mm256_loadu_ps(pi2);
+            __m256 i3 = _mm256_loadu_ps(pi3);
+            __m256 i4 = _mm256_loadu_ps(pi4);
+            __m256 sum0 = _mm256_mul_ps(w0a, i0);
+            __m256 sum1 = _mm256_mul_ps(w1a, i1);
+            sum0 = madd256_ps(w2a, i2, sum0);
+            sum1 = madd256_ps(w3a, i3, sum1);
+            sum0 = madd256_ps(w4a, i4, sum0);
+            sum0 = _mm256_add_ps(sum0, sum1);
+            _mm_store_ss(&ppa[x], _mm_add_ss(sum, hsum256_ps(sum0)));
+            //                      printf("%d %d %d %f\n", inc, y, x, ppa[x]);
+            pi0 += w_stride;
+            pi1 += w_stride;
+            pi2 += w_stride;
+            pi3 += w_stride;
+            pi4 += w_stride;
+          }  // x loop
+          ppa += out.width_;
+        }  // y loop
+      }    // in depth loop
+    }      // out depth loop
+  }        // else
+}  // avx_conv2d_5x5_kernel float ver
 
 // double ver
 template <typename Allocator>
@@ -213,176 +216,178 @@ void avx_conv2d_5x5_kernel(const core::conv_params& params,
                            const std::vector<double, Allocator>& in,
                            const std::vector<double, Allocator>& W,
                            const std::vector<double, Allocator>& bias,
-                           std::vector<double, Allocator>&       a,
+                           std::vector<double, Allocator>& a,
                            const bool layer_parallelize) {
-    assert(params.weight.height_ == 5 && params.weight.width_ == 5);
-    
-    auto& out       = params.out;
-    auto& in_padded = params.in_padded;
-    auto& tbl       = params.tbl;
-    auto  w_stride  = params.w_stride;
-    
-    const size_t out_area = out.area();
-    double bias_scale = params.has_bias ? 1.0 : 0.0;
-    const __m128d y_bias_scale = _mm_set_sd(bias_scale);
-    cnn_size_t oidx = 0;
+  assert(params.weight.height_ == 5 && params.weight.width_ == 5);
 
-    const double* pw = &W[0];
-    const size_t in_stride = params.h_stride * in_padded.width_;
-    const size_t in_padded_area = in_padded.area();
-    if (out.height_ == 1 && out.width_ == 1) {
-        for (size_t o = 0; o < out.depth_; ++o) {
-            __m256d sum0 = _mm256_setzero_pd();
-            __m256d sum1 = _mm256_setzero_pd();
-            __m256d sum2 = _mm256_setzero_pd();
-            __m256d sum3 = _mm256_setzero_pd();
-            __m256d sum4 = _mm256_setzero_pd();
-            __m256d sum5 = _mm256_setzero_pd();
-            __m128d sum6 = _mm_setzero_pd();
-            size_t inidx = 0;
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, inidx += in_padded_area) {
-                if (!tbl.is_connected(o, inc)) {
-                    continue;
-                }
-                __m256d w0 = _mm256_loadu_pd(pw + 0);
-                __m256d w1 = _mm256_loadu_pd(pw + 4);
-                __m256d w2 = _mm256_loadu_pd(pw + 8);
-                __m256d w3 = _mm256_loadu_pd(pw + 12);
-                __m256d w4 = _mm256_loadu_pd(pw + 16);
-                __m256d w5 = _mm256_loadu_pd(pw + 20);
-                __m128d w6 = _mm_load_sd(pw + 24);
-                const double* pi = (const double*)&in[inidx];
-                __m256d i0 = _mm256_loadu_pd(pi + 0);
-                __m256d i1 = _mm256_loadu_pd(pi + 4);
-                __m256d i2 = _mm256_loadu_pd(pi + 8);
-                __m256d i3 = _mm256_loadu_pd(pi + 12);
-                __m256d i4 = _mm256_loadu_pd(pi + 16);
-                __m256d i5 = _mm256_loadu_pd(pi + 20);
-                __m128d i6 = _mm_load_sd(pi + 24);
-                __m256d tmp0 = _mm256_mul_pd(w0, i0);
-                __m256d tmp1 = _mm256_mul_pd(w1, i1);
-                __m256d tmp2 = _mm256_mul_pd(w2, i2);
-                __m256d tmp3 = _mm256_mul_pd(w3, i3);
-                __m256d tmp4 = _mm256_mul_pd(w4, i4);
-                __m256d tmp5 = _mm256_mul_pd(w5, i5);
-                __m128d tmp6 = _mm_mul_pd(w6, i6);
-                sum0 = _mm256_add_pd(tmp0, sum0);
-                sum1 = _mm256_add_pd(tmp1, sum1);
-                sum2 = _mm256_add_pd(tmp2, sum2);
-                sum3 = _mm256_add_pd(tmp3, sum3);
-                sum4 = _mm256_add_pd(tmp4, sum4);
-                sum5 = _mm256_add_pd(tmp5, sum5);
-                sum6 = _mm_add_pd(tmp6, sum6);
-            }
-            sum0 = _mm256_add_pd(sum0, sum1);
-            sum2 = _mm256_add_pd(sum2, sum3);
-            sum4 = _mm256_add_pd(sum4, sum5);
-            sum0 = _mm256_add_pd(sum0, sum2);
-            __m256d sum = _mm256_add_pd(sum0, sum4);
-            __m128d b = _mm_load_sd(&bias[o]);
-            __m128d hsum = hsum256_pd(sum);
-            b = madd128_sd(b, y_bias_scale, sum6);
-            _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
+  auto& out = params.out;
+  auto& in_padded = params.in_padded;
+  auto& tbl = params.tbl;
+  auto w_stride = params.w_stride;
+
+  const size_t out_area = out.area();
+  double bias_scale = params.has_bias ? 1.0 : 0.0;
+  const __m128d y_bias_scale = _mm_set_sd(bias_scale);
+  cnn_size_t oidx = 0;
+
+  const double* pw = &W[0];
+  const size_t in_stride = params.h_stride * in_padded.width_;
+  const size_t in_padded_area = in_padded.area();
+  if (out.height_ == 1 && out.width_ == 1) {
+    for (size_t o = 0; o < out.depth_; ++o) {
+      __m256d sum0 = _mm256_setzero_pd();
+      __m256d sum1 = _mm256_setzero_pd();
+      __m256d sum2 = _mm256_setzero_pd();
+      __m256d sum3 = _mm256_setzero_pd();
+      __m256d sum4 = _mm256_setzero_pd();
+      __m256d sum5 = _mm256_setzero_pd();
+      __m128d sum6 = _mm_setzero_pd();
+      size_t inidx = 0;
+      for (cnn_size_t inc = 0; inc < params.in.depth_;
+           ++inc, pw += 25, inidx += in_padded_area) {
+        if (!tbl.is_connected(o, inc)) {
+          continue;
         }
-    } else {
-        for (cnn_size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
-            double* pa = &a[oidx];
-            double b = bias[o] * bias_scale;
-            {
-                size_t headSize = 0;
-                __m256d b2 = _mm256_set1_pd(b);
-                if (oidx & 3) {
-                    headSize = 4 - (oidx & 3);
-                    assert(headSize < out_area);
-                    for (size_t i = 0; i < headSize; ++i) {
-                        _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
-                    }
-                }
-                size_t cnt = (out_area - headSize) / 8;
-                double* pa2 = pa + headSize;
-                for (size_t i = 0; i < cnt; ++i) {
-                    _mm256_store_pd(&pa2[i*8+0], b2);
-                    _mm256_store_pd(&pa2[i*8+4], b2);
-                }
-                for (size_t i = headSize + cnt*8; i < out_area; ++i) {
-                    _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
-                }
-            }
-            const double* pi0 = &in[0];
-            for (cnn_size_t inc = 0; inc < params.in.depth_; ++inc, pw += 25, pi0 += in_padded_area) {
-                if (!tbl.is_connected(o, inc)) continue;
-                __m256d w0a = _mm256_loadu_pd(pw+0);
-                __m128d w0b = _mm_load_sd(pw+4);
-                __m256d w1a = _mm256_loadu_pd(pw+5);
-                __m128d w1b = _mm_load_sd(pw+9);
-                __m256d w2a = _mm256_loadu_pd(pw+10);
-                __m128d w2b = _mm_load_sd(pw+14);
-                __m256d w3a = _mm256_loadu_pd(pw+15);
-                __m128d w3b = _mm_load_sd(pw+19);
-                __m256d w4a = _mm256_loadu_pd(pw+20);
-                __m128d w4b = _mm_load_sd(pw+24);
-                const double* pi = pi0;
-                double* pa2 = pa;
-                for (cnn_size_t y = 0; y < out.height_; ++y, pi += in_stride, pa2 += out.width_) {
-                    const double* pi1 = pi + 1 * in_padded.width_;
-                    const double* pi2 = pi + 2 * in_padded.width_;
-                    const double* pi3 = pi + 3 * in_padded.width_;
-                    const double* pi4 = pi + 4 * in_padded.width_;
-                    for (cnn_size_t x = 0; x < out.width_; ++x) {
-                        __m128d sum = _mm_load_sd(&pa2[x]);
-                        __m256d i0a = _mm256_loadu_pd(pi);
-                        __m128d i0b = _mm_load_sd(pi + 4);
-                        __m256d i1a = _mm256_loadu_pd(pi1);
-                        __m128d i1b = _mm_load_sd(pi1 + 4);
-                        __m256d i2a = _mm256_loadu_pd(pi2);
-                        __m128d i2b = _mm_load_sd(pi2 + 4);
-                        __m256d i3a = _mm256_loadu_pd(pi3);
-                        __m128d i3b = _mm_load_sd(pi3 + 4);
-                        __m256d i4a = _mm256_loadu_pd(pi4);
-                        __m128d i4b = _mm_load_sd(pi4 + 4);
-                        __m256d sum_a = _mm256_mul_pd(w0a, i0a);
-                        __m128d sum_b = _mm_mul_sd(w0b, i0b);
-                        sum_a = madd256_pd(w1a, i1a, sum_a);
-                        sum_b = madd128_pd(w1b, i1b, sum_b);
-                        sum_a = madd256_pd(w2a, i2a, sum_a);
-                        sum_b = madd128_pd(w2b, i2b, sum_b);
-                        sum_a = madd256_pd(w3a, i3a, sum_a);
-                        sum_b = madd128_pd(w3b, i3b, sum_b);
-                        sum_a = madd256_pd(w4a, i4a, sum_a);
-                        sum_b = madd128_pd(w4b, i4b, sum_b);
-                        __m128d sum_c = hsum256_pd(sum_a);
-                        sum = _mm_add_sd(sum, sum_b);
-                        _mm_store_sd(&pa2[x], _mm_add_sd(sum, sum_c));
-                        pi0 += w_stride;
-                        pi1 += w_stride;
-                        pi2 += w_stride;
-                        pi3 += w_stride;
-                        pi4 += w_stride;
-                    } // x loop
-                } // y loop
-            } // in depth loop
-        } // out depth loop
-    } // else
-} // avx_conv2d_5x5_kernel double ver
-
-#endif // CNN_USE_AVX
-
-inline void conv2d_op_avx(const tensor_t&         in_data,
-                          const vec_t&                  W,
-                          const vec_t&               bias,
-                          tensor_t&              out_data,
-                          const core::conv_params& params,
-                          const bool    layer_parallelize) {
-#ifdef CNN_USE_AVX
-    if (params.weight.height_ == 5 && params.weight.width_ == 5) {
-        // @todo consider better parallelization
-        for_i(layer_parallelize, in_data.size(), [&](int i) {
-            avx_conv2d_5x5_kernel(params, in_data[i], W, bias, out_data[i], layer_parallelize);
-        });
-        return;
+        __m256d w0 = _mm256_loadu_pd(pw + 0);
+        __m256d w1 = _mm256_loadu_pd(pw + 4);
+        __m256d w2 = _mm256_loadu_pd(pw + 8);
+        __m256d w3 = _mm256_loadu_pd(pw + 12);
+        __m256d w4 = _mm256_loadu_pd(pw + 16);
+        __m256d w5 = _mm256_loadu_pd(pw + 20);
+        __m128d w6 = _mm_load_sd(pw + 24);
+        const double* pi = (const double*)&in[inidx];
+        __m256d i0 = _mm256_loadu_pd(pi + 0);
+        __m256d i1 = _mm256_loadu_pd(pi + 4);
+        __m256d i2 = _mm256_loadu_pd(pi + 8);
+        __m256d i3 = _mm256_loadu_pd(pi + 12);
+        __m256d i4 = _mm256_loadu_pd(pi + 16);
+        __m256d i5 = _mm256_loadu_pd(pi + 20);
+        __m128d i6 = _mm_load_sd(pi + 24);
+        __m256d tmp0 = _mm256_mul_pd(w0, i0);
+        __m256d tmp1 = _mm256_mul_pd(w1, i1);
+        __m256d tmp2 = _mm256_mul_pd(w2, i2);
+        __m256d tmp3 = _mm256_mul_pd(w3, i3);
+        __m256d tmp4 = _mm256_mul_pd(w4, i4);
+        __m256d tmp5 = _mm256_mul_pd(w5, i5);
+        __m128d tmp6 = _mm_mul_pd(w6, i6);
+        sum0 = _mm256_add_pd(tmp0, sum0);
+        sum1 = _mm256_add_pd(tmp1, sum1);
+        sum2 = _mm256_add_pd(tmp2, sum2);
+        sum3 = _mm256_add_pd(tmp3, sum3);
+        sum4 = _mm256_add_pd(tmp4, sum4);
+        sum5 = _mm256_add_pd(tmp5, sum5);
+        sum6 = _mm_add_pd(tmp6, sum6);
+      }
+      sum0 = _mm256_add_pd(sum0, sum1);
+      sum2 = _mm256_add_pd(sum2, sum3);
+      sum4 = _mm256_add_pd(sum4, sum5);
+      sum0 = _mm256_add_pd(sum0, sum2);
+      __m256d sum = _mm256_add_pd(sum0, sum4);
+      __m128d b = _mm_load_sd(&bias[o]);
+      __m128d hsum = hsum256_pd(sum);
+      b = madd128_sd(b, y_bias_scale, sum6);
+      _mm_store_sd(&a[o], _mm_add_sd(hsum, b));
     }
+  } else {
+    for (cnn_size_t o = 0; o < out.depth_; ++o, oidx += out_area) {
+      double* pa = &a[oidx];
+      double b = bias[o] * bias_scale;
+      {
+        size_t headSize = 0;
+        __m256d b2 = _mm256_set1_pd(b);
+        if (oidx & 3) {
+          headSize = 4 - (oidx & 3);
+          assert(headSize < out_area);
+          for (size_t i = 0; i < headSize; ++i) {
+            _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
+          }
+        }
+        size_t cnt = (out_area - headSize) / 8;
+        double* pa2 = pa + headSize;
+        for (size_t i = 0; i < cnt; ++i) {
+          _mm256_store_pd(&pa2[i * 8 + 0], b2);
+          _mm256_store_pd(&pa2[i * 8 + 4], b2);
+        }
+        for (size_t i = headSize + cnt * 8; i < out_area; ++i) {
+          _mm_store_sd(&pa[i], _mm256_castpd256_pd128(b2));
+        }
+      }
+      const double* pi0 = &in[0];
+      for (cnn_size_t inc = 0; inc < params.in.depth_;
+           ++inc, pw += 25, pi0 += in_padded_area) {
+        if (!tbl.is_connected(o, inc)) continue;
+        __m256d w0a = _mm256_loadu_pd(pw + 0);
+        __m128d w0b = _mm_load_sd(pw + 4);
+        __m256d w1a = _mm256_loadu_pd(pw + 5);
+        __m128d w1b = _mm_load_sd(pw + 9);
+        __m256d w2a = _mm256_loadu_pd(pw + 10);
+        __m128d w2b = _mm_load_sd(pw + 14);
+        __m256d w3a = _mm256_loadu_pd(pw + 15);
+        __m128d w3b = _mm_load_sd(pw + 19);
+        __m256d w4a = _mm256_loadu_pd(pw + 20);
+        __m128d w4b = _mm_load_sd(pw + 24);
+        const double* pi = pi0;
+        double* pa2 = pa;
+        for (cnn_size_t y = 0; y < out.height_;
+             ++y, pi += in_stride, pa2 += out.width_) {
+          const double* pi1 = pi + 1 * in_padded.width_;
+          const double* pi2 = pi + 2 * in_padded.width_;
+          const double* pi3 = pi + 3 * in_padded.width_;
+          const double* pi4 = pi + 4 * in_padded.width_;
+          for (cnn_size_t x = 0; x < out.width_; ++x) {
+            __m128d sum = _mm_load_sd(&pa2[x]);
+            __m256d i0a = _mm256_loadu_pd(pi);
+            __m128d i0b = _mm_load_sd(pi + 4);
+            __m256d i1a = _mm256_loadu_pd(pi1);
+            __m128d i1b = _mm_load_sd(pi1 + 4);
+            __m256d i2a = _mm256_loadu_pd(pi2);
+            __m128d i2b = _mm_load_sd(pi2 + 4);
+            __m256d i3a = _mm256_loadu_pd(pi3);
+            __m128d i3b = _mm_load_sd(pi3 + 4);
+            __m256d i4a = _mm256_loadu_pd(pi4);
+            __m128d i4b = _mm_load_sd(pi4 + 4);
+            __m256d sum_a = _mm256_mul_pd(w0a, i0a);
+            __m128d sum_b = _mm_mul_sd(w0b, i0b);
+            sum_a = madd256_pd(w1a, i1a, sum_a);
+            sum_b = madd128_pd(w1b, i1b, sum_b);
+            sum_a = madd256_pd(w2a, i2a, sum_a);
+            sum_b = madd128_pd(w2b, i2b, sum_b);
+            sum_a = madd256_pd(w3a, i3a, sum_a);
+            sum_b = madd128_pd(w3b, i3b, sum_b);
+            sum_a = madd256_pd(w4a, i4a, sum_a);
+            sum_b = madd128_pd(w4b, i4b, sum_b);
+            __m128d sum_c = hsum256_pd(sum_a);
+            sum = _mm_add_sd(sum, sum_b);
+            _mm_store_sd(&pa2[x], _mm_add_sd(sum, sum_c));
+            pi0 += w_stride;
+            pi1 += w_stride;
+            pi2 += w_stride;
+            pi3 += w_stride;
+            pi4 += w_stride;
+          }  // x loop
+        }    // y loop
+      }      // in depth loop
+    }        // out depth loop
+  }          // else
+}  // avx_conv2d_5x5_kernel double ver
+
+#endif  // CNN_USE_AVX
+
+inline void conv2d_op_avx(const tensor_t& in_data, const vec_t& W,
+                          const vec_t& bias, tensor_t& out_data,
+                          const core::conv_params& params,
+                          const bool layer_parallelize) {
+#ifdef CNN_USE_AVX
+  if (params.weight.height_ == 5 && params.weight.width_ == 5) {
+    // @todo consider better parallelization
+    for_i(layer_parallelize, in_data.size(), [&](int i) {
+      avx_conv2d_5x5_kernel(params, in_data[i], W, bias, out_data[i],
+                            layer_parallelize);
+    });
+    return;
+  }
 #endif
-    conv2d_op_custom(in_data, W, bias, out_data, params, layer_parallelize);
+  conv2d_op_custom(in_data, W, bias, out_data, params, layer_parallelize);
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/conv2d_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_op_avx.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/core/kernels/conv2d_op_custom.h
+++ b/tiny_dnn/core/kernels/conv2d_op_custom.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/kernels/conv2d_op_custom.h
+++ b/tiny_dnn/core/kernels/conv2d_op_custom.h
@@ -7,167 +7,161 @@
 namespace tiny_dnn {
 namespace kernels {
 
-inline void
-conv2d_op_custom(const tensor_t&         in_data,
-                 const vec_t&                  W,
-                 const vec_t&               bias,
-                 tensor_t&              out_data,
-                 const core::conv_params& params,
-                 const bool          parallelize) {
-    for_i(parallelize, in_data.size(), [&](int sample) {
-        const vec_t& in = in_data[sample];
-        vec_t& a = out_data[sample];
+inline void conv2d_op_custom(const tensor_t& in_data, const vec_t& W,
+                             const vec_t& bias, tensor_t& out_data,
+                             const core::conv_params& params,
+                             const bool parallelize) {
+  for_i(parallelize, in_data.size(), [&](int sample) {
+    const vec_t& in = in_data[sample];
+    vec_t& a = out_data[sample];
 
-        for (cnn_size_t o = 0; o < params.out.depth_; o++) {
-            for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-                if (!params.tbl.is_connected(o, inc)) continue;
+    for (cnn_size_t o = 0; o < params.out.depth_; o++) {
+      for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+        if (!params.tbl.is_connected(o, inc)) continue;
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * o + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                const float_t *pw = &W[idx];
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * o + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        const float_t* pw = &W[idx];
 
-                idx = params.in_padded.get_index(0, 0, inc);
-                const float_t *pi = &in[idx];
+        idx = params.in_padded.get_index(0, 0, inc);
+        const float_t* pi = &in[idx];
 
-                idx = params.out.get_index(0, 0, o);
-                float_t *pa = &a[idx];
+        idx = params.out.get_index(0, 0, o);
+        float_t* pa = &a[idx];
 
-                for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                        const float_t * ppw = pw;
-                        const float_t * ppi = pi + params.in_padded.width_ *
-                            (y * params.h_stride) +
-                            x * params.w_stride;
-                        float_t sum = float_t(0);
+        for (cnn_size_t y = 0; y < params.out.height_; y++) {
+          for (cnn_size_t x = 0; x < params.out.width_; x++) {
+            const float_t* ppw = pw;
+            const float_t* ppi =
+                pi + params.in_padded.width_ * (y * params.h_stride) +
+                x * params.w_stride;
+            float_t sum = float_t(0);
 
-                        // should be optimized for small kernel(3x3,5x5)
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                                idx = wy * params.in_padded.width_ + wx;
-                                sum += *ppw++ * ppi[idx];
-                            }
-                        }
-                        pa[y * params.out.width_ + x] += sum;
-                    }
-                }
+            // should be optimized for small kernel(3x3,5x5)
+            for (cnn_size_t wy = 0; wy < params.weight.height_;
+                 wy++) {  // NOLINT
+              for (cnn_size_t wx = 0; wx < params.weight.width_;
+                   wx++) {  // NOLINT
+                idx = wy * params.in_padded.width_ + wx;
+                sum += *ppw++ * ppi[idx];
+              }
             }
-
-            if (params.has_bias) {
-                float_t * pa = &a[params.out.get_index(0, 0, o)];
-                float_t * paa = pa + params.out.width_ * params.out.height_;
-                std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
-            }
+            pa[y * params.out.width_ + x] += sum;
+          }
         }
-    });
-}
+      }
 
+      if (params.has_bias) {
+        float_t* pa = &a[params.out.get_index(0, 0, o)];
+        float_t* paa = pa + params.out.width_ * params.out.height_;
+        std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
+      }
+    }
+  });
+}
 
 /******************************************************************/
 
+inline void conv2d_op_custom(const tensor_t& prev_out, const vec_t& W,
+                             tensor_t& dW, tensor_t& db, tensor_t& curr_delta,
+                             tensor_t& prev_delta,
+                             const core::conv_params& params,
+                             const bool parallelize) {
+  for_i(parallelize, prev_out.size(), [&](int sample) {
+    // propagate delta to previous layer
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
 
-inline void
-conv2d_op_custom(const tensor_t&        prev_out,
-                 const vec_t&                  W,
-                 tensor_t&                    dW,
-                 tensor_t&                    db,
-                 tensor_t&            curr_delta,
-                 tensor_t&            prev_delta,
-                 const core::conv_params& params,
-                 const bool          parallelize) {
-    for_i(parallelize, prev_out.size(), [&](int sample) {
-        // propagate delta to previous layer
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * outc + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        const float_t* pw = &W[idx];
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * outc + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                const float_t *pw = &W[idx];
+        idx = params.out.get_index(0, 0, outc);
+        const float_t* pdelta_src = &curr_delta[sample][idx];
 
-                idx = params.out.get_index(0, 0, outc);
-                const float_t *pdelta_src = &curr_delta[sample][idx];
+        idx = params.in_padded.get_index(0, 0, inc);
+        // float_t *pdelta_dst = &(*prev_delta)[sample][idx];
+        float_t* pdelta_dst = &prev_delta[sample][idx];
 
-                idx = params.in_padded.get_index(0, 0, inc);
-                //float_t *pdelta_dst = &(*prev_delta)[sample][idx];
-                float_t *pdelta_dst = &prev_delta[sample][idx];
+        for (cnn_size_t y = 0; y < params.out.height_; y++) {
+          for (cnn_size_t x = 0; x < params.out.width_; x++) {
+            const float_t* ppw = pw;
 
-                for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                        const float_t * ppw = pw;
+            idx = y * params.out.width_ + x;
+            const float_t ppdelta_src = pdelta_src[idx];
 
-                        idx = y * params.out.width_ + x;
-                        const float_t ppdelta_src = pdelta_src[idx];
+            float_t* ppdelta_dst =
+                pdelta_dst + y * params.h_stride * params.in_padded.width_ +
+                x * params.w_stride;
 
-                        float_t * ppdelta_dst = pdelta_dst +
-                                y * params.h_stride * params.in_padded.width_ +
-                                x * params.w_stride;
+            for (cnn_size_t wy = 0; wy < params.weight.height_;
+                 wy++) {  // NOLINT
+              for (cnn_size_t wx = 0; wx < params.weight.width_;
+                   wx++) {  // NOLINT
+                idx = wy * params.in_padded.width_ + wx;
+                ppdelta_dst[idx] += *ppw++ * ppdelta_src;
+              }
+            }
+          }
+        }
+      }
+    }
 
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                                idx = wy * params.in_padded.width_ + wx;
-                                ppdelta_dst[idx] += *ppw++ * ppdelta_src;
-                            }
-                        }
-                    }
+    // accumulate dw
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
+
+        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+          for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+            float_t dst = float_t(0);
+
+            cnn_size_t idx = 0;
+            idx = params.in_padded.get_index(wx, wy, inc);
+            const float_t* prevo = &prev_out[sample][idx];
+
+            idx = params.out.get_index(0, 0, outc);
+            const float_t* delta = &curr_delta[sample][idx];
+
+            if (params.w_stride > 1) {
+              for (cnn_size_t y = 0; y < params.out.height_; y++) {
+                cnn_size_t prevo_idx =
+                    y * params.in_padded.width_ * params.h_stride;
+                cnn_size_t delta_idx = y * params.out.width_;
+
+                for (cnn_size_t x = 0; x < params.out.width_; x++) {
+                  dst += prevo[prevo_idx + x * params.w_stride] *
+                         delta[delta_idx + x];
                 }
+              }
+            } else {
+              for (cnn_size_t y = 0; y < params.out.height_; y++) {
+                dst += vectorize::dot(
+                    prevo + y * params.in_padded.width_ * params.h_stride,
+                    delta + y * params.out.width_, params.out.width_);
+              }
             }
+
+            idx = params.in.depth_ * outc + inc;
+            dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
+          }
         }
+      }
+    }
 
-        // accumulate dw
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
-
-                for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                    for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                        float_t dst = float_t(0);
-
-                        cnn_size_t idx = 0;
-                        idx = params.in_padded.get_index(wx, wy, inc);
-                        const float_t * prevo = &prev_out[sample][idx];
-
-                        idx = params.out.get_index(0, 0, outc);
-                        const float_t * delta = &curr_delta[sample][idx];
-
-                        if (params.w_stride > 1) {
-                            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                                cnn_size_t prevo_idx = y * params.in_padded.width_ * params.h_stride;
-                                cnn_size_t delta_idx = y * params.out.width_;
-
-                                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                                    dst += prevo[prevo_idx + x * params.w_stride] * delta[delta_idx + x];
-                                }
-                            }
-                        } else {
-                            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                                dst += vectorize::dot(
-                                    prevo + y * params.in_padded.width_ * params.h_stride,
-                                    delta + y * params.out.width_,
-                                    params.out.width_);
-                            }
-                        }
-
-
-                        idx = params.in.depth_ * outc + inc;
-                        dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
-                    }
-                }
-            }
-        }
-
-        // accumulate db
-        if (params.has_bias) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                cnn_size_t idx = params.out.get_index(0, 0, outc);
-                const float_t * delta = &curr_delta[sample][idx];
-                const float_t * deltaa = delta + params.out.width_ *
-                    params.out.height_;
-                db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
-            }
-        }
-    });
+    // accumulate db
+    if (params.has_bias) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        cnn_size_t idx = params.out.get_index(0, 0, outc);
+        const float_t* delta = &curr_delta[sample][idx];
+        const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+        db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
+      }
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/conv2d_op_libdnn.h
+++ b/tiny_dnn/core/kernels/conv2d_op_libdnn.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-cnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/kernels/conv2d.h"

--- a/tiny_dnn/core/kernels/conv2d_op_libdnn.h
+++ b/tiny_dnn/core/kernels/conv2d_op_libdnn.h
@@ -4,8 +4,8 @@
 
 #pragma once
 
-#include "tiny_dnn/core/kernels/conv2d.h"
 #include "tiny_dnn/core/framework/op_kernel.h"
+#include "tiny_dnn/core/kernels/conv2d.h"
 
 #ifdef CNN_USE_LIBDNN
 #include "libdnn.hpp"
@@ -15,263 +15,240 @@ namespace tiny_dnn {
 
 class Conv2dLibDNNForwardOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dLibDNNForwardOp(const core::OpKernelConstruction& context)
-            : core::OpKernel(context)
-            , initialized_(false) {
-        Conv2d::setParams(OpKernel::params_);
-        // TODO(edgar): remove this if statement when refactor
-        // the init_backend() routine at layer level.
-        if (OpKernel::device_ != nullptr) {
-            init_libdnn(OpKernel::device_, Conv2d::params());
-        }
+  explicit Conv2dLibDNNForwardOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context), initialized_(false) {
+    Conv2d::setParams(OpKernel::params_);
+    // TODO(edgar): remove this if statement when refactor
+    // the init_backend() routine at layer level.
+    if (OpKernel::device_ != nullptr) {
+      init_libdnn(OpKernel::device_, Conv2d::params());
     }
+  }
 
-    void compute(const core::OpKernelContext& context) override {
+  void compute(const core::OpKernelContext& context) override {
 #ifdef CNN_USE_LIBDNN
-        // incoming/outcoming datm
-        const tensor_t& in_data = context.input(0);
-        const vec_t&          W = context.input(1)[0];
-        const vec_t&       bias = context.input(2)[0];
-        tensor_t&      out_data = context.output(1);
+    // incoming/outcoming datm
+    const tensor_t& in_data = context.input(0);
+    const vec_t& W = context.input(1)[0];
+    const vec_t& bias = context.input(2)[0];
+    tensor_t& out_data = context.output(1);
 
-        // retrieve the convolutional parameters and pad input
-        // Conv2d::setParams(context.params());
+    // retrieve the convolutional parameters and pad input
+    // Conv2d::setParams(context.params());
 
-        // initialize outputs
-        fill_tensor(out_data, float_t(0));
+    // initialize outputs
+    fill_tensor(out_data, float_t(0));
 
-        // pad input data
-        tensor_t in_data_padded;
-        Conv2d::copy_and_pad_input(in_data, in_data_padded);
+    // pad input data
+    tensor_t in_data_padded;
+    Conv2d::copy_and_pad_input(in_data, in_data_padded);
 
-        // retrive device context and queue
+    // retrive device context and queue
 
-        CLCudaAPI::Context ctx = OpKernel::device_->context();
-        CLCudaAPI::Queue queue = OpKernel::device_->queue();
+    CLCudaAPI::Context ctx = OpKernel::device_->context();
+    CLCudaAPI::Queue queue = OpKernel::device_->queue();
 
-        for (cnn_size_t i = 0; i < in_data_padded.size(); ++i) {
+    for (cnn_size_t i = 0; i < in_data_padded.size(); ++i) {
+      // allocate data to GPU
 
-            // allocate data to GPU
+      auto dev_in = CLCudaAPI::Buffer<float_t>(
+          ctx, queue, in_data_padded[i].begin(), in_data_padded[i].end());
 
-            auto dev_in = CLCudaAPI::Buffer<float_t>(ctx, queue,
-                in_data_padded[i].begin(), in_data_padded[i].end());
+      auto dev_W = CLCudaAPI::Buffer<float_t>(ctx, queue, W.begin(), W.end());
 
-            auto dev_W = CLCudaAPI::Buffer<float_t>(ctx, queue,
-                W.begin(), W.end());
+      auto dev_bias =
+          CLCudaAPI::Buffer<float_t>(ctx, queue, bias.begin(), bias.end());
 
-            auto dev_bias = CLCudaAPI::Buffer<float_t>(ctx, queue,
-                bias.begin(), bias.end());
+      auto dev_out = CLCudaAPI::Buffer<float_t>(ctx, queue, out_data[i].begin(),
+                                                out_data[i].end());
 
-            auto dev_out = CLCudaAPI::Buffer<float_t>(ctx, queue,
-                out_data[i].begin(), out_data[i].end());
+      // cast data types and call libdnn
 
-            // cast data types and call libdnn
+      // TODO(edgar): set a global variable with batch size or
+      // embedd this inside the next gen Tensor class.
+      const int batch_size = 1;
 
-            // TODO(edgar): set a global variable with batch size or
-            // embedd this inside the next gen Tensor class.
-            const int batch_size = 1;
+      const float_t* input_ptr = double_cast(dev_in());
+      const float_t* weights_ptr = double_cast(dev_W());
+      const float_t* bias_ptr = double_cast(dev_bias());
 
-            const float_t* input_ptr   = double_cast(dev_in());
-            const float_t* weights_ptr = double_cast(dev_W());
-            const float_t* bias_ptr    = double_cast(dev_bias());
+      float_t* output_ptr = mutable_double_cast(dev_out());
 
-            float_t* output_ptr = mutable_double_cast(dev_out());
+      // first time, tune the kernel
 
-            // first time, tune the kernel
+      // TODO(edgar/naibaf): enable when second generation
+      // kernel are available
 
-            // TODO(edgar/naibaf): enable when second generation
-            // kernel are available
+      /*if (!initialized_) {
+          kernel_->Tune(const_cast<float_t*>(output_ptr), nullptr,
+                        const_cast<float_t*>(weights_ptr), nullptr,
+                        const_cast<float_t*>(bias_ptr), nullptr,
+                        const_cast<float_t*>(input_ptr), nullptr,
+                        batch_size);
+          initialized_ = true;
+      }*/
 
-            /*if (!initialized_) {
-                kernel_->Tune(const_cast<float_t*>(output_ptr), nullptr,
-                              const_cast<float_t*>(weights_ptr), nullptr,
-                              const_cast<float_t*>(bias_ptr), nullptr,
-                              const_cast<float_t*>(input_ptr), nullptr,
-                              batch_size);
-                initialized_ = true;
-            }*/
+      // call libdnn forward
 
-            // call libdnn forward
+      kernel_->Forward(input_ptr, weights_ptr, bias_ptr, output_ptr,
+                       batch_size);
 
-            kernel_->Forward(input_ptr,
-                             weights_ptr,
-                             bias_ptr,
-                             output_ptr,
-                             batch_size);
+      // Upload data GPU -> CPU
+      /*std::vector<float_t> dev_W_shadow(W.size(), 0);
+      dev_W.Read(queue, W.size(), dev_W_shadow);
 
-            
-            // Upload data GPU -> CPU
-            /*std::vector<float_t> dev_W_shadow(W.size(), 0);
-            dev_W.Read(queue, W.size(), dev_W_shadow);
+      // FOR DEBUG ONLY
+      nn_warn("W kernel");
+      for (cnn_size_t j = 0; j < W.size(); ++j) {
+          std::cout << dev_W_shadow[j] << " ";
+      }
+      std::cout << std::endl;
 
-            // FOR DEBUG ONLY
-            nn_warn("W kernel");
-            for (cnn_size_t j = 0; j < W.size(); ++j) {
-                std::cout << dev_W_shadow[j] << " ";
-            }
-            std::cout << std::endl;
+      // Upload data GPU -> CPU
+      std::vector<float_t> dev_in_shadow(in_data_padded[i].size(), 0);
+      dev_in.Read(queue, in_data_padded[i].size(), dev_in_shadow);
 
-            // Upload data GPU -> CPU
-            std::vector<float_t> dev_in_shadow(in_data_padded[i].size(), 0);
-            dev_in.Read(queue, in_data_padded[i].size(), dev_in_shadow);
+      // FOR DEBUG ONLY
+      nn_warn("input kernel");
+      for (cnn_size_t j = 0; j < in_data_padded[i].size(); ++j) {
+          std::cout << dev_in_shadow[j] << " ";
+      }
+      std::cout << std::endl;*/
 
-            // FOR DEBUG ONLY
-            nn_warn("input kernel");
-            for (cnn_size_t j = 0; j < in_data_padded[i].size(); ++j) {
-                std::cout << dev_in_shadow[j] << " ";
-            }
-            std::cout << std::endl;*/
+      // Upload data GPU -> CPU
+      // TODO(edgar): trigger this only when is needed
+      std::vector<float_t> out(out_data[i].size(), 0);
+      dev_out.Read(queue, out_data[i].size(), out);
 
+      /*
+      // FOR DEBUG ONLY
+      nn_warn("output kernel");
+      for (cnn_size_t j = 0; j < out.size(); ++j) {
+          std::cout << out[j] << " ";
+      }
+      std::cout << std::endl;
+      */
 
-            // Upload data GPU -> CPU
-            // TODO(edgar): trigger this only when is needed
-            std::vector<float_t> out(out_data[i].size(), 0);
-            dev_out.Read(queue, out_data[i].size(), out);
-
-            /*
-            // FOR DEBUG ONLY
-            nn_warn("output kernel");
-            for (cnn_size_t j = 0; j < out.size(); ++j) {
-                std::cout << out[j] << " ";
-            }
-            std::cout << std::endl;
-            */
-
-            // copy data to be activated
-            std::copy(std::begin(out), std::end(out), std::begin(out_data[i]));
-        }
+      // copy data to be activated
+      std::copy(std::begin(out), std::end(out), std::begin(out_data[i]));
+    }
 
 #else
-        throw nn_error("TinyDNN was not compiled with LibDNN support.");
+    throw nn_error("TinyDNN was not compiled with LibDNN support.");
 #endif
-    }
+  }
 
  private:
 #ifdef CNN_USE_LIBDNN
-    float_t* mutable_double_cast(const cl_mem cl_mem_gpu) {
-        return static_cast<float_t*>(
-            reinterpret_cast<void*>(cl_mem_gpu));
-    }
+  float_t* mutable_double_cast(const cl_mem cl_mem_gpu) {
+    return static_cast<float_t*>(reinterpret_cast<void*>(cl_mem_gpu));
+  }
 
-    const float_t* double_cast(const cl_mem cl_mem_gpu) {
-        return reinterpret_cast<const float_t*>(
-            reinterpret_cast<const void*>(cl_mem_gpu));
-    }
+  const float_t* double_cast(const cl_mem cl_mem_gpu) {
+    return reinterpret_cast<const float_t*>(
+        reinterpret_cast<const void*>(cl_mem_gpu));
+  }
 #endif
 
-    void init_libdnn(const Device* device, const core::conv_params& params) {
+  void init_libdnn(const Device* device, const core::conv_params& params) {
 #ifdef CNN_USE_LIBDNN
-        assert(device != nullptr);
+    assert(device != nullptr);
 
-        // Context needs to be initialized with one device and queue
-        greentea::device::setupViennaCLContext(device->deviceId(),
-            device->context()(), device->device()(), device->queue()());
+    // Context needs to be initialized with one device and queue
+    greentea::device::setupViennaCLContext(
+        device->deviceId(), device->context()(), device->device()(),
+        device->queue()());
 
-        dev_ptr_ =
-            std::make_shared<greentea::device>(
-                device->deviceId(),
-                device->deviceId(), /* list_id, */
-                // TODO(edgar): refactor this since it's possible
-                // to have OpenCL and CUDA.
+    dev_ptr_ = std::make_shared<greentea::device>(
+        device->deviceId(), device->deviceId(), /* list_id, */
+// TODO(edgar): refactor this since it's possible
+// to have OpenCL and CUDA.
 #if defined(USE_OPENCL)
-                greentea::Backend::BACKEND_OpenCL
+        greentea::Backend::BACKEND_OpenCL
 #elif defined(USE_CUDA)
-                greentea::Backend::BACKEND_CUDA
+        greentea::Backend::BACKEND_CUDA
 #else
-                greentea::Backend::BACKEND_CPU
+        greentea::Backend::BACKEND_CPU
 #endif
-            );
+        );
 
-        // Initialize device pointer in libdnn
-        dev_ptr_->Init();
+    // Initialize device pointer in libdnn
+    dev_ptr_->Init();
 
-        // Setup libdnn params
-        greentea::LibDNNConfig config;
+    // Setup libdnn params
+    greentea::LibDNNConfig config;
 
-        config.dev_ptr = dev_ptr_.get();
+    config.dev_ptr = dev_ptr_.get();
 
-        // NCHW shape setups
+    // NCHW shape setups
 
-        const float_t dy = params.in_padded.height_ - params.in.height_;
-        const float_t dx = params.in_padded.width_  - params.in.width_;
+    const float_t dy = params.in_padded.height_ - params.in.height_;
+    const float_t dx = params.in_padded.width_ - params.in.width_;
 
-        std::vector<int32_t> in_shape = {
-            1,
-            params.in.depth_,
-            params.in.height_,
-            params.in.width_
-        };
+    std::vector<int32_t> in_shape = {1, params.in.depth_, params.in.height_,
+                                     params.in.width_};
 
-        std::vector<int32_t> out_shape = {
-            1,
-            params.out.depth_,
-            params.out.height_,
-            params.out.width_
-        };
+    std::vector<int32_t> out_shape = {1, params.out.depth_, params.out.height_,
+                                      params.out.width_};
 
-        std::vector<int32_t> kernel = {
-            params.weight.height_,
-            params.weight.width_
-        };
+    std::vector<int32_t> kernel = {params.weight.height_, params.weight.width_};
 
-        std::vector<int32_t> pad = { dy/2, dx/2 };
+    std::vector<int32_t> pad = {dy / 2, dx / 2};
 
-        std::vector<int32_t> stride = {
-            params.h_stride,
-            params.w_stride
-        };
+    std::vector<int32_t> stride = {params.h_stride, params.w_stride};
 
-        std::vector<int32_t> dilation = { 1, 1 };
+    std::vector<int32_t> dilation = {1, 1};
 
-        config.in_shape  = in_shape;
-        config.out_shape = out_shape;
-        config.pad       = pad;
-        config.kernel    = kernel;
-        config.stride    = stride;
-        config.dilation  = dilation;
-        config.group     = 1;
+    config.in_shape = in_shape;
+    config.out_shape = out_shape;
+    config.pad = pad;
+    config.kernel = kernel;
+    config.stride = stride;
+    config.dilation = dilation;
+    config.group = 1;
 
-        config.bias_term = params.has_bias;
+    config.bias_term = params.has_bias;
 
-        // Disables some optimizations but may give more stable results
-        config.fast_unsafe_math = false;
-        // Disables backward pass of weights during kernel.Backward();
-        config.weights_backward = false;
-        // Disables backward pass for bias during kernel.Backward();
-        config.bias_backward    = false;
+    // Disables some optimizations but may give more stable results
+    config.fast_unsafe_math = false;
+    // Disables backward pass of weights during kernel.Backward();
+    config.weights_backward = false;
+    // Disables backward pass for bias during kernel.Backward();
+    config.bias_backward = false;
 
-        // (Disabling bias and weight backward pass only propagates the data gradient (error))
+    // (Disabling bias and weight backward pass only propagates the data
+    // gradient (error))
 
-        if (std::is_same<float_t, float>::value ||
-            dev_ptr_->CheckCapability("cl_khr_int64_base_atomics")) {
-            config.wgalgo = greentea::LIBDNN_CONVOLUTION_WG_ALGO_ATOMIC;
-            config.bwalgo = greentea::LIBDNN_CONVOLUTION_BW_ALGO_COL2IM_ATOMIC;
-        } else {
-            config.wgalgo = greentea::LIBDNN_CONVOLUTION_WG_ALGO_DIRECT;
-            config.bwalgo = greentea::LIBDNN_CONVOLUTION_BW_ALGO_IM2COL;
-        }
-
-        // generate sources and compile kernel
-        kernel_.reset(new greentea::LibDNNConv<float_t>(config));
-#endif
+    if (std::is_same<float_t, float>::value ||
+        dev_ptr_->CheckCapability("cl_khr_int64_base_atomics")) {
+      config.wgalgo = greentea::LIBDNN_CONVOLUTION_WG_ALGO_ATOMIC;
+      config.bwalgo = greentea::LIBDNN_CONVOLUTION_BW_ALGO_COL2IM_ATOMIC;
+    } else {
+      config.wgalgo = greentea::LIBDNN_CONVOLUTION_WG_ALGO_DIRECT;
+      config.bwalgo = greentea::LIBDNN_CONVOLUTION_BW_ALGO_IM2COL;
     }
+
+    // generate sources and compile kernel
+    kernel_.reset(new greentea::LibDNNConv<float_t>(config));
+#endif
+  }
 
  private:
 #ifdef CNN_USE_LIBDNN
-    std::shared_ptr<greentea::device> dev_ptr_;
-    std::shared_ptr<greentea::LibDNNConv<float_t> > kernel_;
+  std::shared_ptr<greentea::device> dev_ptr_;
+  std::shared_ptr<greentea::LibDNNConv<float_t> > kernel_;
 #endif
-    bool initialized_;
+  bool initialized_;
 };
 
 class Conv2dLibDNNBackwardOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dLibDNNBackwardOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit Conv2dLibDNNBackwardOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        throw nn_error("Not implemented yet.");
-    }
+  void compute(const core::OpKernelContext& context) override {
+    throw nn_error("Not implemented yet.");
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/conv2d_op_nnpack.h
+++ b/tiny_dnn/core/kernels/conv2d_op_nnpack.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/conv_params.h"

--- a/tiny_dnn/core/kernels/conv2d_op_nnpack.h
+++ b/tiny_dnn/core/kernels/conv2d_op_nnpack.h
@@ -10,92 +10,74 @@
 #include "nnpack.h"
 
 inline nnp_convolution_algorithm nnp_algorithm() {
-    return nnp_convolution_algorithm_auto;
+  return nnp_convolution_algorithm_auto;
 }
 
 inline nnp_convolution_kernel_transform_strategy nnp_kts() {
-    return nnp_convolution_kernel_transform_strategy_reuse;
+  return nnp_convolution_kernel_transform_strategy_reuse;
 }
 #endif
 
 namespace tiny_dnn {
 namespace kernels {
 
-inline void
-conv2d_op_nnpack(const tensor_t&         in_data,
-                 const vec_t&                  W,
-                 const vec_t&               bias,
-                 tensor_t&              out_data,
-                 const core::conv_params& params) {
+inline void conv2d_op_nnpack(const tensor_t& in_data, const vec_t& W,
+                             const vec_t& bias, tensor_t& out_data,
+                             const core::conv_params& params) {
 #ifdef CNN_USE_NNPACK
-    nnp_status init_status = nnp_initialize();
-    if (init_status != nnp_status_success) {
-        throw nn_error("Cannot initialize NNPACK.");
-    }
+  nnp_status init_status = nnp_initialize();
+  if (init_status != nnp_status_success) {
+    throw nn_error("Cannot initialize NNPACK.");
+  }
 
-    // TOOD: use input config
-    const auto algorithm = nnp_algorithm();
-    const auto kernel_transform_strategy = nnp_kts();
+  // TOOD: use input config
+  const auto algorithm = nnp_algorithm();
+  const auto kernel_transform_strategy = nnp_kts();
 
-    const cnn_size_t input_channels = params.in.depth_;
-    const cnn_size_t output_channels = params.out.depth_;
+  const cnn_size_t input_channels = params.in.depth_;
+  const cnn_size_t output_channels = params.out.depth_;
 
-    const nnp_size input_size = {
-        static_cast<size_t>(params.in.width_),
-        static_cast<size_t>(params.in.height_)
-    };
+  const nnp_size input_size = {static_cast<size_t>(params.in.width_),
+                               static_cast<size_t>(params.in.height_)};
 
-    const nnp_size kernel_size = {
-        static_cast<size_t>(params.weight.width_),
-        static_cast<size_t>(params.weight.height_)
-    };
+  const nnp_size kernel_size = {static_cast<size_t>(params.weight.width_),
+                                static_cast<size_t>(params.weight.height_)};
 
-    const float_t dx = params.in_padded.width_  - params.in.width_;
-    const float_t dy = params.in_padded.height_ - params.in.height_;
+  const float_t dx = params.in_padded.width_ - params.in.width_;
+  const float_t dy = params.in_padded.height_ - params.in.height_;
 
-    // we'll assume that padding is symmetric
+  // we'll assume that padding is symmetric
 
-    const nnp_padding padding = {
-        static_cast<size_t>(dy/2),  // top
-        static_cast<size_t>(dx/2),  // right
-        static_cast<size_t>(dy/2),  // bottom
-        static_cast<size_t>(dx/2)   // left
-    };
+  const nnp_padding padding = {
+      static_cast<size_t>(dy / 2),  // top
+      static_cast<size_t>(dx / 2),  // right
+      static_cast<size_t>(dy / 2),  // bottom
+      static_cast<size_t>(dx / 2)   // left
+  };
 
-    const float* input_ptr  = reinterpret_cast<const float*>(&in_data[0]);
-    const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
-    const float* bias_ptr   = reinterpret_cast<const float*>(&bias[0]);
+  const float* input_ptr = reinterpret_cast<const float*>(&in_data[0]);
+  const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
+  const float* bias_ptr = reinterpret_cast<const float*>(&bias[0]);
 
-    float* output_ptr = reinterpret_cast<float*>(&out_data[0]);
+  float* output_ptr = reinterpret_cast<float*>(&out_data[0]);
 
-    // TODO: embed it into a class
-    const size_t num_mkl_threads = 1;
-    pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
+  // TODO: embed it into a class
+  const size_t num_mkl_threads = 1;
+  pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
 
-    nnp_profile* profile = nullptr;
+  nnp_profile* profile = nullptr;
 
-    nnp_status status =
-        nnp_convolution_inference(
-            algorithm,
-            kernel_transform_strategy,
-            input_channels,
-            output_channels,
-            input_size,
-            padding,
-            kernel_size,
-            input_ptr,
-            kernel_ptr,
-            bias_ptr,
-            output_ptr,
-            threadpool,
-            profile);
+  nnp_status status = nnp_convolution_inference(
+      algorithm, kernel_transform_strategy, input_channels, output_channels,
+      input_size, padding, kernel_size, input_ptr, kernel_ptr, bias_ptr,
+      output_ptr, threadpool, profile);
 
-    if (status != nnp_status_success) {
-        throw nn_error("Could not succeed with nnp_convolution_inference");
-    }
+  if (status != nnp_status_success) {
+    throw nn_error("Could not succeed with nnp_convolution_inference");
+  }
 
-    // TODO: embed it into a class
-    pthreadpool_destroy(threadpool);
+  // TODO: embed it into a class
+  pthreadpool_destroy(threadpool);
 #endif
 }
 

--- a/tiny_dnn/core/kernels/conv2d_op_opencl.h
+++ b/tiny_dnn/core/kernels/conv2d_op_opencl.h
@@ -4,132 +4,134 @@
 
 #pragma once
 
-#include "tiny_dnn/core/kernels/conv2d.h"
 #include "tiny_dnn/core/framework/op_kernel.h"
+#include "tiny_dnn/core/kernels/conv2d.h"
 
 namespace tiny_dnn {
 
 class Conv2dOpenCLForwardOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dOpenCLForwardOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit Conv2dOpenCLForwardOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
+  void compute(const core::OpKernelContext& context) override {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-        // incoming/outcoming data
-        const tensor_t& in_data = context.input(0);
-        const vec_t&          W = context.input(1)[0];
-        const vec_t&       bias = context.input(2)[0];
-        tensor_t&      out_data = context.output(1);
+    // incoming/outcoming data
+    const tensor_t& in_data = context.input(0);
+    const vec_t& W = context.input(1)[0];
+    const vec_t& bias = context.input(2)[0];
+    tensor_t& out_data = context.output(1);
 
-        // retrieve the convolutional parameters and pad input
-        Conv2d::setParams(context.params());
+    // retrieve the convolutional parameters and pad input
+    Conv2d::setParams(context.params());
 
-        // initialize outputs
-        fill_tensor(out_data, float_t(0));
+    // initialize outputs
+    fill_tensor(out_data, float_t(0));
 
-        // pad input data
-        tensor_t in_data_padded;
-        Conv2d::copy_and_pad_input(in_data, in_data_padded);
+    // pad input data
+    tensor_t in_data_padded;
+    Conv2d::copy_and_pad_input(in_data, in_data_padded);
 
-        // retrieve program from register
-        CLCudaAPI::Program program = ProgramManager::getInstance()
-            .program(Program(context.device(), context.Layer()));
-        nn_warn("Got Program");
+    // retrieve program from register
+    CLCudaAPI::Program program = ProgramManager::getInstance().program(
+        Program(context.device(), context.Layer()));
+    nn_warn("Got Program");
 
-        // Creates the kernel from the compiled program and sets the three arguments.
-        // Note that the indices of the arguments have to be set according to their
-        // order in the kernel.
-        auto kernel = CLCudaAPI::Kernel(program, "CFMulti");
-        nn_warn("Got Kernel");
+    // Creates the kernel from the compiled program and sets the three
+    // arguments.
+    // Note that the indices of the arguments have to be set according to their
+    // order in the kernel.
+    auto kernel = CLCudaAPI::Kernel(program, "CFMulti");
+    nn_warn("Got Kernel");
 
-        tiny_dnn::Device* device = context.device();
-        CLCudaAPI::Context   ctx = context.device()->context();
-        CLCudaAPI::Queue   queue = context.device()->queue();
+    tiny_dnn::Device* device = context.device();
+    CLCudaAPI::Context ctx = context.device()->context();
+    CLCudaAPI::Queue queue = context.device()->queue();
 
-        // TODO(edgar): check if we really need that
-        for (cnn_size_t i = 0; i < in_data_padded.size(); ++i) {
+    // TODO(edgar): check if we really need that
+    for (cnn_size_t i = 0; i < in_data_padded.size(); ++i) {
+      // Creates device buffers and copies the host data to these
+      // device buffers.
 
-        // Creates device buffers and copies the host data to these
-        // device buffers.
+      auto dev_in = CLCudaAPI::Buffer<float_t>(
+          ctx, queue, in_data_padded[i].begin(), in_data_padded[i].end());
 
-        auto dev_in = CLCudaAPI::Buffer<float_t>(ctx, queue,
-            in_data_padded[i].begin(), in_data_padded[i].end());
+      auto dev_W = CLCudaAPI::Buffer<float_t>(ctx, queue, W.begin(), W.end());
 
-        auto dev_W = CLCudaAPI::Buffer<float_t>(ctx, queue,
-            W.begin(), W.end());
+      auto dev_bias =
+          CLCudaAPI::Buffer<float_t>(ctx, queue, bias.begin(), bias.end());
 
-        auto dev_bias = CLCudaAPI::Buffer<float_t>(ctx, queue,
-            bias.begin(), bias.end());
+      auto dev_out = CLCudaAPI::Buffer<float_t>(ctx, queue, out_data[i].begin(),
+                                                out_data[i].end());
 
-        auto dev_out = CLCudaAPI::Buffer<float_t>(ctx, queue,
-            out_data[i].begin(), out_data[i].end());
+      // TODO(edgar); I guess offset arguments hould change
+      core::conv_params params = Conv2d::params();
 
-        // TODO(edgar); I guess offset arguments hould change
-        core::conv_params params = Conv2d::params();
+      kernel.SetArgument(0, dev_in);    // image_data
+      kernel.SetArgument(1, 0);         // image_offset
+      kernel.SetArgument(2, dev_W);     // kernel_data
+      kernel.SetArgument(3, 0);         // kernel_offset
+      kernel.SetArgument(4, dev_bias);  // bias
+      kernel.SetArgument(5, 0);         // bias_offset
+      kernel.SetArgument(6, dev_out);   // convolved_image
+      kernel.SetArgument(7, 0);         // convolved_image_offset
 
-        kernel.SetArgument(0,  dev_in);   // image_data
-        kernel.SetArgument(1,  0);        // image_offset
-        kernel.SetArgument(2,  dev_W);    // kernel_data
-        kernel.SetArgument(3,  0);        // kernel_offset
-        kernel.SetArgument(4,  dev_bias); // bias
-        kernel.SetArgument(5,  0);        // bias_offset
-        kernel.SetArgument(6,  dev_out);  // convolved_image
-        kernel.SetArgument(7,  0);        // convolved_image_offset
+      kernel.SetArgument(8, static_cast<ushort>(params.in.width_));   // WIDTH
+      kernel.SetArgument(9, static_cast<ushort>(params.in.height_));  // HEIGHT
+      kernel.SetArgument(10,
+                         static_cast<ushort>(params.out.width_));  // OUTPUT_W
+      kernel.SetArgument(11,
+                         static_cast<ushort>(params.out.height_));  // OUTPUT_H
 
-        kernel.SetArgument(8,  static_cast<ushort>(params.in.width_));   // WIDTH
-        kernel.SetArgument(9,  static_cast<ushort>(params.in.height_));  // HEIGHT
-        kernel.SetArgument(10, static_cast<ushort>(params.out.width_));  // OUTPUT_W
-        kernel.SetArgument(11, static_cast<ushort>(params.out.height_)); // OUTPUT_H
+      // We make sure that work group size is multiple of 16
+      cnn_size_t res = device->device().MaxWorkGroupSize() % 16;
+      cnn_size_t size = device->device().MaxWorkGroupSize() - res;
 
-        // We make sure that work group size is multiple of 16
-        cnn_size_t res  = device->device().MaxWorkGroupSize() % 16;
-        cnn_size_t size = device->device().MaxWorkGroupSize() - res;
+      auto global = std::vector<size_t>{size};
+      auto local = std::vector<size_t>{16};
 
-        auto global = std::vector<size_t>{size};
-        auto local = std::vector<size_t>{16};
+      // Creates a new CLCudaAPI event to be able to time kernels
+      auto event = CLCudaAPI::Event();
 
-        // Creates a new CLCudaAPI event to be able to time kernels
-        auto event = CLCudaAPI::Event();
+      // Enqueues the kernel and waits for the result.
+      // Note that launching the kernel is always a-synchronous and thus
+      // requires finishing the queue in order to complete the operation.
+      nn_info("## Running the kernel ...");
 
-        // Enqueues the kernel and waits for the result.
-        // Note that launching the kernel is always a-synchronous and thus
-        // requires finishing the queue in order to complete the operation.
-        nn_info("## Running the kernel ...");
+      kernel.Launch(queue, global, local, event.pointer());
+      queue.Finish(event);
 
-        kernel.Launch(queue, global, local, event.pointer());
-        queue.Finish(event);
+      nn_info(" > Took " + to_string(event.GetElapsedTime()) + " ms");
 
-        nn_info(" > Took " + to_string(event.GetElapsedTime()) + " ms");
+      // Upload data GPU -> CPU
+      std::vector<float_t> out(out_data[i].size(), 0);
+      dev_out.Read(queue, out_data[i].size(), out);
 
-        // Upload data GPU -> CPU
-        std::vector<float_t> out(out_data[i].size(), 0);
-        dev_out.Read(queue, out_data[i].size(), out);
+      // FOR DEBUG ONLY
+      nn_warn("output kernel");
+      for (cnn_size_t j = 0; j < out.size(); ++j) {
+        std::cout << out[j] << " ";
+      }
+      std::cout << std::endl;
 
-        // FOR DEBUG ONLY
-        nn_warn("output kernel");
-        for (cnn_size_t j = 0; j < out.size(); ++j) {
-            std::cout << out[j] << " ";
-        }
-        std::cout << std::endl;
-
-        // copy back
-        std::copy(std::begin(out), std::end(out), std::back_inserter(out_data[i]));
-        }
-#else
-        throw nn_error("Not compiled with OpenCL");
-#endif
+      // copy back
+      std::copy(std::begin(out), std::end(out),
+                std::back_inserter(out_data[i]));
     }
+#else
+    throw nn_error("Not compiled with OpenCL");
+#endif
+  }
 };
 
 class Conv2dOpenCLBackwardOp : private Conv2d, public core::OpKernel {
  public:
-    explicit Conv2dOpenCLBackwardOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit Conv2dOpenCLBackwardOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        nn_error("Not implemented yet.");
-    }
+  void compute(const core::OpKernelContext& context) override {
+    nn_error("Not implemented yet.");
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/conv2d_op_opencl.h
+++ b/tiny_dnn/core/kernels/conv2d_op_opencl.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-cnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/kernels/conv2d.h"

--- a/tiny_dnn/core/kernels/fully_connected_grad_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_grad_op.h
@@ -13,59 +13,45 @@ namespace tiny_dnn {
 
 class FullyConnectedGradOp : public core::OpKernel {
  public:
-    explicit FullyConnectedGradOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit FullyConnectedGradOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        auto params = OpKernel::params_->fully();
+  void compute(const core::OpKernelContext& context) override {
+    auto params = OpKernel::params_->fully();
 
-        // incoming/outcoming data
-        const tensor_t& prev_out = context.input(0);
-        const tensor_t& W        = context.input(1);
-        tensor_t& dW = context.input_grad(1);
-        tensor_t* db = params.has_bias_ ? &context.input_grad(2) : nullptr;
-        tensor_t& prev_delta = context.input_grad(0);
-        tensor_t& curr_delta = context.output_grad(1);
-        tensor_t dummy; // need lvalue for non-const reference
+    // incoming/outcoming data
+    const tensor_t& prev_out = context.input(0);
+    const tensor_t& W = context.input(1);
+    tensor_t& dW = context.input_grad(1);
+    tensor_t* db = params.has_bias_ ? &context.input_grad(2) : nullptr;
+    tensor_t& prev_delta = context.input_grad(0);
+    tensor_t& curr_delta = context.output_grad(1);
+    tensor_t dummy;  // need lvalue for non-const reference
 
-        // TODO(nyanp): Why we only need to initialize prev_delta ?
+    // TODO(nyanp): Why we only need to initialize prev_delta ?
 
-        // initialize outputs
-        //fill_tensor(dW, float_t(0));
-        //fill_tensor(db, float_t(0));
-        fill_tensor(prev_delta, float_t(0));
-        //fill_tensor(curr_delta, float_t(0));
+    // initialize outputs
+    // fill_tensor(dW, float_t(0));
+    // fill_tensor(db, float_t(0));
+    fill_tensor(prev_delta, float_t(0));
+    // fill_tensor(curr_delta, float_t(0));
 
-        // call the algorithm depending on the selected engine type
+    // call the algorithm depending on the selected engine type
 
-        const core::backend_t engine = context.engine();
+    const core::backend_t engine = context.engine();
 
-        if (engine == core::backend_t::tiny_dnn) {
-            kernels::fully_connected_op_custom(
-                prev_out,
-                W[0],
-                dW,
-                params.has_bias_ ? *db : dummy,
-                curr_delta,
-                prev_delta,
-                params,
-                context.parallelize());
-        }
-        else if (engine == core::backend_t::avx) {
-            kernels::fully_connected_op_avx(
-                prev_out,
-                W[0],
-                dW,
-                params.has_bias_ ? *db : dummy,
-                curr_delta,
-                prev_delta,
-                params,
-                context.parallelize());
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(engine));
-        }
+    if (engine == core::backend_t::tiny_dnn) {
+      kernels::fully_connected_op_custom(
+          prev_out, W[0], dW, params.has_bias_ ? *db : dummy, curr_delta,
+          prev_delta, params, context.parallelize());
+    } else if (engine == core::backend_t::avx) {
+      kernels::fully_connected_op_avx(
+          prev_out, W[0], dW, params.has_bias_ ? *db : dummy, curr_delta,
+          prev_delta, params, context.parallelize());
+    } else {
+      throw nn_error("Not supported engine: " + to_string(engine));
     }
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/fully_connected_grad_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_grad_op.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/op_kernel.h"

--- a/tiny_dnn/core/kernels/fully_connected_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_op.h
@@ -1,47 +1,7 @@
-/*
-    COPYRIGHT
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    All contributions by Taiga Nomi
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-
-    All other contributions:
-    Copyright (c) 2013-2016, the respective contributors.
-    All rights reserved.
-
-    Each contributor holds copyright over their respective contributions.
-    The project versioning (Git) records all such contribution source information.
-
-    LICENSE
-
-    The BSD 3-Clause License
-
-
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice, this
-      list of conditions and the following disclaimer.
-
-    * Redistributions in binary form must reproduce the above copyright notice,
-      this list of conditions and the following disclaimer in the documentation
-      and/or other materials provided with the distribution.
-
-    * Neither the name of tiny-dnn nor the names of its
-      contributors may be used to endorse or promote products derived from
-      this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
-    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/framework/op_kernel.h"

--- a/tiny_dnn/core/kernels/fully_connected_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_op.h
@@ -14,56 +14,41 @@ namespace tiny_dnn {
 
 class FullyConnectedOp : public core::OpKernel {
  public:
-    explicit FullyConnectedOp(const core::OpKernelConstruction& context)
-        : core::OpKernel(context) {}
+  explicit FullyConnectedOp(const core::OpKernelConstruction& context)
+      : core::OpKernel(context) {}
 
-    void compute(const core::OpKernelContext& context) override {
-        auto params = OpKernel::params_->fully();
+  void compute(const core::OpKernelContext& context) override {
+    auto params = OpKernel::params_->fully();
 
-        // incomimg/outcoming data 
-        const tensor_t& in_data = context.input(0);
-        const tensor_t&       W = context.input(1);
-        const tensor_t*    bias = params.has_bias_ ? &context.input(2) : nullptr;
-        tensor_t&      out_data = context.output(1);
+    // incomimg/outcoming data
+    const tensor_t& in_data = context.input(0);
+    const tensor_t& W = context.input(1);
+    const tensor_t* bias = params.has_bias_ ? &context.input(2) : nullptr;
+    tensor_t& out_data = context.output(1);
 
-        // initialize outputs
-        fill_tensor(out_data, float_t(0));
+    // initialize outputs
+    fill_tensor(out_data, float_t(0));
 
-        // call the algorithm depending  on the selected engine type
+    // call the algorithm depending  on the selected engine type
 
-        const core::backend_t engine = context.engine();
+    const core::backend_t engine = context.engine();
 
-        if (engine == core::backend_t::tiny_dnn) {
-            kernels::fully_connected_op_custom(
-                in_data,
-                W[0],
-                params.has_bias_ ? (*bias)[0] : vec_t(),
-                out_data,
-                params,
-                context.parallelize());
-        }
-        else if (engine == core::backend_t::nnpack) {
-            kernels::fully_connected_op_nnpack(
-                in_data,
-                W[0],
-                params.has_bias_ ? (*bias)[0] : vec_t(),
-                out_data,
-                params,
-                context.parallelize());
-        }
-        else if (engine == core::backend_t::avx) {
-            kernels::fully_connected_op_avx(
-                in_data,
-                W[0],
-                params.has_bias_ ? (*bias)[0] : vec_t(),
-                out_data,
-                params,
-                context.parallelize());
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(engine));
-        }
+    if (engine == core::backend_t::tiny_dnn) {
+      kernels::fully_connected_op_custom(
+          in_data, W[0], params.has_bias_ ? (*bias)[0] : vec_t(), out_data,
+          params, context.parallelize());
+    } else if (engine == core::backend_t::nnpack) {
+      kernels::fully_connected_op_nnpack(
+          in_data, W[0], params.has_bias_ ? (*bias)[0] : vec_t(), out_data,
+          params, context.parallelize());
+    } else if (engine == core::backend_t::avx) {
+      kernels::fully_connected_op_avx(in_data, W[0],
+                                      params.has_bias_ ? (*bias)[0] : vec_t(),
+                                      out_data, params, context.parallelize());
+    } else {
+      throw nn_error("Not supported engine: " + to_string(engine));
     }
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/fully_connected_op_avx.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_avx.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/kernels/fully_connected_op_custom.h"

--- a/tiny_dnn/core/kernels/fully_connected_op_avx.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_avx.h
@@ -9,51 +9,31 @@
 namespace tiny_dnn {
 namespace kernels {
 
-inline void
-fully_connected_op_avx(const tensor_t& in_data,
-                       const vec_t&    W,
-                       const vec_t&    bias,
-                       tensor_t&       out_data,
-                       const fully_params& params,
-                       const bool      layer_parallelize) {
+inline void fully_connected_op_avx(const tensor_t& in_data, const vec_t& W,
+                                   const vec_t& bias, tensor_t& out_data,
+                                   const fully_params& params,
+                                   const bool layer_parallelize) {
 #ifdef CNN_USE_AVX
-    // TODO(nyanp/beru): is this really AVX ??
-    fully_connected_op_custom(
-        in_data,
-        W,
-        bias,
-        out_data,
-        params,
-        layer_parallelize);
+  // TODO(nyanp/beru): is this really AVX ??
+  fully_connected_op_custom(in_data, W, bias, out_data, params,
+                            layer_parallelize);
 #else
-    throw nn_error("TinyDNN has not been compiled with AVX support.");
+  throw nn_error("TinyDNN has not been compiled with AVX support.");
 #endif
 }
 
-inline void
-fully_connected_op_avx(const tensor_t& prev_out,
-                       const vec_t&    W,
-                       tensor_t&       dW,
-                       tensor_t&       db,
-                       tensor_t&       curr_delta,
-                       tensor_t&       prev_delta,
-                       const fully_params& params,
-                       const bool      layer_parallelize) {
+inline void fully_connected_op_avx(const tensor_t& prev_out, const vec_t& W,
+                                   tensor_t& dW, tensor_t& db,
+                                   tensor_t& curr_delta, tensor_t& prev_delta,
+                                   const fully_params& params,
+                                   const bool layer_parallelize) {
 #ifdef CNN_USE_AVX
-    // TODO(nyanp/beru): is this really AVX ??
-    fully_connected_op_custom(
-        prev_out,
-        W,
-        dW,
-        db,
-        curr_delta,
-        prev_delta,
-        params,
-        layer_parallelize);
+  // TODO(nyanp/beru): is this really AVX ??
+  fully_connected_op_custom(prev_out, W, dW, db, curr_delta, prev_delta, params,
+                            layer_parallelize);
 #else
-    throw nn_error("TinyDNN has not been compiled with AVX support.");
+  throw nn_error("TinyDNN has not been compiled with AVX support.");
 #endif
-
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/fully_connected_op_custom.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_custom.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/fully_connected_op_custom.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_custom.h
@@ -9,65 +9,59 @@
 namespace tiny_dnn {
 namespace kernels {
 
-inline void
-fully_connected_op_custom(const tensor_t&     in_data,
-                          const vec_t&        W,
-                          const vec_t&        bias,
-                          tensor_t&           out_data,
-                          const fully_params& params,
-                          const bool          layer_parallelize) {
-    for_i(layer_parallelize, in_data.size(), [&](int sample) {
-        const vec_t& in = in_data[sample];
-        vec_t& out = out_data[sample];
+inline void fully_connected_op_custom(const tensor_t& in_data, const vec_t& W,
+                                      const vec_t& bias, tensor_t& out_data,
+                                      const fully_params& params,
+                                      const bool layer_parallelize) {
+  for_i(layer_parallelize, in_data.size(), [&](int sample) {
+    const vec_t& in = in_data[sample];
+    vec_t& out = out_data[sample];
 
-        for (cnn_size_t i = 0; i < params.out_size_; i++) {
-            out[i] = float_t(0);
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                out[i] += W[c * params.out_size_ + i] * in[c];
-            }
+    for (cnn_size_t i = 0; i < params.out_size_; i++) {
+      out[i] = float_t(0);
+      for (cnn_size_t c = 0; c < params.in_size_; c++) {
+        out[i] += W[c * params.out_size_ + i] * in[c];
+      }
 
-            if (params.has_bias_) {
-                out[i] += bias[i];
-            }
-        }
-    });
+      if (params.has_bias_) {
+        out[i] += bias[i];
+      }
+    }
+  });
 }
 
-inline void
-fully_connected_op_custom(const tensor_t& prev_out,
-                          const vec_t&    W,
-                          tensor_t&       dW,
-                          tensor_t&       db,
-                          tensor_t&       curr_delta,
-                          tensor_t&       prev_delta,
-                          const fully_params& params,
-                          const bool      layer_parallelize) {
-    for (cnn_size_t sample = 0; sample < prev_out.size(); sample++) {
-        for (cnn_size_t c = 0; c < params.in_size_; c++) {
-            // propagate delta to previous layer
-            // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
-            prev_delta[sample][c] += vectorize::dot(&curr_delta[sample][0],
-                &W[c * params.out_size_],
-                params.out_size_);
-        }
-
-        for_(layer_parallelize, 0, size_t(params.out_size_), [&](const blocked_range& r) {
-            // accumulate weight-step using delta
-            // dW[c * out_size + i] += current_delta[i] * prev_out[c]
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                vectorize::muladd(&curr_delta[sample][r.begin()],
-                    prev_out[sample][c], r.end() - r.begin(),
-                    &dW[sample][c * params.out_size_ + r.begin()]);
-            }
-
-            if (params.has_bias_) {
-                // vec_t& db = *in_grad[2];
-                for (int i = r.begin(); i < r.end(); i++) {
-                    db[sample][i] += curr_delta[sample][i];
-                }
-            }
-        });
+inline void fully_connected_op_custom(const tensor_t& prev_out, const vec_t& W,
+                                      tensor_t& dW, tensor_t& db,
+                                      tensor_t& curr_delta,
+                                      tensor_t& prev_delta,
+                                      const fully_params& params,
+                                      const bool layer_parallelize) {
+  for (cnn_size_t sample = 0; sample < prev_out.size(); sample++) {
+    for (cnn_size_t c = 0; c < params.in_size_; c++) {
+      // propagate delta to previous layer
+      // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
+      prev_delta[sample][c] += vectorize::dot(
+          &curr_delta[sample][0], &W[c * params.out_size_], params.out_size_);
     }
+
+    for_(layer_parallelize, 0, size_t(params.out_size_),
+         [&](const blocked_range& r) {
+           // accumulate weight-step using delta
+           // dW[c * out_size + i] += current_delta[i] * prev_out[c]
+           for (cnn_size_t c = 0; c < params.in_size_; c++) {
+             vectorize::muladd(&curr_delta[sample][r.begin()],
+                               prev_out[sample][c], r.end() - r.begin(),
+                               &dW[sample][c * params.out_size_ + r.begin()]);
+           }
+
+           if (params.has_bias_) {
+             // vec_t& db = *in_grad[2];
+             for (int i = r.begin(); i < r.end(); i++) {
+               db[sample][i] += curr_delta[sample][i];
+             }
+           }
+         });
+  }
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
@@ -9,47 +9,39 @@
 namespace tiny_dnn {
 namespace kernels {
 
-inline void
-fully_connected_op_nnpack(const tensor_t&     in_data,
-                          const vec_t&        W,
-                          const vec_t&        bias,
-                          tensor_t&           out_data,
-                          const fully_params& params,
-                          const bool          layer_parallelize) {
+inline void fully_connected_op_nnpack(const tensor_t& in_data, const vec_t& W,
+                                      const vec_t& bias, tensor_t& out_data,
+                                      const fully_params& params,
+                                      const bool layer_parallelize) {
 #ifdef CNN_USE_NNPACK
-    const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
-    const float* input_ptr  = reinterpret_cast<const float*>(&in_data[0]);
-    float*       output_ptr = reinterpret_cast<float*>(&out_data[0]);
+  const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
+  const float* input_ptr = reinterpret_cast<const float*>(&in_data[0]);
+  float* output_ptr = reinterpret_cast<float*>(&out_data[0]);
 
-    // TODO: embed it into a class
-    const size_t num_mkl_threads = 1;
-    pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
+  // TODO: embed it into a class
+  const size_t num_mkl_threads = 1;
+  pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
 
-    const auto status =
-        nnp_fully_connected_inference(
-            params.in_size_,
-            params.out_size_,
-            input_ptr,
-            kernel_ptr,
-            output_ptr,
-            threadpool);
+  const auto status = nnp_fully_connected_inference(
+      params.in_size_, params.out_size_, input_ptr, kernel_ptr, output_ptr,
+      threadpool);
 
-     if (status != nnp_status_success) {
-        throw nn_error("Could not succeed with nnp_max_pooling_output");
-    }
+  if (status != nnp_status_success) {
+    throw nn_error("Could not succeed with nnp_max_pooling_output");
+  }
 
-    // TODO: embed it into a class
-    pthreadpool_destroy(threadpool);
+  // TODO: embed it into a class
+  pthreadpool_destroy(threadpool);
 
-    // TODO: find a proper way to do this
-    if (params.has_bias_) {
-        for_i(layer_parallelize, params.out_size_, [&](int i) {
-            // TODO(edgar): revise this
-            // a[i] += b[i];
-        });
-    }
+  // TODO: find a proper way to do this
+  if (params.has_bias_) {
+    for_i(layer_parallelize, params.out_size_, [&](int i) {
+      // TODO(edgar): revise this
+      // a[i] += b[i];
+    });
+  }
 #else
-    throw nn_error("TinyDNN has not been compiled with NNPACK support.");
+  throw nn_error("TinyDNN has not been compiled with NNPACK support.");
 #endif
 }
 

--- a/tiny_dnn/core/kernels/nnp_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_deconv2d_kernel.h
@@ -15,11 +15,8 @@ namespace kernels {
 
 inline void nnp_deconv2d_kernel(const conv_params& params,
                                 const std::vector<const vec_t*>& in,
-                                const vec_t&       W,
-                                const vec_t&       bias,
-                                tensor_t&          a) {
-
-}
+                                const vec_t& W, const vec_t& bias,
+                                tensor_t& a) {}
 
 }  // namespace kernels
 }  // namespace core

--- a/tiny_dnn/core/kernels/nnp_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_deconv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/nnp_fully_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_fully_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/nnp_fully_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_fully_kernel.h
@@ -11,43 +11,36 @@ namespace core {
 namespace kernels {
 
 inline void nnp_fully_connected_kernel(const fully_params& params,
-                                       const tensor_t&     in,
-                                       const vec_t&        W,
-                                       vec_t&              b,
-                                       tensor_t&           a,
-                                       const bool          layer_parallelize) {
+                                       const tensor_t& in, const vec_t& W,
+                                       vec_t& b, tensor_t& a,
+                                       const bool layer_parallelize) {
 #ifdef CNN_USE_NNPACK
-    const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
-    const float* input_ptr  = reinterpret_cast<const float*>(&in[0]);
-    float*       output_ptr = reinterpret_cast<float*>(&a[0]);
+  const float* kernel_ptr = reinterpret_cast<const float*>(&W[0]);
+  const float* input_ptr = reinterpret_cast<const float*>(&in[0]);
+  float* output_ptr = reinterpret_cast<float*>(&a[0]);
 
-    // TODO: embed it into a class
-    const size_t num_mkl_threads = 1;
-    pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
+  // TODO: embed it into a class
+  const size_t num_mkl_threads = 1;
+  pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
 
-    const auto status =
-        nnp_fully_connected_inference(
-            params.in_size_,
-            params.out_size_,
-            input_ptr,
-            kernel_ptr,
-            output_ptr,
-            threadpool);
+  const auto status = nnp_fully_connected_inference(
+      params.in_size_, params.out_size_, input_ptr, kernel_ptr, output_ptr,
+      threadpool);
 
-     if (status != nnp_status_success) {
-        throw nn_error("Could not succeed with nnp_max_pooling_output");
-    }
+  if (status != nnp_status_success) {
+    throw nn_error("Could not succeed with nnp_max_pooling_output");
+  }
 
-    // TODO: embed it into a class
-    pthreadpool_destroy(threadpool);
+  // TODO: embed it into a class
+  pthreadpool_destroy(threadpool);
 
-    // TODO: find a proper way to do this
-    if (params.has_bias_) {
-        for_i(layer_parallelize, params.out_size_, [&](int i) {
-            // TODO(edgar): revise this
-            // a[i] += b[i];
-        });
-    }
+  // TODO: find a proper way to do this
+  if (params.has_bias_) {
+    for_i(layer_parallelize, params.out_size_, [&](int i) {
+      // TODO(edgar): revise this
+      // a[i] += b[i];
+    });
+  }
 #endif
 }
 

--- a/tiny_dnn/core/kernels/nnp_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_maxpool_kernel.h
@@ -12,61 +12,46 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-inline void nnp_maxpool_kernel(const maxpool_params& params,
-                               const tensor_t&          in,
-                               tensor_t&                a) {
+inline void nnp_maxpool_kernel(const maxpool_params& params, const tensor_t& in,
+                               tensor_t& a) {
 #ifdef CNN_USE_NNPACK
 
-    const cnn_size_t input_channels  = params.in_.depth_;
-    const cnn_size_t output_channels = params.out_.depth_;
+  const cnn_size_t input_channels = params.in_.depth_;
+  const cnn_size_t output_channels = params.out_.depth_;
 
-    const nnp_size input_size = {
-        static_cast<size_t>(params.in_.width_),
-        static_cast<size_t>(params.in_.height_)
-    };
+  const nnp_size input_size = {static_cast<size_t>(params.in_.width_),
+                               static_cast<size_t>(params.in_.height_)};
 
-    const nnp_padding input_padding = {
-        static_cast<size_t>(0),  // top
-        static_cast<size_t>(0),  // right
-        static_cast<size_t>(0),  // bottom
-        static_cast<size_t>(0)   // left
-    };
+  const nnp_padding input_padding = {
+      static_cast<size_t>(0),  // top
+      static_cast<size_t>(0),  // right
+      static_cast<size_t>(0),  // bottom
+      static_cast<size_t>(0)   // left
+  };
 
-    const nnp_size pooling_size = {
-        static_cast<size_t>(params.pool_size_),
-        static_cast<size_t>(params.pool_size_)
-    };
+  const nnp_size pooling_size = {static_cast<size_t>(params.pool_size_),
+                                 static_cast<size_t>(params.pool_size_)};
 
-    const nnp_size pooling_stride = {
-        static_cast<size_t>(params.stride_),
-        static_cast<size_t>(params.stride_)
-    };
+  const nnp_size pooling_stride = {static_cast<size_t>(params.stride_),
+                                   static_cast<size_t>(params.stride_)};
 
-    const float* input_ptr = reinterpret_cast<const float*>(&in[0]);
-    float*      output_ptr = reinterpret_cast<float*>(&a[0]);
+  const float* input_ptr = reinterpret_cast<const float*>(&in[0]);
+  float* output_ptr = reinterpret_cast<float*>(&a[0]);
 
-    // TODO: embed it into a class
-    const size_t num_mkl_threads = 1;
-    pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
+  // TODO: embed it into a class
+  const size_t num_mkl_threads = 1;
+  pthreadpool_t threadpool = pthreadpool_create(num_mkl_threads);
 
-    const auto status =
-        nnp_max_pooling_output(
-            input_channels,
-            output_channels,
-            input_size,
-            input_padding,
-            pooling_size,
-            pooling_stride,
-            input_ptr,
-            output_ptr,
-            threadpool);
+  const auto status = nnp_max_pooling_output(
+      input_channels, output_channels, input_size, input_padding, pooling_size,
+      pooling_stride, input_ptr, output_ptr, threadpool);
 
-    if (status != nnp_status_success) {
-        throw nn_error("Could not succeed with nnp_max_pooling_output");
-    }
+  if (status != nnp_status_success) {
+    throw nn_error("Could not succeed with nnp_max_pooling_output");
+  }
 
-    // TODO: embed it into a class
-    pthreadpool_destroy(threadpool);
+  // TODO: embed it into a class
+  pthreadpool_destroy(threadpool);
 #endif
 }
 

--- a/tiny_dnn/core/kernels/nnp_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/nnp_maxpool_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #ifdef CNN_USE_NNPACK

--- a/tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/conv_params.h"

--- a/tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_conv2d_back_kernel.h
@@ -12,94 +12,92 @@ namespace kernels {
 
 inline void tiny_conv2d_back_kernel(const conv_params& params,
                                     const std::vector<const vec_t*>& prev_out,
-                                    const vec_t&       W,
-                                    tensor_t&          dW,
-                                    tensor_t&          db,
-                                    tensor_t&          curr_delta,
-                                    tensor_t*          prev_delta) {
-    // propagate delta to previous layer
+                                    const vec_t& W, tensor_t& dW, tensor_t& db,
+                                    tensor_t& curr_delta,
+                                    tensor_t* prev_delta) {
+  // propagate delta to previous layer
 
-    for_i(prev_out.size(), [&](int sample) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
+  for_i(prev_out.size(), [&](int sample) {
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * outc + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                const float_t *pw = &W[idx];
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * outc + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        const float_t* pw = &W[idx];
 
-                idx = params.out.get_index(0, 0, outc);
-                const float_t *pdelta_src = &curr_delta[sample][idx];
+        idx = params.out.get_index(0, 0, outc);
+        const float_t* pdelta_src = &curr_delta[sample][idx];
 
-                idx = params.in_padded.get_index(0, 0, inc);
-                float_t *pdelta_dst = &(*prev_delta)[sample][idx];
+        idx = params.in_padded.get_index(0, 0, inc);
+        float_t* pdelta_dst = &(*prev_delta)[sample][idx];
 
-                for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                        const float_t * ppw = pw;
+        for (cnn_size_t y = 0; y < params.out.height_; y++) {
+          for (cnn_size_t x = 0; x < params.out.width_; x++) {
+            const float_t* ppw = pw;
 
-                        idx = y * params.out.width_ + x;
-                        const float_t ppdelta_src = pdelta_src[idx];
+            idx = y * params.out.width_ + x;
+            const float_t ppdelta_src = pdelta_src[idx];
 
-                        float_t * ppdelta_dst = pdelta_dst +
-                            y * params.h_stride * params.in_padded.width_ +
-                            x * params.w_stride;
+            float_t* ppdelta_dst =
+                pdelta_dst + y * params.h_stride * params.in_padded.width_ +
+                x * params.w_stride;
 
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                                idx = wy * params.in_padded.width_ + wx;
-                                ppdelta_dst[idx] += *ppw++ * ppdelta_src;
-                            }
-                        }
-                    }
-                }
+            for (cnn_size_t wy = 0; wy < params.weight.height_;
+                 wy++) {  // NOLINT
+              for (cnn_size_t wx = 0; wx < params.weight.width_;
+                   wx++) {  // NOLINT
+                idx = wy * params.in_padded.width_ + wx;
+                ppdelta_dst[idx] += *ppw++ * ppdelta_src;
+              }
             }
+          }
         }
+      }
+    }
 
-        // accumulate dw
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
+    // accumulate dw
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
 
-                for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                    for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                        float_t dst = float_t(0);
+        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+          for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+            float_t dst = float_t(0);
 
-                        cnn_size_t idx = 0;
-                        idx = params.in_padded.get_index(wx, wy, inc);
-                        const float_t * prevo = &(*prev_out[sample])[idx];
+            cnn_size_t idx = 0;
+            idx = params.in_padded.get_index(wx, wy, inc);
+            const float_t* prevo = &(*prev_out[sample])[idx];
 
-                        idx = params.out.get_index(0, 0, outc);
-                        const float_t * delta = &curr_delta[sample][idx];
+            idx = params.out.get_index(0, 0, outc);
+            const float_t* delta = &curr_delta[sample][idx];
 
-                        for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                            dst += vectorize::dot(
-                                prevo + y * params.in_padded.width_,
-                                delta + y * params.out.width_,
-                                params.out.width_);
-                        }
-
-                        idx = params.in.depth_ * outc + inc;
-                        dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
-                    }
-                }
+            for (cnn_size_t y = 0; y < params.out.height_; y++) {
+              dst += vectorize::dot(prevo + y * params.in_padded.width_,
+                                    delta + y * params.out.width_,
+                                    params.out.width_);
             }
-        }
 
-        // accumulate db
-        if (params.has_bias) {
-            //vec_t& db = *in_grad[2];
-
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                cnn_size_t idx = params.out.get_index(0, 0, outc);
-                const float_t * delta = &curr_delta[sample][idx];
-                const float_t * deltaa = delta + params.out.width_ *
-                    params.out.height_;
-                db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
-            }
+            idx = params.in.depth_ * outc + inc;
+            dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
+          }
         }
-    });
+      }
+    }
+
+    // accumulate db
+    if (params.has_bias) {
+      // vec_t& db = *in_grad[2];
+
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        cnn_size_t idx = params.out.get_index(0, 0, outc);
+        const float_t* delta = &curr_delta[sample][idx];
+        const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+        db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
+      }
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_conv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/conv_params.h"

--- a/tiny_dnn/core/kernels/tiny_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_conv2d_kernel.h
@@ -11,58 +11,58 @@ namespace core {
 namespace kernels {
 
 inline void tiny_conv2d_kernel(const conv_params& params,
-                               const std::vector<const vec_t*>&   in_data,
-                               const vec_t&       W,
-                               const vec_t&       bias,
-                               tensor_t&          out_data,
+                               const std::vector<const vec_t*>& in_data,
+                               const vec_t& W, const vec_t& bias,
+                               tensor_t& out_data,
                                const bool layer_parallelize) {
+  for_i(layer_parallelize, in_data.size(), [&](int sample) {
+    const vec_t& in = *in_data[sample];
+    vec_t& a = out_data[sample];
 
-    for_i(layer_parallelize, in_data.size(), [&](int sample) {
-        const vec_t& in = *in_data[sample];
-        vec_t& a = out_data[sample];
+    for (cnn_size_t o = 0; o < params.out.depth_; o++) {
+      for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+        if (!params.tbl.is_connected(o, inc)) continue;
 
-        for (cnn_size_t o = 0; o < params.out.depth_; o++) {
-            for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-                if (!params.tbl.is_connected(o, inc)) continue;
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * o + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        const float_t* pw = &W[idx];
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * o + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                const float_t *pw = &W[idx];
+        idx = params.in_padded.get_index(0, 0, inc);
+        const float_t* pi = &in[idx];
 
-                idx = params.in_padded.get_index(0, 0, inc);
-                const float_t *pi = &in[idx];
+        idx = params.out.get_index(0, 0, o);
+        float_t* pa = &a[idx];
 
-                idx = params.out.get_index(0, 0, o);
-                float_t *pa = &a[idx];
+        for (cnn_size_t y = 0; y < params.out.height_; y++) {
+          for (cnn_size_t x = 0; x < params.out.width_; x++) {
+            const float_t* ppw = pw;
+            const float_t* ppi =
+                pi + params.in_padded.width_ * (y * params.h_stride) +
+                x * params.w_stride;
+            float_t sum = float_t(0);
 
-                for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                        const float_t * ppw = pw;
-                        const float_t * ppi = pi + params.in_padded.width_ *
-                            (y * params.h_stride) +
-                            x * params.w_stride;
-                        float_t sum = float_t(0);
-
-                        // should be optimized for small kernel(3x3,5x5)
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                                idx = wy * params.in_padded.width_ + wx;
-                                sum += *ppw++ * ppi[idx];
-                            }
-                        }
-                        pa[y * params.out.width_ + x] += sum;
-                    }
-                }
+            // should be optimized for small kernel(3x3,5x5)
+            for (cnn_size_t wy = 0; wy < params.weight.height_;
+                 wy++) {  // NOLINT
+              for (cnn_size_t wx = 0; wx < params.weight.width_;
+                   wx++) {  // NOLINT
+                idx = wy * params.in_padded.width_ + wx;
+                sum += *ppw++ * ppi[idx];
+              }
             }
-
-            if (params.has_bias) {
-                float_t * pa = &a[params.out.get_index(0, 0, o)];
-                float_t * paa = pa + params.out.width_ * params.out.height_;
-                std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
-            }
+            pa[y * params.out.width_ + x] += sum;
+          }
         }
-    });
+      }
+
+      if (params.has_bias) {
+        float_t* pa = &a[params.out.get_index(0, 0, o)];
+        float_t* paa = pa + params.out.width_ * params.out.height_;
+        std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
+      }
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_deconv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_deconv2d_back_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/tiny_deconv2d_back_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_deconv2d_back_kernel.h
@@ -11,94 +11,88 @@ namespace core {
 namespace kernels {
 
 inline void tiny_deconv2d_back_kernel(const deconv_params& params,
-                                      const tensor_t& prev_out,
-                                      const vec_t& W,
-                                      tensor_t&       dW,
-                                      tensor_t&       db,
-                                      tensor_t&       curr_delta,
-                                      tensor_t*       prev_delta) {
-    // propagate delta to previous layer
-    for_i(prev_out.size(), [&](int sample) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
+                                      const tensor_t& prev_out, const vec_t& W,
+                                      tensor_t& dW, tensor_t& db,
+                                      tensor_t& curr_delta,
+                                      tensor_t* prev_delta) {
+  // propagate delta to previous layer
+  for_i(prev_out.size(), [&](int sample) {
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * outc + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                const float_t *pw = &W[idx];
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * outc + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        const float_t* pw = &W[idx];
 
-                idx = params.out_unpadded.get_index(0, 0, outc);
-                const float_t *pdelta_src = &curr_delta[sample][idx];
+        idx = params.out_unpadded.get_index(0, 0, outc);
+        const float_t* pdelta_src = &curr_delta[sample][idx];
 
-                idx = params.in.get_index(0, 0, inc);
-                float_t *pdelta_dst = &(*prev_delta)[sample][idx];
+        idx = params.in.get_index(0, 0, inc);
+        float_t* pdelta_dst = &(*prev_delta)[sample][idx];
 
-                for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                        const float_t * ppw = pw;
+        for (cnn_size_t y = 0; y < params.in.height_; y++) {
+          for (cnn_size_t x = 0; x < params.in.width_; x++) {
+            const float_t* ppw = pw;
 
-                        float_t * ppdelta_dst = pdelta_dst + y * params.in.width_ + x;
-                        float_t sum = float_t(0);
+            float_t* ppdelta_dst = pdelta_dst + y * params.in.width_ + x;
+            float_t sum = float_t(0);
 
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                                idx = (y * params.h_stride + wy) *
-                                    params.out.width_ + (x *
-                                    params.w_stride + wx);
-                                sum += ppw[wy * params.weight.width_ + wx] *
-                                    pdelta_src[idx];
-                            }
-                        }
-                        *ppdelta_dst += sum;
-                    }
-                }
+            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+              for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+                idx = (y * params.h_stride + wy) * params.out.width_ +
+                      (x * params.w_stride + wx);
+                sum += ppw[wy * params.weight.width_ + wx] * pdelta_src[idx];
+              }
             }
+            *ppdelta_dst += sum;
+          }
         }
+      }
+    }
 
-        // accumulate dw
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                if (!params.tbl.is_connected(outc, inc)) continue;
+    // accumulate dw
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        if (!params.tbl.is_connected(outc, inc)) continue;
 
-                for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                    for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                        float_t dst = float_t(0);
+        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+          for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+            float_t dst = float_t(0);
 
-                        cnn_size_t idx = 0;
-                        idx = params.in.get_index(0, 0, inc);
-                        const float_t * prevo = &prev_out[sample][idx];
+            cnn_size_t idx = 0;
+            idx = params.in.get_index(0, 0, inc);
+            const float_t* prevo = &prev_out[sample][idx];
 
-                        idx = params.out.get_index(wx, wy, outc);
-                        const float_t * delta = &curr_delta[sample][idx];
+            idx = params.out.get_index(wx, wy, outc);
+            const float_t* delta = &curr_delta[sample][idx];
 
-                        for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                            dst += vectorize::dot(
-                                prevo + y * params.in.width_,
-                                delta + y * params.out.width_,
-                                params.in.width_);
-                        }
-
-                        idx = params.in.depth_ * outc + inc;
-                        dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
-                    }
-                }
+            for (cnn_size_t y = 0; y < params.in.height_; y++) {
+              dst += vectorize::dot(prevo + y * params.in.width_,
+                                    delta + y * params.out.width_,
+                                    params.in.width_);
             }
-        }
 
-        // accumulate db
-        if (params.has_bias) {
-            //vec_t& db = *in_grad[2];
-
-            for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-                cnn_size_t idx = params.out.get_index(0, 0, outc);
-                const float_t * delta = &curr_delta[sample][idx];
-                const float_t * deltaa = delta + params.out.width_ *
-                    params.out.height_;
-                db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
-            }
+            idx = params.in.depth_ * outc + inc;
+            dW[sample][params.weight.get_index(wx, wy, idx)] += dst;
+          }
         }
-    });
+      }
+    }
+
+    // accumulate db
+    if (params.has_bias) {
+      // vec_t& db = *in_grad[2];
+
+      for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+        cnn_size_t idx = params.out.get_index(0, 0, outc);
+        const float_t* delta = &curr_delta[sample][idx];
+        const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+        db[sample][outc] += std::accumulate(delta, deltaa, float_t(0));
+      }
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_deconv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/tiny_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_deconv2d_kernel.h
@@ -11,57 +11,53 @@ namespace core {
 namespace kernels {
 
 inline void tiny_deconv2d_kernel(const deconv_params& params,
-                                 const tensor_t&      in,
-                                 const vec_t&         W,
-                                 const vec_t&         bias,
-                                 tensor_t&            a,
+                                 const tensor_t& in, const vec_t& W,
+                                 const vec_t& bias, tensor_t& a,
                                  const bool layer_parallelize) {
+  for_i(layer_parallelize, in.size(), [&](int sample) {
+    for (cnn_size_t o = 0; o < params.out.depth_; o++) {
+      for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+        if (!params.tbl.is_connected(o, inc)) continue;
 
-    for_i(layer_parallelize, in.size(), [&](int sample) {
-        for (cnn_size_t o = 0; o < params.out.depth_; o++) {
-            for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-                if (!params.tbl.is_connected(o, inc)) continue;
+        cnn_size_t idx = 0;
+        idx = params.in.depth_ * o + inc;
+        idx = params.weight.get_index(0, 0, idx);
+        assert(idx < W.size());
+        const float_t* pw = &W[idx];
 
-                cnn_size_t idx = 0;
-                idx = params.in.depth_ * o + inc;
-                idx = params.weight.get_index(0, 0, idx);
-                assert(idx < W.size());
-                const float_t *pw = &W[idx];
+        idx = params.in.get_index(0, 0, inc);
+        assert(static_cast<cnn_size_t>(sample) < in.size() &&
+               idx < in[sample].size());
+        const float_t* pi = &in[sample][idx];
 
-                idx = params.in.get_index(0, 0, inc);
-                assert(static_cast<cnn_size_t>(sample) < in.size() &&
-                       idx < in[sample].size());
-                const float_t *pi = &in[sample][idx];
+        idx = params.out.get_index(0, 0, o);
+        assert(static_cast<cnn_size_t>(sample) < a.size() &&
+               idx < a[sample].size());
+        float_t* pa = &a[sample][idx];
 
-                idx = params.out.get_index(0, 0, o);
-                assert(static_cast<cnn_size_t>(sample) < a.size() &&
-                       idx < a[sample].size());
-                float_t *pa = &a[sample][idx];
-
-                for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                    for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                        const float_t * ppw = pw;
-                        const float_t * ppi = pi + y * params.in.width_ + x;
-                        // should be optimized for small kernel(3x3,5x5)
-                        for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                                pa[(y * params.h_stride + wy) *
-                                    params.out.width_ + (x *
-                                    params.w_stride + wx)] += ppw[wy *
-                                    params.weight.width_ + wx] * (*ppi);
-                            }
-                        }
-                    }
-                }
+        for (cnn_size_t y = 0; y < params.in.height_; y++) {
+          for (cnn_size_t x = 0; x < params.in.width_; x++) {
+            const float_t* ppw = pw;
+            const float_t* ppi = pi + y * params.in.width_ + x;
+            // should be optimized for small kernel(3x3,5x5)
+            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+              for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+                pa[(y * params.h_stride + wy) * params.out.width_ +
+                   (x * params.w_stride + wx)] +=
+                    ppw[wy * params.weight.width_ + wx] * (*ppi);
+              }
             }
-
-            if (params.has_bias) {
-                float_t * pa = &a[sample][params.out.get_index(0, 0, o)];
-                float_t * paa = pa + params.out.width_ * params.out.height_;
-                std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
-            }
+          }
         }
-    });
+      }
+
+      if (params.has_bias) {
+        float_t* pa = &a[sample][params.out.get_index(0, 0, o)];
+        float_t* paa = pa + params.out.width_ * params.out.height_;
+        std::for_each(pa, paa, [&](float_t& f) { f += bias[o]; });
+      }
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_fully_connected_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/tiny_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_fully_connected_kernel.h
@@ -11,64 +11,58 @@ namespace core {
 namespace kernels {
 
 inline void tiny_fully_connected_kernel(const fully_params& params,
-                                        const tensor_t&     in_data,
-                                        const vec_t&        W,
-                                        const vec_t&        b,
-                                        tensor_t&           out_data,
-                                        const bool          layer_parallelize) {
+                                        const tensor_t& in_data, const vec_t& W,
+                                        const vec_t& b, tensor_t& out_data,
+                                        const bool layer_parallelize) {
+  for_i(layer_parallelize, in_data.size(), [&](int sample) {
+    const vec_t& in = in_data[sample];
+    vec_t& out = out_data[sample];
 
-    for_i(layer_parallelize, in_data.size(), [&](int sample) {
-        const vec_t& in = in_data[sample];
-        vec_t& out = out_data[sample];
+    for (cnn_size_t i = 0; i < params.out_size_; i++) {
+      out[i] = float_t(0);
+      for (cnn_size_t c = 0; c < params.in_size_; c++) {
+        out[i] += W[c * params.out_size_ + i] * in[c];
+      }
 
-        for (cnn_size_t i = 0; i < params.out_size_; i++) {
-            out[i] = float_t(0);
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                out[i] += W[c * params.out_size_ + i] * in[c];
-            }
-
-            if (params.has_bias_) {
-                out[i] += b[i];
-            }
-        }
-    });
+      if (params.has_bias_) {
+        out[i] += b[i];
+      }
+    }
+  });
 }
 
 inline void tiny_fully_connected_back_kernel(const fully_params& params,
                                              const tensor_t& prev_out,
-                                             const vec_t&    W,
-                                             tensor_t&       dW,
-                                             tensor_t&       prev_delta,
-                                             tensor_t&       curr_delta,
-                                             tensor_t&       db,
-                                             const bool      layer_parallelize) {
-
-    for (cnn_size_t sample = 0; sample < prev_out.size(); sample++) {
-        for (cnn_size_t c = 0; c < params.in_size_; c++) {
-            // propagate delta to previous layer
-            // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
-            prev_delta[sample][c] += vectorize::dot(&curr_delta[sample][0],
-                &W[c * params.out_size_],
-                params.out_size_);
-        }
-
-        for_(layer_parallelize, 0, size_t(params.out_size_), [&](const blocked_range& r) {
-            // accumulate weight-step using delta
-            // dW[c * out_size + i] += current_delta[i] * prev_out[c]
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                vectorize::muladd(&curr_delta[sample][r.begin()],
-                    prev_out[sample][c], r.end() - r.begin(),
-                    &dW[sample][c * params.out_size_ + r.begin()]);
-            }
-
-            if (params.has_bias_) {
-                // vec_t& db = *in_grad[2];
-                for (int i = r.begin(); i < r.end(); i++) {
-                    db[sample][i] += curr_delta[sample][i];
-                }
-            }
-        });
+                                             const vec_t& W, tensor_t& dW,
+                                             tensor_t& prev_delta,
+                                             tensor_t& curr_delta, tensor_t& db,
+                                             const bool layer_parallelize) {
+  for (cnn_size_t sample = 0; sample < prev_out.size(); sample++) {
+    for (cnn_size_t c = 0; c < params.in_size_; c++) {
+      // propagate delta to previous layer
+      // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
+      prev_delta[sample][c] += vectorize::dot(
+          &curr_delta[sample][0], &W[c * params.out_size_], params.out_size_);
     }
+
+    for_(layer_parallelize, 0, size_t(params.out_size_),
+         [&](const blocked_range& r) {
+           // accumulate weight-step using delta
+           // dW[c * out_size + i] += current_delta[i] * prev_out[c]
+           for (cnn_size_t c = 0; c < params.in_size_; c++) {
+             vectorize::muladd(&curr_delta[sample][r.begin()],
+                               prev_out[sample][c], r.end() - r.begin(),
+                               &dW[sample][c * params.out_size_ + r.begin()]);
+           }
+
+           if (params.has_bias_) {
+             // vec_t& db = *in_grad[2];
+             for (int i = r.begin(); i < r.end(); i++) {
+               db[sample][i] += curr_delta[sample][i];
+             }
+           }
+         });
+  }
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_maxpool_kernel.h
@@ -8,50 +8,46 @@ namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-inline void tiny_maxpool_kernel(const tensor_t& in_data,
-                                tensor_t&       out_data,
-                                std::vector<std::vector<cnn_size_t>>& max_idx,
-                                const std::vector<std::vector<cnn_size_t>>& out2in,
-                                const bool layer_parallelize) {
+inline void tiny_maxpool_kernel(
+    const tensor_t& in_data, tensor_t& out_data,
+    std::vector<std::vector<cnn_size_t>>& max_idx,
+    const std::vector<std::vector<cnn_size_t>>& out2in,
+    const bool layer_parallelize) {
+  for_i(layer_parallelize, in_data.size(), [&](int sample) {
+    const vec_t& in = in_data[sample];
+    vec_t& a = out_data[sample];
+    std::vector<cnn_size_t>& max = max_idx[sample];
 
-    for_i(layer_parallelize, in_data.size(), [&](int sample) {
-        const vec_t& in = in_data[sample];
-        vec_t& a = out_data[sample];
-        std::vector<cnn_size_t>& max = max_idx[sample];
+    for (cnn_size_t i = 0; i < out2in.size(); i++) {
+      const auto& in_index = out2in[i];
+      float_t max_value = std::numeric_limits<float_t>::lowest();
 
-        for (cnn_size_t i = 0; i < out2in.size(); i++) {
-            const auto& in_index = out2in[i];
-            float_t max_value = std::numeric_limits<float_t>::lowest();
-
-            for (auto j : in_index) {
-                if (in[j] > max_value) {
-                    max_value = in[j];
-                    max[i] = j;
-                }
-            }
-            a[i] = max_value;
+      for (auto j : in_index) {
+        if (in[j] > max_value) {
+          max_value = in[j];
+          max[i] = j;
         }
-    });
+      }
+      a[i] = max_value;
+    }
+  });
 }
 
-inline void tiny_maxpool_back_kernel(tensor_t& prev_delta,
-                                     const tensor_t&  curr_delta,
-                                     std::vector<std::vector<cnn_size_t>>& max_idx,
-                                     const std::vector<cnn_size_t>& in2out,
-                                     const bool layer_parallelize) {
+inline void tiny_maxpool_back_kernel(
+    tensor_t& prev_delta, const tensor_t& curr_delta,
+    std::vector<std::vector<cnn_size_t>>& max_idx,
+    const std::vector<cnn_size_t>& in2out, const bool layer_parallelize) {
+  for_i(layer_parallelize, prev_delta.size(), [&](int sample) {
+    vec_t& prev = prev_delta[sample];
+    const vec_t& curr = curr_delta[sample];
+    const std::vector<cnn_size_t>& max = max_idx[sample];
 
-    for_i(layer_parallelize, prev_delta.size(), [&](int sample) {
-        vec_t& prev       = prev_delta[sample];
-        const vec_t& curr = curr_delta[sample];
-        const std::vector<cnn_size_t>& max = max_idx[sample];
-
-        for (cnn_size_t i = 0; i < in2out.size(); i++) {
-            cnn_size_t outi = in2out[i];
-            prev[i] = (max[outi] == static_cast<cnn_size_t>(i)) ?
-                       curr[outi] : float_t(0);
-        }
-    });
-    
+    for (cnn_size_t i = 0; i < in2out.size(); i++) {
+      cnn_size_t outi = in2out[i];
+      prev[i] =
+          (max[outi] == static_cast<cnn_size_t>(i)) ? curr[outi] : float_t(0);
+    }
+  });
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_maxpool_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_maxpool_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/kernels/tiny_quantization_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantization_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/conv_params.h"

--- a/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
@@ -4,431 +4,456 @@
 
 #pragma once
 
-#include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/kernels/tiny_quantization_kernel.h"
+#include "tiny_dnn/core/params/conv_params.h"
 
 namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
 inline void tiny_quantized_conv2d_kernel(const conv_params& params,
-                                         const vec_t&       in,
-                                         const vec_t&       W,
-                                         const vec_t&       bias,
-                                         vec_t&             a,
+                                         const vec_t& in, const vec_t& W,
+                                         const vec_t& bias, vec_t& a,
                                          const bool layer_parallelize) {
-    // image quantization
-    float min_input(in[0]);
-    float max_input(in[0]);
+  // image quantization
+  float min_input(in[0]);
+  float max_input(in[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.in_padded.height_ * params.in_padded.height_; ins++) {
+      cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
+      min_input = std::min(min_input, (&in[idx])[ins]);
+      max_input = std::max(max_input, (&in[idx])[ins]);
+    }
+  }
+  std::vector<uint8_t> in_quantized =
+      float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t inc = 0; inc < params.in_padded.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.weight.height_ * params.weight.height_; ins++) {
+      cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
+      min_filter = std::min(min_filter, (&W[idx])[ins]);
+      max_filter = std::max(max_filter, (&W[idx])[ins]);
+    }
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  // bias quantization
+  float min_bias(0);
+  float max_bias(0);
+  std::vector<uint8_t> bias_quantized;
+  if (params.has_bias) {
+    for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
+      min_bias = std::min(min_bias, bias[inc]);
+      max_bias = std::max(max_bias, bias[inc]);
+    }
+    if (min_bias == max_bias) {
+      max_bias = bias[0] + 1e-3f;
+      min_bias = bias[0] - 1e-3f;
+    }
+    bias_quantized =
+        float_tensor_to_quantized<uint8_t>(bias, min_bias, max_bias);
+  }
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_input, max_input, min_filter, max_filter, &min_output_value,
+      &max_output_value);
+
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+
+  // calculating offset
+  const int32_t offset_input = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t zero_in_total_space = int64_to_int32(
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+
+  for_i(layer_parallelize, params.out.depth_, [&](int o) {
     for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.in_padded.height_*params.in_padded.height_; ins++) {
-            cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
-            min_input = std::min(min_input, (&in[idx])[ins]);
-            max_input = std::max(max_input, (&in[idx])[ins]);
-        }
-    }
-    std::vector<uint8_t> in_quantized =
-        float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t inc = 0; inc < params.in_padded.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.weight.height_*params.weight.height_; ins++) {
-            cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
-            min_filter = std::min(min_filter, (&W[idx])[ins]);
-            max_filter = std::max(max_filter, (&W[idx])[ins]);
-        }
-    }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
-    }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
-    // bias quantization
-    float min_bias(0);
-    float max_bias(0);
-    std::vector<uint8_t> bias_quantized;
-    if (params.has_bias) {
-        for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
-            min_bias = std::min(min_bias, bias[inc]);
-            max_bias = std::max(max_bias, bias[inc]);
-        }
-        if (min_bias == max_bias) {
-          max_bias = bias[0] + 1e-3f;
-          min_bias = bias[0] - 1e-3f;
-        }
-        bias_quantized =
-            float_tensor_to_quantized<uint8_t>(bias, min_bias, max_bias);
-    }
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_input, max_input, min_filter, max_filter, &min_output_value,
-        &max_output_value);
+      if (!params.tbl.is_connected(o, inc)) continue;
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * o + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-    // calculating offset
-    const int32_t offset_input =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t zero_in_total_space =
-        int64_to_int32(float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+      idx = params.in_padded.get_index(0, 0, inc);
+      const uint8_t* pi = &in_quantized[idx];
 
-    for_i(layer_parallelize, params.out.depth_, [&](int o) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            if (!params.tbl.is_connected(o, inc)) continue;
+      idx = params.out.get_index(0, 0, o);
+      int32_t* pa_quantized = &a_quantized[idx];
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * o + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
+      for (cnn_size_t y = 0; y < params.out.height_; y++) {
+        for (cnn_size_t x = 0; x < params.out.width_; x++) {
+          const uint8_t* ppw = pw;
+          const uint8_t* ppi = pi +
+                               params.in_padded.width_ * (y * params.h_stride) +
+                               x * params.w_stride;
+          int32_t sum = 0;
 
-            idx = params.in_padded.get_index(0, 0, inc);
-            const uint8_t *pi = &in_quantized[idx];
-
-            idx = params.out.get_index(0, 0, o);
-            int32_t *pa_quantized = &a_quantized[idx];
-
-            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                    const uint8_t * ppw = pw;
-                    const uint8_t * ppi = pi + params.in_padded.width_ *
-                                        (y * params.h_stride) +
-                                         x * params.w_stride;
-                    int32_t sum = 0;
-
-                    // should be optimized for small kernel(3x3,5x5)
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                            idx = wy * params.in_padded.width_ + wx;
-                            sum += (static_cast<int32_t>(*ppw++) - offset_filter)
-                                    * (static_cast<int32_t>(ppi[idx]) - offset_input);
-                        }
-                    }
-                    pa_quantized[y * params.out.width_ + x] += sum;
-                }
+          // should be optimized for small kernel(3x3,5x5)
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+              idx = wy * params.in_padded.width_ + wx;
+              sum += (static_cast<int32_t>(*ppw++) - offset_filter) *
+                     (static_cast<int32_t>(ppi[idx]) - offset_input);
             }
+          }
+          pa_quantized[y * params.out.width_ + x] += sum;
         }
-        if (params.has_bias) {
-            int32_t * pa_quantized  = &a_quantized[params.out.get_index(0, 0, o)];
-            int32_t * paa_quantized = pa_quantized + params.out.width_ * params.out.height_;
-            std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
-                f += (bias_quantized[o] - zero_in_total_space);
-            });
-        }
-    });
+      }
+    }
+    if (params.has_bias) {
+      int32_t* pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
+      int32_t* paa_quantized =
+          pa_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
+        f += (bias_quantized[o] - zero_in_total_space);
+      });
+    }
+  });
 
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
 
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-    &min_output_requantized, &max_output_requantized, &a_requantized);
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
 
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized,
+                                         max_output_requantized);
 }
 
 inline void tiny_quantized_conv2d_back_kernel(const conv_params& params,
                                               const vec_t& prev_out,
-                                              const vec_t& W,
-                                              vec_t&       dW,
-                                              vec_t&       db,
-                                              vec_t&       curr_delta,
-                                              vec_t*       prev_delta) {
-    // previous output quantization
-    float min_prev_out(prev_out[0]);
-    float max_prev_out(prev_out[0]);
-    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.in_padded.height_*params.in_padded.height_; ins++) {
-            cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
-            min_prev_out = std::min(min_prev_out, (&prev_out[idx])[ins]);
-            max_prev_out = std::max(min_prev_out, (&prev_out[idx])[ins]);
-        }
+                                              const vec_t& W, vec_t& dW,
+                                              vec_t& db, vec_t& curr_delta,
+                                              vec_t* prev_delta) {
+  // previous output quantization
+  float min_prev_out(prev_out[0]);
+  float max_prev_out(prev_out[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.in_padded.height_ * params.in_padded.height_; ins++) {
+      cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
+      min_prev_out = std::min(min_prev_out, (&prev_out[idx])[ins]);
+      max_prev_out = std::max(min_prev_out, (&prev_out[idx])[ins]);
     }
-    std::vector<uint8_t> prev_out_quantized =
-        float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
+  }
+  std::vector<uint8_t> prev_out_quantized =
+      float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
 
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t inc = 0; inc < params.in_padded.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.weight.height_*params.weight.height_; ins++) {
-            cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
-            min_filter = std::min(min_filter, (&W[idx])[ins]);
-            max_filter = std::max(max_filter, (&W[idx])[ins]);
-        }
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t inc = 0; inc < params.in_padded.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.weight.height_ * params.weight.height_; ins++) {
+      cnn_size_t idx = params.in_padded.get_index(0, 0, inc);
+      min_filter = std::min(min_filter, (&W[idx])[ins]);
+      max_filter = std::max(max_filter, (&W[idx])[ins]);
     }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+
+  // current delta quantization
+  float min_curr_delta(curr_delta[0]);
+  float max_curr_delta(curr_delta[0]);
+  for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
+    for (cnn_size_t ins = 0; ins < params.out.height_ * params.out.height_;
+         ins++) {
+      cnn_size_t idx = params.out.get_index(0, 0, inc);
+      min_curr_delta = std::min(min_curr_delta, (&curr_delta[idx])[ins]);
+      max_curr_delta = std::max(max_curr_delta, (&curr_delta[idx])[ins]);
     }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  }
+  std::vector<uint8_t> curr_delta_quantized =
+      float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta,
+                                         max_curr_delta);
 
-    // current delta quantization
-    float min_curr_delta(curr_delta[0]);
-    float max_curr_delta(curr_delta[0]);
-    for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.out.height_*params.out.height_; ins++) {
-            cnn_size_t idx = params.out.get_index(0, 0, inc);
-            min_curr_delta = std::min(min_curr_delta, (&curr_delta[idx])[ins]);
-            max_curr_delta = std::max(max_curr_delta, (&curr_delta[idx])[ins]);
-        }
-    }
-    std::vector<uint8_t> curr_delta_quantized =
-        float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta, max_curr_delta);
+  // output range for previous delta
+  float min_prev_delta_value;
+  float max_prev_delta_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_filter, max_filter,
+      &min_prev_delta_value, &max_prev_delta_value);
 
-    // output range for previous delta
-    float min_prev_delta_value;
-    float max_prev_delta_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_filter, max_filter, &min_prev_delta_value,
-        &max_prev_delta_value);
+  std::vector<int32_t> prev_delta_quantized(prev_delta->size(),
+                                            static_cast<int32_t>(0));
 
-    std::vector<int32_t> prev_delta_quantized(prev_delta->size(), static_cast<int32_t>(0));
+  // output range for dW
+  float min_dW_value;
+  float max_dW_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
+      &max_dW_value);
 
-    // output range for dW
-    float min_dW_value;
-    float max_dW_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
-        &max_dW_value);
+  std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
 
-    std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
+  // calculating offset
+  const int32_t offset_prev_out = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t offset_curr_delta =
+      int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_curr_delta,
+                                                           max_curr_delta));
+  // const int32_t zero_in_prev_delta =
+  //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value,
+  //    max_prev_delta_value);
 
-    // calculating offset
-    const int32_t offset_prev_out =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t offset_curr_delta =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_curr_delta, max_curr_delta));
-    // const int32_t zero_in_prev_delta =
-    //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value, max_prev_delta_value);
+  // propagate delta to previous layer
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
 
-    // propagate delta to previous layer
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * outc + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * outc + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
+      idx = params.out.get_index(0, 0, outc);
+      const uint8_t* pdelta_src = &curr_delta_quantized[idx];
 
-            idx = params.out.get_index(0, 0, outc);
-            const uint8_t *pdelta_src = &curr_delta_quantized[idx];
+      idx = params.in_padded.get_index(0, 0, inc);
+      int32_t* pdelta_quantized_dst = &(prev_delta_quantized)[idx];
 
-            idx = params.in_padded.get_index(0, 0, inc);
-            int32_t *pdelta_quantized_dst = &(prev_delta_quantized)[idx];
+      for (cnn_size_t y = 0; y < params.out.height_; y++) {
+        for (cnn_size_t x = 0; x < params.out.width_; x++) {
+          const uint8_t* ppw = pw;
 
-            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                    const uint8_t * ppw = pw;
+          idx = y * params.out.width_ + x;
+          const uint8_t ppdelta_src = pdelta_src[idx];
 
-                    idx = y * params.out.width_ + x;
-                    const uint8_t ppdelta_src = pdelta_src[idx];
+          int32_t* ppdelta_quantized_dst =
+              pdelta_quantized_dst +
+              y * params.h_stride * params.in_padded.width_ +
+              x * params.w_stride;
 
-                    int32_t * ppdelta_quantized_dst = pdelta_quantized_dst +
-                          y * params.h_stride * params.in_padded.width_ +
-                          x * params.w_stride;
-
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {    // NOLINT
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) { // NOLINT
-                            idx = wy * params.in_padded.width_ + wx;
-                            ppdelta_quantized_dst[idx] += (static_cast<int32_t>(*ppw++) - offset_filter)
-                                                * (static_cast<int32_t>(ppdelta_src) - offset_curr_delta);
-                        }
-                    }
-                }
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {  // NOLINT
+            for (cnn_size_t wx = 0; wx < params.weight.width_;
+                 wx++) {  // NOLINT
+              idx = wy * params.in_padded.width_ + wx;
+              ppdelta_quantized_dst[idx] +=
+                  (static_cast<int32_t>(*ppw++) - offset_filter) *
+                  (static_cast<int32_t>(ppdelta_src) - offset_curr_delta);
             }
+          }
         }
-    });
-
-    float min_prev_delta_requantized;
-    float max_prev_delta_requantized;
-    std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
-    &min_prev_delta_requantized, &max_prev_delta_requantized, &prev_delta_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(prev_delta_requantized, min_prev_delta_requantized, max_prev_delta_requantized);
-    prev_delta = &prev_delta_vec;
-
-    // Accumulate dw
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
-
-            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                    int32_t dst = int32_t(0);
-
-                    cnn_size_t idx = 0;
-                    idx = params.in_padded.get_index(wx, wy, inc);
-                    const uint8_t * prevo = &prev_out_quantized[idx];
-
-                    idx = params.out.get_index(0, 0, outc);
-                    const uint8_t * delta = &curr_delta_quantized[idx];
-
-                    for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                        for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                            dst += (static_cast<int32_t>(*(prevo + y * params.in_padded.width_ + x)) - offset_prev_out) *
-                                   (static_cast<int32_t>(*(delta + y * params.out.width_ + x)) - offset_curr_delta);
-                        }
-                    }
-
-                    idx = params.in.depth_ * outc + inc;
-                    dW_quantized[params.weight.get_index(wx, wy, idx)] += dst;
-                }
-            }
-        }
-    });
-
-    float min_dW_requantized;
-    float max_dW_requantized;
-    std::vector<uint8_t> dW_requantized(dW_quantized.size(), static_cast<uint8_t>(0));
-
-    // requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(dW_quantized, min_dW_value, max_dW_value,
-    &min_dW_requantized, &max_dW_requantized, &dW_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized, max_dW_requantized);
-
-    // Accumulate db
-    if (params.has_bias) {
-        //vec_t& db = *in_grad[2];
-
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            cnn_size_t idx = params.out.get_index(0, 0, outc);
-            const float_t * delta = &curr_delta[idx];
-            const float_t * deltaa = delta + params.out.width_ *
-                                             params.out.height_;
-            db[outc] += std::accumulate(delta, deltaa, float_t(0));
-        }
+      }
     }
+  });
+
+  float min_prev_delta_requantized;
+  float max_prev_delta_requantized;
+  std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(),
+                                              static_cast<uint8_t>(0));
+
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
+      &min_prev_delta_requantized, &max_prev_delta_requantized,
+      &prev_delta_requantized);
+
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(
+      prev_delta_requantized, min_prev_delta_requantized,
+      max_prev_delta_requantized);
+  prev_delta = &prev_delta_vec;
+
+  // Accumulate dw
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
+
+      for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+          int32_t dst = int32_t(0);
+
+          cnn_size_t idx = 0;
+          idx = params.in_padded.get_index(wx, wy, inc);
+          const uint8_t* prevo = &prev_out_quantized[idx];
+
+          idx = params.out.get_index(0, 0, outc);
+          const uint8_t* delta = &curr_delta_quantized[idx];
+
+          for (cnn_size_t y = 0; y < params.out.height_; y++) {
+            for (cnn_size_t x = 0; x < params.out.width_; x++) {
+              dst +=
+                  (static_cast<int32_t>(
+                       *(prevo + y * params.in_padded.width_ + x)) -
+                   offset_prev_out) *
+                  (static_cast<int32_t>(*(delta + y * params.out.width_ + x)) -
+                   offset_curr_delta);
+            }
+          }
+
+          idx = params.in.depth_ * outc + inc;
+          dW_quantized[params.weight.get_index(wx, wy, idx)] += dst;
+        }
+      }
+    }
+  });
+
+  float min_dW_requantized;
+  float max_dW_requantized;
+  std::vector<uint8_t> dW_requantized(dW_quantized.size(),
+                                      static_cast<uint8_t>(0));
+
+  // requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      dW_quantized, min_dW_value, max_dW_value, &min_dW_requantized,
+      &max_dW_requantized, &dW_requantized);
+
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized,
+                                          max_dW_requantized);
+
+  // Accumulate db
+  if (params.has_bias) {
+    // vec_t& db = *in_grad[2];
+
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      cnn_size_t idx = params.out.get_index(0, 0, outc);
+      const float_t* delta = &curr_delta[idx];
+      const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+      db[outc] += std::accumulate(delta, deltaa, float_t(0));
+    }
+  }
 }
 
 inline void tiny_quantized_conv2d_kernel(const conv_params& params,
-                                         const vec_t&       in,
-                                         const vec_t&       W,
-                                         const vec_t&       bias,
-                                         const vec_t&       in_r,
-                                         const vec_t&       W_r,
-                                         const vec_t&       b_r,
-                                         vec_t&             a,
-                                         vec_t&             a_r,
+                                         const vec_t& in, const vec_t& W,
+                                         const vec_t& bias, const vec_t& in_r,
+                                         const vec_t& W_r, const vec_t& b_r,
+                                         vec_t& a, vec_t& a_r,
                                          const bool layer_parallelize) {
-    // filter range
-    float min_filter(W_r[0]);
-    float max_filter(W_r[1]);
-    if (W_r[0] == W_r[1]) {
-      max_filter = W_r[1] + 1e-3f;
-      min_filter = W_r[0] - 1e-3f;
+  // filter range
+  float min_filter(W_r[0]);
+  float max_filter(W_r[1]);
+  if (W_r[0] == W_r[1]) {
+    max_filter = W_r[1] + 1e-3f;
+    min_filter = W_r[0] - 1e-3f;
+  }
+  // bias range
+  float min_bias(b_r[0]);
+  float max_bias(b_r[1]);
+  if (params.has_bias) {
+    if (min_bias == max_bias) {
+      max_bias = b_r[1] + 1e-3f;
+      min_bias = b_r[0] - 1e-3f;
     }
-    // bias range
-    float min_bias(b_r[0]);
-    float max_bias(b_r[1]);
-    if (params.has_bias) {
-        if (min_bias == max_bias) {
-          max_bias = b_r[1] + 1e-3f;
-          min_bias = b_r[0] - 1e-3f;
-        }
-    }
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
-        &max_output_value);
-    // data type restore
-    std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
-    for (size_t i = 0; i < in.size(); i++) {
-       in_quantized.push_back(static_cast<uint8_t>(in[i]));
-    }
-    for (size_t i = 0; i < W.size(); i++) {
-        W_quantized.push_back(static_cast<uint8_t>(W[i]));
-    }
-    for (size_t i = 0; i < bias.size(); i++) {
-        bias_quantized.push_back(static_cast<uint8_t>(bias[i]));
-    }
+  }
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
+      &max_output_value);
+  // data type restore
+  std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
+  for (size_t i = 0; i < in.size(); i++) {
+    in_quantized.push_back(static_cast<uint8_t>(in[i]));
+  }
+  for (size_t i = 0; i < W.size(); i++) {
+    W_quantized.push_back(static_cast<uint8_t>(W[i]));
+  }
+  for (size_t i = 0; i < bias.size(); i++) {
+    bias_quantized.push_back(static_cast<uint8_t>(bias[i]));
+  }
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
 
-    // calculating offset
-    const int32_t offset_input =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t zero_in_total_space =
-        int64_to_int32(float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+  // calculating offset
+  const int32_t offset_input = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t zero_in_total_space = int64_to_int32(
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
 
-    for_i(layer_parallelize, params.out.depth_, [&](int o) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            if (!params.tbl.is_connected(o, inc)) continue;
+  for_i(layer_parallelize, params.out.depth_, [&](int o) {
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      if (!params.tbl.is_connected(o, inc)) continue;
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * o + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * o + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-            idx = params.in_padded.get_index(0, 0, inc);
-            const uint8_t *pi = &in_quantized[idx];
+      idx = params.in_padded.get_index(0, 0, inc);
+      const uint8_t* pi = &in_quantized[idx];
 
-            idx = params.out.get_index(0, 0, o);
-            int32_t *pa_quantized = &a_quantized[idx];
+      idx = params.out.get_index(0, 0, o);
+      int32_t* pa_quantized = &a_quantized[idx];
 
-            for (cnn_size_t y = 0; y < params.out.height_; y++) {
-                for (cnn_size_t x = 0; x < params.out.width_; x++) {
-                    const uint8_t * ppw = pw;
-                    const uint8_t * ppi = pi + params.in_padded.width_ *
-                                        (y * params.h_stride) +
-                                         x * params.w_stride;
-                    int32_t sum = 0;
+      for (cnn_size_t y = 0; y < params.out.height_; y++) {
+        for (cnn_size_t x = 0; x < params.out.width_; x++) {
+          const uint8_t* ppw = pw;
+          const uint8_t* ppi = pi +
+                               params.in_padded.width_ * (y * params.h_stride) +
+                               x * params.w_stride;
+          int32_t sum = 0;
 
-                    // should be optimized for small kernel(3x3,5x5)
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                            idx = wy * params.in_padded.width_ + wx;
-                            sum += (static_cast<int32_t>(*ppw++) - offset_filter)
-                                    * (static_cast<int32_t>(ppi[idx]) - offset_input);
-                        }
-                    }
-                    pa_quantized[y * params.out.width_ + x] += sum;
-                }
+          // should be optimized for small kernel(3x3,5x5)
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+              idx = wy * params.in_padded.width_ + wx;
+              sum += (static_cast<int32_t>(*ppw++) - offset_filter) *
+                     (static_cast<int32_t>(ppi[idx]) - offset_input);
             }
+          }
+          pa_quantized[y * params.out.width_ + x] += sum;
         }
-        if (params.has_bias) {
-            int32_t * pa_quantized  = &a_quantized[params.out.get_index(0, 0, o)];
-            int32_t * paa_quantized = pa_quantized + params.out.width_ * params.out.height_;
-            std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
-                f += static_cast<int32_t>((bias[o] - zero_in_total_space));
-            });
-        }
-    });
-
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-        &min_output_requantized, &max_output_requantized, &a_requantized);
-    // store directly in float datatype
-    for (size_t i = 0; i < a_requantized.size(); i++) {
-        a[i] = static_cast<float>(a_requantized[i]);
+      }
     }
-    a_r[0] = min_output_requantized;
-    a_r[1] = max_output_requantized;
+    if (params.has_bias) {
+      int32_t* pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
+      int32_t* paa_quantized =
+          pa_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
+        f += static_cast<int32_t>((bias[o] - zero_in_total_space));
+      });
+    }
+  });
+
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
+
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
+  // store directly in float datatype
+  for (size_t i = 0; i < a_requantized.size(); i++) {
+    a[i] = static_cast<float>(a_requantized[i]);
+  }
+  a_r[0] = min_output_requantized;
+  a_r[1] = max_output_requantized;
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -4,425 +4,449 @@
 
 #pragma once
 
-#include "tiny_dnn/core/params/deconv_params.h"
 #include "tiny_dnn/core/kernels/tiny_quantization_kernel.h"
+#include "tiny_dnn/core/params/deconv_params.h"
 
 namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
 inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
-                                           const vec_t&         in,
-                                           const vec_t&         W,
-                                           const vec_t&         bias,
-                                           vec_t&               a,
+                                           const vec_t& in, const vec_t& W,
+                                           const vec_t& bias, vec_t& a,
                                            const bool layer_parallelize) {
-    // image quantization
-    float min_input(in[0]);
-    float max_input(in[0]);
+  // image quantization
+  float min_input(in[0]);
+  float max_input(in[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0; ins < params.in.height_ * params.in.height_;
+         ins++) {
+      cnn_size_t idx = params.in.get_index(0, 0, inc);
+      min_input = std::min(min_input, (&in[idx])[ins]);
+      max_input = std::max(max_input, (&in[idx])[ins]);
+    }
+  }
+  std::vector<uint8_t> in_quantized =
+      float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.weight.height_ * params.weight.height_; ins++) {
+      cnn_size_t idx = params.in.get_index(0, 0, inc);
+      min_filter = std::min(min_filter, (&W[idx])[ins]);
+      max_filter = std::max(max_filter, (&W[idx])[ins]);
+    }
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  // bias quantization
+  float min_bias(0);
+  float max_bias(0);
+  std::vector<uint8_t> bias_quantized;
+  if (params.has_bias) {
+    for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
+      min_bias = std::min(min_bias, bias[inc]);
+      max_bias = std::max(max_bias, bias[inc]);
+    }
+    if (min_bias == max_bias) {
+      max_bias = bias[0] + 1e-3f;
+      min_bias = bias[0] - 1e-3f;
+    }
+    bias_quantized =
+        float_tensor_to_quantized<uint8_t>(bias, min_bias, max_bias);
+  }
+
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_input, max_input, min_filter, max_filter, &min_output_value,
+      &max_output_value);
+
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+
+  // calculating offset
+  const int32_t offset_input = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t zero_in_total_space = int64_to_int32(
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+
+  for_i(layer_parallelize, params.out.depth_, [&](int o) {
     for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.in.height_*params.in.height_; ins++) {
-            cnn_size_t idx = params.in.get_index(0, 0, inc);
-            min_input = std::min(min_input, (&in[idx])[ins]);
-            max_input = std::max(max_input, (&in[idx])[ins]);
-        }
-    }
-    std::vector<uint8_t> in_quantized =
-        float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.weight.height_*params.weight.height_; ins++) {
-            cnn_size_t idx = params.in.get_index(0, 0, inc);
-            min_filter = std::min(min_filter, (&W[idx])[ins]);
-            max_filter = std::max(max_filter, (&W[idx])[ins]);
-        }
-    }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
-    }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
-    // bias quantization
-    float min_bias(0);
-    float max_bias(0);
-    std::vector<uint8_t> bias_quantized;
-    if (params.has_bias) {
-        for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
-            min_bias = std::min(min_bias, bias[inc]);
-            max_bias = std::max(max_bias, bias[inc]);
-        }
-        if (min_bias == max_bias) {
-          max_bias = bias[0] + 1e-3f;
-          min_bias = bias[0] - 1e-3f;
-        }
-        bias_quantized =
-            float_tensor_to_quantized<uint8_t>(bias, min_bias, max_bias);
-    }
+      if (!params.tbl.is_connected(o, inc)) continue;
 
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_input, max_input, min_filter, max_filter, &min_output_value,
-        &max_output_value);
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * o + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+      idx = params.in.get_index(0, 0, inc);
+      const uint8_t* pi = &in_quantized[idx];
 
-    // calculating offset
-    const int32_t offset_input =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t zero_in_total_space =
-        int64_to_int32(float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+      idx = params.out.get_index(0, 0, o);
+      int32_t* pa_quantized = &a_quantized[idx];
 
-    for_i(layer_parallelize, params.out.depth_, [&](int o) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            if (!params.tbl.is_connected(o, inc)) continue;
-
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * o + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
-
-            idx = params.in.get_index(0, 0, inc);
-            const uint8_t *pi = &in_quantized[idx];
-
-            idx = params.out.get_index(0, 0, o);
-            int32_t *pa_quantized = &a_quantized[idx];
-
-            for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                    const uint8_t * ppw = pw;
-                    const uint8_t * ppi = pi + y * params.in.width_ + x;
-                    // should be optimized for small kernel(3x3,5x5)
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                            pa_quantized[(y * params.h_stride + wy) *
-                                    params.out.width_ + (x *
-                                    params.w_stride + wx)] += static_cast<int32_t>(ppw[wy *
-                                    params.weight.width_ + wx] - offset_filter) *
-                                    static_cast<int32_t>(*ppi - offset_input);
-                        }
-                    }
-                }
+      for (cnn_size_t y = 0; y < params.in.height_; y++) {
+        for (cnn_size_t x = 0; x < params.in.width_; x++) {
+          const uint8_t* ppw = pw;
+          const uint8_t* ppi = pi + y * params.in.width_ + x;
+          // should be optimized for small kernel(3x3,5x5)
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+              pa_quantized[(y * params.h_stride + wy) * params.out.width_ +
+                           (x * params.w_stride + wx)] +=
+                  static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] -
+                                       offset_filter) *
+                  static_cast<int32_t>(*ppi - offset_input);
             }
+          }
         }
-        if (params.has_bias) {
-            int32_t * pa_quantized  = &a_quantized[params.out.get_index(0, 0, o)];
-            int32_t * paa_quantized = pa_quantized + params.out.width_ * params.out.height_;
-            std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
-                f += (bias_quantized[o] - zero_in_total_space);
-            });
-        }
-    });
+      }
+    }
+    if (params.has_bias) {
+      int32_t* pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
+      int32_t* paa_quantized =
+          pa_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
+        f += (bias_quantized[o] - zero_in_total_space);
+      });
+    }
+  });
 
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
 
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-    &min_output_requantized, &max_output_requantized, &a_requantized);
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
 
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized,
+                                         max_output_requantized);
 }
 
 inline void tiny_quantized_deconv2d_back_kernel(const deconv_params& params,
                                                 const vec_t& prev_out,
-                                                const vec_t& W,
-                                                vec_t&       dW,
-                                                vec_t&       db,
-                                                vec_t&       curr_delta,
-                                                vec_t*       prev_delta) {
-    // previous output quantization
-    float min_prev_out(prev_out[0]);
-    float max_prev_out(prev_out[0]);
-    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.in.height_*params.in.height_; ins++) {
-            cnn_size_t idx = params.in.get_index(0, 0, inc);
-            min_prev_out = std::min(min_prev_out, (&prev_out[idx])[ins]);
-            max_prev_out = std::max(min_prev_out, (&prev_out[idx])[ins]);
-        }
+                                                const vec_t& W, vec_t& dW,
+                                                vec_t& db, vec_t& curr_delta,
+                                                vec_t* prev_delta) {
+  // previous output quantization
+  float min_prev_out(prev_out[0]);
+  float max_prev_out(prev_out[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0; ins < params.in.height_ * params.in.height_;
+         ins++) {
+      cnn_size_t idx = params.in.get_index(0, 0, inc);
+      min_prev_out = std::min(min_prev_out, (&prev_out[idx])[ins]);
+      max_prev_out = std::max(min_prev_out, (&prev_out[idx])[ins]);
     }
-    std::vector<uint8_t> prev_out_quantized =
-        float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
+  }
+  std::vector<uint8_t> prev_out_quantized =
+      float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
 
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.weight.height_*params.weight.height_; ins++) {
-            cnn_size_t idx = params.in.get_index(0, 0, inc);
-            min_filter = std::min(min_filter, (&W[idx])[ins]);
-            max_filter = std::max(max_filter, (&W[idx])[ins]);
-        }
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+    for (cnn_size_t ins = 0;
+         ins < params.weight.height_ * params.weight.height_; ins++) {
+      cnn_size_t idx = params.in.get_index(0, 0, inc);
+      min_filter = std::min(min_filter, (&W[idx])[ins]);
+      max_filter = std::max(max_filter, (&W[idx])[ins]);
     }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+
+  // current delta quantization
+  float min_curr_delta(curr_delta[0]);
+  float max_curr_delta(curr_delta[0]);
+  for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
+    for (cnn_size_t ins = 0; ins < params.out.height_ * params.out.height_;
+         ins++) {
+      cnn_size_t idx = params.out.get_index(0, 0, inc);
+      min_curr_delta = std::min(min_curr_delta, (&curr_delta[idx])[ins]);
+      max_curr_delta = std::max(max_curr_delta, (&curr_delta[idx])[ins]);
     }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  }
+  std::vector<uint8_t> curr_delta_quantized =
+      float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta,
+                                         max_curr_delta);
 
-    // current delta quantization
-    float min_curr_delta(curr_delta[0]);
-    float max_curr_delta(curr_delta[0]);
-    for (cnn_size_t inc = 0; inc < params.out.depth_; inc++) {
-        for (cnn_size_t ins = 0; ins < params.out.height_*params.out.height_; ins++) {
-            cnn_size_t idx = params.out.get_index(0, 0, inc);
-            min_curr_delta = std::min(min_curr_delta, (&curr_delta[idx])[ins]);
-            max_curr_delta = std::max(max_curr_delta, (&curr_delta[idx])[ins]);
-        }
-    }
-    std::vector<uint8_t> curr_delta_quantized =
-        float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta, max_curr_delta);
+  // output range for previous delta
+  float min_prev_delta_value;
+  float max_prev_delta_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_filter, max_filter,
+      &min_prev_delta_value, &max_prev_delta_value);
 
-    // output range for previous delta
-    float min_prev_delta_value;
-    float max_prev_delta_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_filter, max_filter, &min_prev_delta_value,
-        &max_prev_delta_value);
+  std::vector<int32_t> prev_delta_quantized(prev_delta->size(),
+                                            static_cast<int32_t>(0));
 
-    std::vector<int32_t> prev_delta_quantized(prev_delta->size(), static_cast<int32_t>(0));
+  // output range for dW
+  float min_dW_value;
+  float max_dW_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
+      &max_dW_value);
 
-    // output range for dW
-    float min_dW_value;
-    float max_dW_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
-        &max_dW_value);
+  std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
 
-    std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
+  // calculating offset
+  // TODO wangdiya: do we need to check overflows?
+  const int32_t offset_prev_out = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t offset_curr_delta =
+      int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_curr_delta,
+                                                           max_curr_delta));
+  // const int32_t zero_in_prev_delta =
+  //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value,
+  //    max_prev_delta_value);
 
-    // calculating offset
-    // TODO wangdiya: do we need to check overflows?
-    const int32_t offset_prev_out =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t offset_curr_delta =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_curr_delta, max_curr_delta));
-    // const int32_t zero_in_prev_delta =
-    //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value, max_prev_delta_value);
+  // propagate delta to previous layer
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
 
-    // propagate delta to previous layer
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * outc + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * outc + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
+      idx = params.out_unpadded.get_index(0, 0, outc);
+      const uint8_t* pdelta_src = &curr_delta_quantized[idx];
 
-            idx = params.out_unpadded.get_index(0, 0, outc);
-            const uint8_t *pdelta_src = &curr_delta_quantized[idx];
+      idx = params.in.get_index(0, 0, inc);
+      int32_t* pdelta_quantized_dst = &(prev_delta_quantized)[idx];
 
-            idx = params.in.get_index(0, 0, inc);
-            int32_t *pdelta_quantized_dst = &(prev_delta_quantized)[idx];
+      for (cnn_size_t y = 0; y < params.in.height_; y++) {
+        for (cnn_size_t x = 0; x < params.in.width_; x++) {
+          const uint8_t* ppw = pw;
+          int32_t* ppdelta_quantized_dst =
+              pdelta_quantized_dst + y * params.in.width_ + x;
+          int32_t sum = int32_t(0);
 
-            for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                    const uint8_t * ppw = pw;
-                    int32_t * ppdelta_quantized_dst = pdelta_quantized_dst + y * params.in.width_ + x;
-                    int32_t sum = int32_t(0);
-
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                            sum += static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] - offset_filter) *
-                                static_cast<int32_t>(pdelta_src[(y * params.h_stride + wy) *
-                                                                params.out.width_ + (x *
-                                                                params.w_stride + wx)] -
-                                                                offset_curr_delta);
-                        }
-                    }
-                    *ppdelta_quantized_dst += sum;
-                }
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+              sum +=
+                  static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] -
+                                       offset_filter) *
+                  static_cast<int32_t>(pdelta_src[(y * params.h_stride + wy) *
+                                                      params.out.width_ +
+                                                  (x * params.w_stride + wx)] -
+                                       offset_curr_delta);
             }
+          }
+          *ppdelta_quantized_dst += sum;
         }
-    });
-
-    float min_prev_delta_requantized;
-    float max_prev_delta_requantized;
-    std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
-    &min_prev_delta_requantized, &max_prev_delta_requantized, &prev_delta_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(prev_delta_requantized, min_prev_delta_requantized, max_prev_delta_requantized);
-    prev_delta = &prev_delta_vec;
-
-    // Accumulate dw
-    for_i(params.in.depth_, [&](int inc) {
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            if (!params.tbl.is_connected(outc, inc)) continue;
-
-            for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                    int32_t dst = int32_t(0);
-
-                    cnn_size_t idx = 0;
-                    idx = params.in.get_index(0, 0, inc);
-                    const uint8_t * prevo = &prev_out_quantized[idx];
-
-                    idx = params.out.get_index(wx, wy, outc);
-                    const uint8_t * delta = &curr_delta_quantized[idx];
-
-                    for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                        for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                            dst += (static_cast<int32_t>(*(prevo + y * params.in.width_ + x)) - offset_prev_out) *
-                                   (static_cast<int32_t>(*(delta + y * params.out.width_ + x)) - offset_curr_delta);
-                        }
-                    }
-
-                    idx = params.in.depth_ * outc + inc;
-                    dW_quantized[params.weight.get_index(wx, wy, idx)] += dst;
-                }
-            }
-        }
-    });
-
-    float min_dW_requantized;
-    float max_dW_requantized;
-    std::vector<uint8_t> dW_requantized(dW_quantized.size(), static_cast<uint8_t>(0));
-
-    // requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(dW_quantized, min_dW_value, max_dW_value,
-    &min_dW_requantized, &max_dW_requantized, &dW_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized, max_dW_requantized);
-
-    // Accumulate db
-    if (params.has_bias) {
-        //vec_t& db = *in_grad[2];
-
-        for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
-            cnn_size_t idx = params.out.get_index(0, 0, outc);
-            const float_t * delta = &curr_delta[idx];
-            const float_t * deltaa = delta + params.out.width_ *
-                                             params.out.height_;
-            db[outc] += std::accumulate(delta, deltaa, float_t(0));
-        }
+      }
     }
+  });
+
+  float min_prev_delta_requantized;
+  float max_prev_delta_requantized;
+  std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(),
+                                              static_cast<uint8_t>(0));
+
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
+      &min_prev_delta_requantized, &max_prev_delta_requantized,
+      &prev_delta_requantized);
+
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(
+      prev_delta_requantized, min_prev_delta_requantized,
+      max_prev_delta_requantized);
+  prev_delta = &prev_delta_vec;
+
+  // Accumulate dw
+  for_i(params.in.depth_, [&](int inc) {
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      if (!params.tbl.is_connected(outc, inc)) continue;
+
+      for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+          int32_t dst = int32_t(0);
+
+          cnn_size_t idx = 0;
+          idx = params.in.get_index(0, 0, inc);
+          const uint8_t* prevo = &prev_out_quantized[idx];
+
+          idx = params.out.get_index(wx, wy, outc);
+          const uint8_t* delta = &curr_delta_quantized[idx];
+
+          for (cnn_size_t y = 0; y < params.in.height_; y++) {
+            for (cnn_size_t x = 0; x < params.in.width_; x++) {
+              dst +=
+                  (static_cast<int32_t>(*(prevo + y * params.in.width_ + x)) -
+                   offset_prev_out) *
+                  (static_cast<int32_t>(*(delta + y * params.out.width_ + x)) -
+                   offset_curr_delta);
+            }
+          }
+
+          idx = params.in.depth_ * outc + inc;
+          dW_quantized[params.weight.get_index(wx, wy, idx)] += dst;
+        }
+      }
+    }
+  });
+
+  float min_dW_requantized;
+  float max_dW_requantized;
+  std::vector<uint8_t> dW_requantized(dW_quantized.size(),
+                                      static_cast<uint8_t>(0));
+
+  // requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      dW_quantized, min_dW_value, max_dW_value, &min_dW_requantized,
+      &max_dW_requantized, &dW_requantized);
+
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized,
+                                          max_dW_requantized);
+
+  // Accumulate db
+  if (params.has_bias) {
+    // vec_t& db = *in_grad[2];
+
+    for (cnn_size_t outc = 0; outc < params.out.depth_; outc++) {
+      cnn_size_t idx = params.out.get_index(0, 0, outc);
+      const float_t* delta = &curr_delta[idx];
+      const float_t* deltaa = delta + params.out.width_ * params.out.height_;
+      db[outc] += std::accumulate(delta, deltaa, float_t(0));
+    }
+  }
 }
 
 inline void tiny_quantized_deconv2d_kernel(const deconv_params& params,
-                                           const vec_t&         in,
-                                           const vec_t&         W,
-                                           const vec_t&         bias,
-                                           const vec_t&         in_r,
-                                           const vec_t&         W_r,
-                                           const vec_t&         b_r,
-                                           vec_t&               a,
-                                           vec_t&               a_r,
+                                           const vec_t& in, const vec_t& W,
+                                           const vec_t& bias, const vec_t& in_r,
+                                           const vec_t& W_r, const vec_t& b_r,
+                                           vec_t& a, vec_t& a_r,
                                            const bool layer_parallelize) {
-    // filter range
-    float min_filter(W_r[0]);
-    float max_filter(W_r[1]);
-    if (W_r[0] == W_r[1]) {
-      max_filter = W_r[1] + 1e-3f;
-      min_filter = W_r[0] - 1e-3f;
+  // filter range
+  float min_filter(W_r[0]);
+  float max_filter(W_r[1]);
+  if (W_r[0] == W_r[1]) {
+    max_filter = W_r[1] + 1e-3f;
+    min_filter = W_r[0] - 1e-3f;
+  }
+  // bias range
+  float min_bias(b_r[0]);
+  float max_bias(b_r[1]);
+  if (params.has_bias) {
+    if (min_bias == max_bias) {
+      max_bias = b_r[1] + 1e-3f;
+      min_bias = b_r[0] - 1e-3f;
     }
-    // bias range
-    float min_bias(b_r[0]);
-    float max_bias(b_r[1]);
-    if (params.has_bias) {
-        if (min_bias == max_bias) {
-          max_bias = b_r[1] + 1e-3f;
-          min_bias = b_r[0] - 1e-3f;
-        }
-    }
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
-        &max_output_value);
-    // data type restore
-    std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
-    for (size_t i = 0; i < in.size(); i++) {
-       in_quantized.push_back(static_cast<uint8_t>(in[i]));
-    }
-    for (size_t i = 0; i < W.size(); i++) {
-        W_quantized.push_back(static_cast<uint8_t>(W[i]));
-    }
-    for (size_t i = 0; i < bias.size(); i++) {
-        bias_quantized.push_back(static_cast<uint8_t>(bias[i]));
-    }
+  }
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
+      &max_output_value);
+  // data type restore
+  std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
+  for (size_t i = 0; i < in.size(); i++) {
+    in_quantized.push_back(static_cast<uint8_t>(in[i]));
+  }
+  for (size_t i = 0; i < W.size(); i++) {
+    W_quantized.push_back(static_cast<uint8_t>(W[i]));
+  }
+  for (size_t i = 0; i < bias.size(); i++) {
+    bias_quantized.push_back(static_cast<uint8_t>(bias[i]));
+  }
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
 
-    // calculating offset
-    const int32_t offset_input =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]));
-    const int32_t offset_filter =
-        int64_to_int32(float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
-    const int32_t zero_in_total_space =
-        int64_to_int32(float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
+  // calculating offset
+  const int32_t offset_input = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]));
+  const int32_t offset_filter = int64_to_int32(
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter));
+  const int32_t zero_in_total_space = int64_to_int32(
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value));
 
-    for_i(layer_parallelize, params.out.depth_, [&](int o) {
-        for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
-            if (!params.tbl.is_connected(o, inc)) continue;
+  for_i(layer_parallelize, params.out.depth_, [&](int o) {
+    for (cnn_size_t inc = 0; inc < params.in.depth_; inc++) {
+      if (!params.tbl.is_connected(o, inc)) continue;
 
-            cnn_size_t idx = 0;
-            idx = params.in.depth_ * o + inc;
-            idx = params.weight.get_index(0, 0, idx);
-            const uint8_t *pw = &W_quantized[idx];
+      cnn_size_t idx = 0;
+      idx = params.in.depth_ * o + inc;
+      idx = params.weight.get_index(0, 0, idx);
+      const uint8_t* pw = &W_quantized[idx];
 
-            idx = params.in.get_index(0, 0, inc);
-            const uint8_t *pi = &in_quantized[idx];
+      idx = params.in.get_index(0, 0, inc);
+      const uint8_t* pi = &in_quantized[idx];
 
-            idx = params.out.get_index(0, 0, o);
-            int32_t *pa_quantized = &a_quantized[idx];
+      idx = params.out.get_index(0, 0, o);
+      int32_t* pa_quantized = &a_quantized[idx];
 
-            for (cnn_size_t y = 0; y < params.in.height_; y++) {
-                for (cnn_size_t x = 0; x < params.in.width_; x++) {
-                    const uint8_t * ppw = pw;
-                    const uint8_t * ppi = pi + y * params.in.width_ + x;
-                    // should be optimized for small kernel(3x3,5x5)
-                    for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
-                        for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
-                            pa_quantized[(y * params.h_stride + wy) *
-                                    params.out.width_ + (x *
-                                    params.w_stride + wx)] += static_cast<int32_t>(ppw[wy *
-                                    params.weight.width_ + wx] - offset_filter) *
-                                    static_cast<int32_t>(*ppi - offset_input);
-                        }
-                    }
-                }
+      for (cnn_size_t y = 0; y < params.in.height_; y++) {
+        for (cnn_size_t x = 0; x < params.in.width_; x++) {
+          const uint8_t* ppw = pw;
+          const uint8_t* ppi = pi + y * params.in.width_ + x;
+          // should be optimized for small kernel(3x3,5x5)
+          for (cnn_size_t wy = 0; wy < params.weight.height_; wy++) {
+            for (cnn_size_t wx = 0; wx < params.weight.width_; wx++) {
+              pa_quantized[(y * params.h_stride + wy) * params.out.width_ +
+                           (x * params.w_stride + wx)] +=
+                  static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] -
+                                       offset_filter) *
+                  static_cast<int32_t>(*ppi - offset_input);
             }
+          }
         }
-        if (params.has_bias) {
-            int32_t * pa_quantized  = &a_quantized[params.out.get_index(0, 0, o)];
-            int32_t * paa_quantized = pa_quantized + params.out.width_ * params.out.height_;
-            std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
-                f += static_cast<int32_t>((bias[o] - zero_in_total_space));
-            });
-        }
-    });
-
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-        &min_output_requantized, &max_output_requantized, &a_requantized);
-    // store directly in float datatype
-    for (size_t i = 0; i < a_requantized.size(); i++) {
-        a[i] = static_cast<float>(a_requantized[i]);
+      }
     }
-    a_r[0] = min_output_requantized;
-    a_r[1] = max_output_requantized;
+    if (params.has_bias) {
+      int32_t* pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
+      int32_t* paa_quantized =
+          pa_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pa_quantized, paa_quantized, [&](int32_t& f) {
+        f += static_cast<int32_t>((bias[o] - zero_in_total_space));
+      });
+    }
+  });
+
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
+
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
+  // store directly in float datatype
+  for (size_t i = 0; i < a_requantized.size(); i++) {
+    a[i] = static_cast<float>(a_requantized[i]);
+  }
+  a_r[0] = min_output_requantized;
+  a_r[1] = max_output_requantized;
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/deconv_params.h"

--- a/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/core/params/fully_params.h"

--- a/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_fully_connected_kernel.h
@@ -4,344 +4,345 @@
 
 #pragma once
 
-#include "tiny_dnn/core/params/fully_params.h"
 #include "tiny_dnn/core/kernels/tiny_quantization_kernel.h"
 #include "tiny_dnn/core/kernels/tiny_quantized_matmul_kernel.h"
+#include "tiny_dnn/core/params/fully_params.h"
 
 namespace tiny_dnn {
 namespace core {
 namespace kernels {
 
-inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
-                                                  const vec_t&        in,
-                                                  const vec_t&        W,
-                                                  const vec_t&        b,
-                                                  vec_t&              a,
-                                                  const bool          layer_parallelize) {
-    // input quantization
-    float min_input(in[0]);
-    float max_input(in[0]);
-    for (cnn_size_t c = 0; c < params.in_size_; c++) {
-        min_input = std::min(min_input, in[c]);
-        max_input = std::max(max_input, in[c]);
+inline void tiny_quantized_fully_connected_kernel(
+    const fully_params& params, const vec_t& in, const vec_t& W, const vec_t& b,
+    vec_t& a, const bool layer_parallelize) {
+  // input quantization
+  float min_input(in[0]);
+  float max_input(in[0]);
+  for (cnn_size_t c = 0; c < params.in_size_; c++) {
+    min_input = std::min(min_input, in[c]);
+    max_input = std::max(max_input, in[c]);
+  }
+  std::vector<uint8_t> in_quantized =
+      float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t c = 0; c < W.size(); c++) {
+    min_filter = std::min(min_filter, W[c]);
+    max_filter = std::max(max_filter, W[c]);
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_input, max_input, min_filter, max_filter, &min_output_value,
+      &max_output_value);
+  // bias quantization
+  float min_bias(0);
+  float max_bias(0);
+  std::vector<uint8_t> bias_quantized;
+  if (params.has_bias_) {
+    for (cnn_size_t inc = 0; inc < b.size(); inc++) {
+      min_bias = std::min(min_bias, b[inc]);
+      max_bias = std::max(max_bias, b[inc]);
     }
-    std::vector<uint8_t> in_quantized =
-        float_tensor_to_quantized<uint8_t>(in, min_input, max_input);
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t c = 0; c < W.size(); c++) {
-        min_filter = std::min(min_filter, W[c]);
-        max_filter = std::max(max_filter, W[c]);
+    if (min_bias == max_bias) {
+      max_bias = b[0] + 1e-3f;
+      min_bias = b[0] - 1e-3f;
     }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
-    }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_input, max_input, min_filter, max_filter, &min_output_value,
-        &max_output_value);
-    // bias quantization
-    float min_bias(0);
-    float max_bias(0);
-    std::vector<uint8_t> bias_quantized;
+    bias_quantized = float_tensor_to_quantized<uint8_t>(b, min_bias, max_bias);
+  }
+  min_output_value += min_bias;
+  max_output_value += max_bias;
+
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+
+  // calculating offset
+  const int32_t offset_input =
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input);
+  const int32_t offset_filter =
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
+  const int32_t zero_in_total_space =
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value);
+
+  const int32_t offset_output = 0;
+  const int32_t mult_output = 1;
+  const int32_t shift_output = 0;
+
+  bool use_gemm = false;
+  if (use_gemm) {
+    std::vector<size_t> shape{params.in_size_, 1, params.out_size_,
+                              params.in_size_};
+    tiny_quantized_matmul(in_quantized, W_quantized, a_quantized, shape,
+                          offset_input, offset_filter, offset_output,
+                          mult_output, shift_output);
     if (params.has_bias_) {
-        for (cnn_size_t inc = 0; inc < b.size(); inc++) {
-            min_bias = std::min(min_bias, b[inc]);
-            max_bias = std::max(max_bias, b[inc]);
-        }
-        if (min_bias == max_bias) {
-          max_bias = b[0] + 1e-3f;
-          min_bias = b[0] - 1e-3f;
-        }
-        bias_quantized =
-            float_tensor_to_quantized<uint8_t>(b, min_bias, max_bias);
+      for_i(layer_parallelize, params.out_size_, [&](int i) { a[i] += b[i]; });
     }
-    min_output_value += min_bias;
-    max_output_value += max_bias;
+  } else {
+    for_i(layer_parallelize, params.out_size_, [&](int i) {
+      for (cnn_size_t c = 0; c < params.in_size_; c++) {
+        a_quantized[i] +=
+            static_cast<int32_t>(W_quantized[c * params.out_size_ + i] -
+                                 offset_filter) *
+            static_cast<int32_t>(in_quantized[c] - offset_input);
+      }
+      if (params.has_bias_) {
+        a_quantized[i] += (bias_quantized[i] - zero_in_total_space);
+      }
+    });
+  }
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
 
-    // calculating offset
-    const int32_t offset_input =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_input, max_input);
-    const int32_t offset_filter =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
-    const int32_t zero_in_total_space =
-        float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value);
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
 
-    const int32_t offset_output = 0;
-    const int32_t mult_output = 1;
-    const int32_t shift_output = 0;
-
-    bool use_gemm = false;
-    if (use_gemm) {
-        std::vector<size_t> shape{params.in_size_, 1, params.out_size_, params.in_size_};
-        tiny_quantized_matmul(in_quantized,
-                              W_quantized,
-                              a_quantized,
-                              shape,
-                              offset_input,
-                              offset_filter,
-                              offset_output,
-                              mult_output,
-                              shift_output);
-        if (params.has_bias_) {
-            for_i(layer_parallelize, params.out_size_, [&](int i) {
-            a[i] += b[i];
-        });
-    }
-    } else {
-        for_i(layer_parallelize, params.out_size_, [&](int i) {
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                a_quantized[i] += static_cast<int32_t>(W_quantized[c * params.out_size_ + i] - offset_filter) *
-                 static_cast<int32_t>(in_quantized[c] - offset_input);
-            }
-            if (params.has_bias_) {
-                a_quantized[i] += (bias_quantized[i] - zero_in_total_space);
-            }
-        });
-    }
-
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-    &min_output_requantized, &max_output_requantized, &a_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized, max_output_requantized);
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized,
+                                         max_output_requantized);
 }
 
-inline void tiny_quantized_fully_connected_back_kernel(const fully_params& params,
-                                                       const vec_t& prev_out,
-                                                       const vec_t& W,
-                                                       vec_t&       dW,
-                                                       vec_t&       prev_delta,
-                                                       vec_t&       curr_delta,
-                                                       vec_t&       db,
-                                                       const bool   layer_parallelize) {
-    // previous output quantization
-    float min_prev_out(prev_out[0]);
-    float max_prev_out(prev_out[0]);
-    for (cnn_size_t inc = 0; inc < prev_out.size(); inc++) {
-        min_prev_out = std::min(min_prev_out, prev_out[inc]);
-        max_prev_out = std::max(min_prev_out, prev_out[inc]);
+inline void tiny_quantized_fully_connected_back_kernel(
+    const fully_params& params, const vec_t& prev_out, const vec_t& W,
+    vec_t& dW, vec_t& prev_delta, vec_t& curr_delta, vec_t& db,
+    const bool layer_parallelize) {
+  // previous output quantization
+  float min_prev_out(prev_out[0]);
+  float max_prev_out(prev_out[0]);
+  for (cnn_size_t inc = 0; inc < prev_out.size(); inc++) {
+    min_prev_out = std::min(min_prev_out, prev_out[inc]);
+    max_prev_out = std::max(min_prev_out, prev_out[inc]);
+  }
+  std::vector<uint8_t> prev_out_quantized =
+      float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
+
+  // filter quantization
+  float min_filter(W[0]);
+  float max_filter(W[0]);
+  for (cnn_size_t c = 0; c < W.size(); c++) {
+    min_filter = std::min(min_filter, W[c]);
+    max_filter = std::max(max_filter, W[c]);
+  }
+  if (min_filter == max_filter) {
+    max_filter = W[0] + 1e-3f;
+    min_filter = W[0] - 1e-3f;
+  }
+  std::vector<uint8_t> W_quantized =
+      float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+
+  // current delta quantization
+  float min_curr_delta(curr_delta[0]);
+  float max_curr_delta(curr_delta[0]);
+  for (cnn_size_t inc = 0; inc < curr_delta.size(); inc++) {
+    min_curr_delta = std::min(min_curr_delta, curr_delta[inc]);
+    max_curr_delta = std::max(max_curr_delta, curr_delta[inc]);
+  }
+  std::vector<uint8_t> curr_delta_quantized =
+      float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta,
+                                         max_curr_delta);
+
+  // output range for previous delta
+  float min_prev_delta_value;
+  float max_prev_delta_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_filter, max_filter,
+      &min_prev_delta_value, &max_prev_delta_value);
+
+  std::vector<int32_t> prev_delta_quantized(prev_delta.size(),
+                                            static_cast<int32_t>(0));
+
+  // output range for dW
+  float min_dW_value;
+  float max_dW_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
+      &max_dW_value);
+
+  std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
+
+  // calculating offset
+  const int32_t offset_prev_out =
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out);
+  const int32_t offset_filter =
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
+  const int32_t offset_curr_delta = float_to_quantized_unclamped<uint8_t>(
+      0.0f, min_curr_delta, max_curr_delta);
+  // const int32_t zero_in_prev_delta =
+  //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value,
+  //    max_prev_delta_value);
+
+  for (cnn_size_t c = 0; c < params.in_size_; c++) {
+    // propagate delta to previous layer
+    // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
+    for (cnn_size_t io = 0; io < params.out_size_; io++) {
+      prev_delta_quantized[c] +=
+          (static_cast<int32_t>(curr_delta_quantized[io]) - offset_curr_delta) *
+          (static_cast<int32_t>(W_quantized[c * params.out_size_ + io]) -
+           offset_filter);
     }
-    std::vector<uint8_t> prev_out_quantized =
-        float_tensor_to_quantized<uint8_t>(prev_out, min_prev_out, max_prev_out);
+  }
 
-    // filter quantization
-    float min_filter(W[0]);
-    float max_filter(W[0]);
-    for (cnn_size_t c = 0; c < W.size(); c++) {
-        min_filter = std::min(min_filter, W[c]);
-        max_filter = std::max(max_filter, W[c]);
-    }
-    if (min_filter == max_filter) {
-      max_filter = W[0] + 1e-3f;
-      min_filter = W[0] - 1e-3f;
-    }
-    std::vector<uint8_t> W_quantized =
-        float_tensor_to_quantized<uint8_t>(W, min_filter, max_filter);
+  float min_prev_delta_requantized;
+  float max_prev_delta_requantized;
+  std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(),
+                                              static_cast<uint8_t>(0));
 
-    // current delta quantization
-    float min_curr_delta(curr_delta[0]);
-    float max_curr_delta(curr_delta[0]);
-    for (cnn_size_t inc = 0; inc < curr_delta.size(); inc++) {
-            min_curr_delta = std::min(min_curr_delta, curr_delta[inc]);
-            max_curr_delta = std::max(max_curr_delta, curr_delta[inc]);
-    }
-    std::vector<uint8_t> curr_delta_quantized =
-        float_tensor_to_quantized<uint8_t>(curr_delta, min_curr_delta, max_curr_delta);
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
+      &min_prev_delta_requantized, &max_prev_delta_requantized,
+      &prev_delta_requantized);
 
-    // output range for previous delta
-    float min_prev_delta_value;
-    float max_prev_delta_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_filter, max_filter, &min_prev_delta_value,
-        &max_prev_delta_value);
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  prev_delta = quantized_tensor_to_float<uint8_t>(prev_delta_requantized,
+                                                  min_prev_delta_requantized,
+                                                  max_prev_delta_requantized);
 
-    std::vector<int32_t> prev_delta_quantized(prev_delta.size(), static_cast<int32_t>(0));
-
-    // output range for dW
-    float min_dW_value;
-    float max_dW_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        min_curr_delta, max_curr_delta, min_prev_out, max_prev_out, &min_dW_value,
-        &max_dW_value);
-
-    std::vector<int32_t> dW_quantized(dW.size(), static_cast<int32_t>(0));
-
-    // calculating offset
-    const int32_t offset_prev_out =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_prev_out, max_prev_out);
-    const int32_t offset_filter =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
-    const int32_t offset_curr_delta =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_curr_delta, max_curr_delta);
-    //const int32_t zero_in_prev_delta =
-    //    float_to_quantized<int32_t>(0.0f, min_prev_delta_value, max_prev_delta_value);
-
-    for (cnn_size_t c = 0; c < params.in_size_; c++) {
-        // propagate delta to previous layer
-        // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
-        for (cnn_size_t io = 0; io < params.out_size_; io++) {
-            prev_delta_quantized[c] += (static_cast<int32_t>(curr_delta_quantized[io]) - offset_curr_delta)
-                                       * (static_cast<int32_t>(W_quantized[c * params.out_size_ + io]) - offset_filter);
-        }
-    }
-
-    float min_prev_delta_requantized;
-    float max_prev_delta_requantized;
-    std::vector<uint8_t> prev_delta_requantized(prev_delta_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(prev_delta_quantized, min_prev_delta_value, max_prev_delta_value,
-    &min_prev_delta_requantized, &max_prev_delta_requantized, &prev_delta_requantized);
-
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    prev_delta = quantized_tensor_to_float<uint8_t>(prev_delta_requantized, min_prev_delta_requantized, max_prev_delta_requantized);
-
-    for_(layer_parallelize, 0, size_t(params.out_size_), [&](const blocked_range& r) {
+  for_(
+      layer_parallelize, 0, size_t(params.out_size_),
+      [&](const blocked_range& r) {
         // accumulate weight-step using delta
         // dW[c * out_size + i] += current_delta[i] * prev_out[c]
         for (cnn_size_t c = 0; c < params.in_size_; c++) {
-            for (cnn_size_t io = 0; io < params.out_size_; io++) {
-                dW_quantized[c * params.out_size_ + io] += (static_cast<int32_t>(curr_delta_quantized[io]) - offset_curr_delta)
-                                                   * (static_cast<int32_t>(prev_out_quantized[c]) - offset_prev_out);
-            }
+          for (cnn_size_t io = 0; io < params.out_size_; io++) {
+            dW_quantized[c * params.out_size_ + io] +=
+                (static_cast<int32_t>(curr_delta_quantized[io]) -
+                 offset_curr_delta) *
+                (static_cast<int32_t>(prev_out_quantized[c]) - offset_prev_out);
+          }
         }
 
         if (params.has_bias_) {
-            // vec_t& db = *in_grad[2];
-            for (int i = r.begin(); i < r.end(); i++) {
-                db[i] += curr_delta[i];
-            }
+          // vec_t& db = *in_grad[2];
+          for (int i = r.begin(); i < r.end(); i++) {
+            db[i] += curr_delta[i];
+          }
         }
-    });
+      });
 
-    float min_dW_requantized;
-    float max_dW_requantized;
-    std::vector<uint8_t> dW_requantized(dW_quantized.size(), static_cast<uint8_t>(0));
+  float min_dW_requantized;
+  float max_dW_requantized;
+  std::vector<uint8_t> dW_requantized(dW_quantized.size(),
+                                      static_cast<uint8_t>(0));
 
-    // requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(dW_quantized, min_dW_value, max_dW_value,
-    &min_dW_requantized, &max_dW_requantized, &dW_requantized);
+  // requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      dW_quantized, min_dW_value, max_dW_value, &min_dW_requantized,
+      &max_dW_requantized, &dW_requantized);
 
-    // dequantize to flaot, this could be removed within concatenated quantized network
-    dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized, max_dW_requantized);
+  // dequantize to flaot, this could be removed within concatenated quantized
+  // network
+  dW = quantized_tensor_to_float<uint8_t>(dW_requantized, min_dW_requantized,
+                                          max_dW_requantized);
 }
 
-inline void tiny_quantized_fully_connected_kernel(const fully_params& params,
-                                                  const vec_t&        in,
-                                                  const vec_t&        W,
-                                                  const vec_t&        b,
-                                                  const vec_t&        in_r,
-                                                  const vec_t&        W_r,
-                                                  const vec_t&        b_r,
-                                                  vec_t&              a,
-                                                  vec_t&              a_r,
-                                                  const bool          layer_parallelize) {
-    // filter range
-    float min_filter(W_r[0]);
-    float max_filter(W_r[1]);
-    if (min_filter == max_filter) {
-      max_filter = W_r[1] + 1e-3f;
-      min_filter = W_r[0] - 1e-3f;
+inline void tiny_quantized_fully_connected_kernel(
+    const fully_params& params, const vec_t& in, const vec_t& W, const vec_t& b,
+    const vec_t& in_r, const vec_t& W_r, const vec_t& b_r, vec_t& a, vec_t& a_r,
+    const bool layer_parallelize) {
+  // filter range
+  float min_filter(W_r[0]);
+  float max_filter(W_r[1]);
+  if (min_filter == max_filter) {
+    max_filter = W_r[1] + 1e-3f;
+    min_filter = W_r[0] - 1e-3f;
+  }
+  // bias range
+  float min_bias(b_r[0]);
+  float max_bias(b_r[1]);
+  if (params.has_bias_) {
+    if (min_bias == max_bias) {
+      max_bias = b_r[1] + 1e-3f;
+      min_bias = b_r[0] - 1e-3f;
     }
-    // bias range
-    float min_bias(b_r[0]);
-    float max_bias(b_r[1]);
+  }
+  // output range
+  float min_output_value;
+  float max_output_value;
+  quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
+      in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
+      &max_output_value);
+  // data type restore
+  std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
+  for (size_t i = 0; i < in.size(); i++) {
+    in_quantized.push_back(static_cast<uint8_t>(in[i]));
+  }
+  for (size_t i = 0; i < W.size(); i++) {
+    W_quantized.push_back(static_cast<uint8_t>(W[i]));
+  }
+  for (size_t i = 0; i < b.size(); i++) {
+    bias_quantized.push_back(static_cast<uint8_t>(b[i]));
+  }
+  min_output_value += min_bias;
+  max_output_value += max_bias;
+
+  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+
+  // calculating offset
+  const int32_t offset_input =
+      float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]);
+  const int32_t offset_filter =
+      float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
+  const int32_t zero_in_total_space =
+      float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value);
+
+  const int32_t offset_output = 0;
+  const int32_t mult_output = 1;
+  const int32_t shift_output = 0;
+
+  bool use_gemm = false;
+  if (use_gemm) {
+    std::vector<size_t> shape{params.in_size_, 1, params.out_size_,
+                              params.in_size_};
+    tiny_quantized_matmul(in_quantized, W_quantized, a_quantized, shape,
+                          offset_input, offset_filter, offset_output,
+                          mult_output, shift_output);
     if (params.has_bias_) {
-        if (min_bias == max_bias) {
-          max_bias = b_r[1] + 1e-3f;
-          min_bias = b_r[0] - 1e-3f;
-        }
+      for_i(layer_parallelize, params.out_size_, [&](int i) { a[i] += b[i]; });
     }
-    // output range
-    float min_output_value;
-    float max_output_value;
-    quantization_range_for_multiplication<uint8_t, uint8_t, int32_t>(
-        in_r[0], in_r[1], min_filter, max_filter, &min_output_value,
-        &max_output_value);
-    // data type restore
-    std::vector<uint8_t> in_quantized, W_quantized, bias_quantized;
-    for (size_t i = 0; i < in.size(); i++) {
-       in_quantized.push_back(static_cast<uint8_t>(in[i]));
-    }
-    for (size_t i = 0; i < W.size(); i++) {
-        W_quantized.push_back(static_cast<uint8_t>(W[i]));
-    }
-    for (size_t i = 0; i < b.size(); i++) {
-        bias_quantized.push_back(static_cast<uint8_t>(b[i]));
-    }
-    min_output_value += min_bias;
-    max_output_value += max_bias;
+  } else {
+    for_i(layer_parallelize, params.out_size_, [&](int i) {
+      for (cnn_size_t c = 0; c < params.in_size_; c++) {
+        a_quantized[i] +=
+            static_cast<int32_t>(W_quantized[c * params.out_size_ + i] -
+                                 offset_filter) *
+            static_cast<int32_t>(in_quantized[c] - offset_input);
+      }
+      if (params.has_bias_) {
+        a_quantized[i] += (bias_quantized[i] - zero_in_total_space);
+      }
+    });
+  }
 
-    std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  float min_output_requantized;
+  float max_output_requantized;
+  std::vector<uint8_t> a_requantized(a_quantized.size(),
+                                     static_cast<uint8_t>(0));
 
-    // calculating offset
-    const int32_t offset_input =
-        float_to_quantized_unclamped<uint8_t>(0.0f, in_r[0], in_r[1]);
-    const int32_t offset_filter =
-        float_to_quantized_unclamped<uint8_t>(0.0f, min_filter, max_filter);
-    const int32_t zero_in_total_space =
-        float_to_quantized<int32_t>(0.0f, min_output_value, max_output_value);
-
-    const int32_t offset_output = 0;
-    const int32_t mult_output = 1;
-    const int32_t shift_output = 0;
-
-    bool use_gemm = false;
-    if (use_gemm) {
-        std::vector<size_t> shape{params.in_size_, 1, params.out_size_, params.in_size_};
-        tiny_quantized_matmul(in_quantized,
-                              W_quantized,
-                              a_quantized,
-                              shape,
-                              offset_input,
-                              offset_filter,
-                              offset_output,
-                              mult_output,
-                              shift_output);
-        if (params.has_bias_) {
-            for_i(layer_parallelize, params.out_size_, [&](int i) {
-            a[i] += b[i];
-        });
-    }
-    } else {
-        for_i(layer_parallelize, params.out_size_, [&](int i) {
-            for (cnn_size_t c = 0; c < params.in_size_; c++) {
-                a_quantized[i] += static_cast<int32_t>(W_quantized[c * params.out_size_ + i] - offset_filter) *
-                 static_cast<int32_t>(in_quantized[c] - offset_input);
-            }
-            if (params.has_bias_) {
-                a_quantized[i] += (bias_quantized[i] - zero_in_total_space);
-            }
-        });
-    }
-
-    float min_output_requantized;
-    float max_output_requantized;
-    std::vector<uint8_t> a_requantized(a_quantized.size(), static_cast<uint8_t>(0));
-
-    // Requantize from 32bits to 8 bits for next layer
-    quantize_down_and_shrink_range<int32_t, uint8_t>(a_quantized, min_output_value, max_output_value,
-        &min_output_requantized, &max_output_requantized, &a_requantized);
-    // store directly in float datatype
-    for (size_t i = 0; i < a_requantized.size(); i++) {
-        a[i] = static_cast<float>(a_requantized[i]);
-    }
-    a_r[0] = min_output_requantized;
-    a_r[1] = max_output_requantized;
+  // Requantize from 32bits to 8 bits for next layer
+  quantize_down_and_shrink_range<int32_t, uint8_t>(
+      a_quantized, min_output_value, max_output_value, &min_output_requantized,
+      &max_output_requantized, &a_requantized);
+  // store directly in float datatype
+  for (size_t i = 0; i < a_requantized.size(); i++) {
+    a[i] = static_cast<float>(a_requantized[i]);
+  }
+  a_r[0] = min_output_requantized;
+  a_r[1] = max_output_requantized;
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_quantized_matmul_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_matmul_kernel.h
@@ -23,17 +23,9 @@ namespace core {
 namespace kernels {
 
 template <bool TransposeA, bool TransposeB, bool TransposeC>
-void gemmlowp_multiply(const uint8_t*        a_data,
-                      const uint8_t*        b_data,
-                      int32_t*       c_data,
-                      int m,
-                      int n,
-                      int k,
-                      int offset_a,
-                      int offset_b,
-                      int lda,
-                      int ldb,
-                      int ldc) {
+void gemmlowp_multiply(const uint8_t* a_data, const uint8_t* b_data,
+                       int32_t* c_data, int m, int n, int k, int offset_a,
+                       int offset_b, int lda, int ldb, int ldc) {
   const uint8_t* a_data_as_uint8 = a_data;
   const uint8_t* b_data_as_uint8 = b_data;
   int32_t* c_data_as_int32 = c_data;
@@ -57,76 +49,67 @@ void gemmlowp_multiply(const uint8_t*        a_data,
 }
 
 template <class T1, class T2, class Toutput>
-void tiny_quantized_matmul(const std::vector<T1>&  a,
-                          const std::vector<T2>&  b,
-                          std::vector<Toutput>&   c,
-                          const std::vector<size_t> shape_all,
-                          const int32_t offset_a,
-                          const int32_t offset_b,
-                          const int32_t offset_c,
-                          const int32_t mult_c,
-                          const int32_t shift_c) {
+void tiny_quantized_matmul(const std::vector<T1>& a, const std::vector<T2>& b,
+                           std::vector<Toutput>& c,
+                           const std::vector<size_t> shape_all,
+                           const int32_t offset_a, const int32_t offset_b,
+                           const int32_t offset_c, const int32_t mult_c,
+                           const int32_t shift_c) {
+  // Make sure that we have valid quantization ranges for the input buffers.
+  // If the difference between the min and max is negative or zero, it makes
+  // it hard to do meaningful intermediate operations on the values.
 
-    // Make sure that we have valid quantization ranges for the input buffers.
-    // If the difference between the min and max is negative or zero, it makes
-    // it hard to do meaningful intermediate operations on the values.
+  int transpose_a_ = 0;
+  int transpose_b_ = 1;
+  int a_dim_remaining = 1 - transpose_a_;
+  int b_dim_remaining = 1 - transpose_b_;
 
-    int transpose_a_ = 0;
-    int transpose_b_ = 1;
-    int a_dim_remaining = 1 - transpose_a_;
-    int b_dim_remaining = 1 - transpose_b_;
+  const T1* a_data = &a[0];
+  const T2* b_data = &b[0];
+  Toutput* c_data = &c[0];
 
-    const T1* a_data = &a[0];
-    const T2* b_data = &b[0];
-    Toutput* c_data = &c[0];
+  const bool transpose_c = false;
+  const size_t m = shape_all[a_dim_remaining];
+  const size_t n = shape_all[2 + b_dim_remaining];
+  const size_t k = shape_all[transpose_a_];
+  const size_t lda = shape_all[1];
+  const size_t ldb = shape_all[3];
+  const size_t ldc = n;
 
-    const bool transpose_c = false;
-    const size_t m = shape_all[a_dim_remaining];
-    const size_t n = shape_all[2 + b_dim_remaining];
-    const size_t k = shape_all[transpose_a_];
-    const size_t lda = shape_all[1];
-    const size_t ldb = shape_all[3];
-    const size_t ldc = n;
-
-    // The gemmlowp optimized library only works for a particular set of data
-    // types, so check if we meet those requirements and
-    // fall back to a slower reference implementation if not.
-    if (std::is_same<T1, uint8_t>() && std::is_same<T2, uint8_t>() &&
-        std::is_same<Toutput, int32_t>() && (offset_c == 0) && (mult_c == 1) &&
-        (shift_c == 0) && (transpose_c == false)) {
-      if (transpose_a_) {
-        if (transpose_b_) {
-          gemmlowp_multiply<true, true, false>(a_data, b_data, c_data, m, n, k,
-                                              offset_a, offset_b, lda, ldb,
-                                              ldc);
-        } else {
-          gemmlowp_multiply<true, false, false>(a_data, b_data, c_data, m, n, k,
-                                               offset_a, offset_b, lda, ldb,
-                                               ldc);
-        }
+  // The gemmlowp optimized library only works for a particular set of data
+  // types, so check if we meet those requirements and
+  // fall back to a slower reference implementation if not.
+  if (std::is_same<T1, uint8_t>() && std::is_same<T2, uint8_t>() &&
+      std::is_same<Toutput, int32_t>() && (offset_c == 0) && (mult_c == 1) &&
+      (shift_c == 0) && (transpose_c == false)) {
+    if (transpose_a_) {
+      if (transpose_b_) {
+        gemmlowp_multiply<true, true, false>(a_data, b_data, c_data, m, n, k,
+                                             offset_a, offset_b, lda, ldb, ldc);
       } else {
-        if (transpose_b_) {
-          gemmlowp_multiply<false, true, false>(a_data, b_data, c_data, m, n, k,
-                                               offset_a, offset_b, lda, ldb,
-                                               ldc);
-        } else {
-          gemmlowp_multiply<false, false, false>(a_data, b_data, c_data, m, n, k,
-                                                offset_a, offset_b, lda, ldb,
-                                                ldc);
-        }
+        gemmlowp_multiply<true, false, false>(
+            a_data, b_data, c_data, m, n, k, offset_a, offset_b, lda, ldb, ldc);
       }
-    } /*else {
-      ReferenceGemm<T1, T2, Toutput>(
-          transpose_a_, transpose_b_, transpose_c, m, n, k, a_data, offset_a,
-          lda, b_data, offset_b, ldb, c_data, shift_c, offset_c, mult_c, ldc);
+    } else {
+      if (transpose_b_) {
+        gemmlowp_multiply<false, true, false>(
+            a_data, b_data, c_data, m, n, k, offset_a, offset_b, lda, ldb, ldc);
+      } else {
+        gemmlowp_multiply<false, false, false>(
+            a_data, b_data, c_data, m, n, k, offset_a, offset_b, lda, ldb, ldc);
+      }
     }
-
-    float min_c_value;
-    float max_c_value;
-    quantization_range_for_multiplication<T1, T2, Toutput>(
-        min_a, max_a, min_b, max_b, &min_c_value, &max_c_value);*/
+  } /*else {
+    ReferenceGemm<T1, T2, Toutput>(
+        transpose_a_, transpose_b_, transpose_c, m, n, k, a_data, offset_a,
+        lda, b_data, offset_b, ldb, c_data, shift_c, offset_c, mult_c, ldc);
   }
 
+  float min_c_value;
+  float max_c_value;
+  quantization_range_for_multiplication<T1, T2, Toutput>(
+      min_a, max_a, min_b, max_b, &min_c_value, &max_c_value);*/
+}
 }
 }
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/params/conv_params.h
+++ b/tiny_dnn/core/params/conv_params.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "params.h"

--- a/tiny_dnn/core/params/conv_params.h
+++ b/tiny_dnn/core/params/conv_params.h
@@ -10,91 +10,88 @@ namespace tiny_dnn {
 namespace core {
 
 enum class padding {
-    valid,  ///< use valid pixels of input
-    same    ///< add zero-padding around input so as to keep image size
+  valid,  ///< use valid pixels of input
+  same    ///< add zero-padding around input so as to keep image size
 };
 
 struct conv_layer_worker_specific_storage {
-    std::vector<const vec_t*> prev_out_padded_;
-    std::vector<vec_t> prev_out_buf_;
-    std::vector<vec_t> prev_delta_padded_;
+  std::vector<const vec_t*> prev_out_padded_;
+  std::vector<vec_t> prev_out_buf_;
+  std::vector<vec_t> prev_delta_padded_;
 };
 
 struct connection_table {
-    connection_table() : rows_(0), cols_(0) {}
-    connection_table(const bool *ar, cnn_size_t rows, cnn_size_t cols)
-            : connected_(rows * cols), rows_(rows), cols_(cols) {
-        std::copy(ar, ar + rows * cols, connected_.begin());
+  connection_table() : rows_(0), cols_(0) {}
+  connection_table(const bool* ar, cnn_size_t rows, cnn_size_t cols)
+      : connected_(rows * cols), rows_(rows), cols_(cols) {
+    std::copy(ar, ar + rows * cols, connected_.begin());
+  }
+  connection_table(cnn_size_t ngroups, cnn_size_t rows, cnn_size_t cols)
+      : connected_(rows * cols, false), rows_(rows), cols_(cols) {
+    if (rows % ngroups || cols % ngroups) {
+      throw nn_error("invalid group size");
     }
-    connection_table(cnn_size_t ngroups, cnn_size_t rows, cnn_size_t cols)
-            : connected_(rows * cols, false), rows_(rows), cols_(cols) {
-        if (rows % ngroups || cols % ngroups) {
-            throw nn_error("invalid group size");
+
+    cnn_size_t row_group = rows / ngroups;
+    cnn_size_t col_group = cols / ngroups;
+
+    cnn_size_t idx = 0;
+
+    for (cnn_size_t g = 0; g < ngroups; g++) {
+      for (cnn_size_t r = 0; r < row_group; r++) {
+        for (cnn_size_t c = 0; c < col_group; c++) {
+          idx = (r + g * row_group) * cols_ + c + g * col_group;
+          connected_[idx] = true;
         }
-
-        cnn_size_t row_group = rows / ngroups;
-        cnn_size_t col_group = cols / ngroups;
-
-        cnn_size_t idx = 0;
-
-        for (cnn_size_t g = 0; g < ngroups; g++) {
-            for (cnn_size_t r = 0; r < row_group; r++) {
-                for (cnn_size_t c = 0; c < col_group; c++) {
-                    idx = (r + g * row_group) * cols_ + c + g * col_group;
-                    connected_[idx] = true;
-                }
-            }
-        }
+      }
     }
+  }
 
-    bool is_connected(cnn_size_t x, cnn_size_t y) const {
-        return is_empty() ? true : connected_[y * cols_ + x];
+  bool is_connected(cnn_size_t x, cnn_size_t y) const {
+    return is_empty() ? true : connected_[y * cols_ + x];
+  }
+
+  bool is_empty() const { return rows_ == 0 && cols_ == 0; }
+
+  template <typename Archive>
+  void serialize(Archive& ar) {
+    ar(cereal::make_nvp("rows", rows_), cereal::make_nvp("cols", cols_));
+
+    if (is_empty()) {
+      ar(cereal::make_nvp("connection", std::string("all")));
+    } else {
+      ar(cereal::make_nvp("connection", connected_));
     }
+  }
 
-    bool is_empty() const {
-        return rows_ == 0 && cols_ == 0;
-    }
-
-    template <typename Archive>
-    void serialize(Archive & ar) {
-        ar(cereal::make_nvp("rows", rows_), cereal::make_nvp("cols", cols_));
-
-        if (is_empty()) {
-            ar(cereal::make_nvp("connection", std::string("all")));
-        }
-        else {
-            ar(cereal::make_nvp("connection", connected_));
-        }
-    }
-
-    std::deque<bool> connected_;
-    cnn_size_t rows_;
-    cnn_size_t cols_;
+  std::deque<bool> connected_;
+  cnn_size_t rows_;
+  cnn_size_t cols_;
 };
 
 class conv_params : public Params {
  public:
-    connection_table tbl;
-    index3d<cnn_size_t> in;
-    index3d<cnn_size_t> in_padded;
-    index3d<cnn_size_t> out;
-    index3d<cnn_size_t> weight;
-    bool has_bias;
-    padding pad_type;
-    size_t w_stride;
-    size_t h_stride;
+  connection_table tbl;
+  index3d<cnn_size_t> in;
+  index3d<cnn_size_t> in_padded;
+  index3d<cnn_size_t> out;
+  index3d<cnn_size_t> weight;
+  bool has_bias;
+  padding pad_type;
+  size_t w_stride;
+  size_t h_stride;
 
-    friend std::ostream& operator<<(std::ostream &o,
-                                    const core::conv_params& param) {
-        o << "in:        " << param.in        << "\n";
-        o << "out:       " << param.out       << "\n";
-        o << "in_padded: " << param.in_padded << "\n";
-        o << "weight:    " << param.weight    << "\n";
-        o << "has_bias:  " << param.has_bias  << "\n";
-        o << "w_stride:  " << param.w_stride  << "\n";
-        o << "h_stride:  " << param.h_stride  << "\n";
-        return o;
-    }
+  friend std::ostream& operator<<(std::ostream& o,
+                                  const core::conv_params& param) {
+    o << "in:        " << param.in << "\n";
+    o << "out:       " << param.out << "\n";
+    o << "in_padded: " << param.in_padded << "\n";
+    o << "weight:    " << param.weight << "\n";
+    o << "has_bias:  " << param.has_bias << "\n";
+    o << "w_stride:  " << param.w_stride << "\n";
+    o << "h_stride:  " << param.h_stride << "\n";
+    return o;
+  }
 };
 
 }  // namespace core

--- a/tiny_dnn/core/params/deconv_params.h
+++ b/tiny_dnn/core/params/deconv_params.h
@@ -8,22 +8,22 @@ namespace tiny_dnn {
 namespace core {
 
 struct deconv_layer_worker_specific_storage {
-    const tensor_t* prev_out_;
-    const tensor_t* curr_out_unpadded_;
-    tensor_t curr_out_buf_;
-    tensor_t curr_delta_padded;
+  const tensor_t* prev_out_;
+  const tensor_t* curr_out_unpadded_;
+  tensor_t curr_out_buf_;
+  tensor_t curr_delta_padded;
 };
 
 struct deconv_params {
-    connection_table tbl;
-    index3d<cnn_size_t> in;
-    index3d<cnn_size_t> out;
-    index3d<cnn_size_t> out_unpadded;
-    index3d<cnn_size_t> weight;
-    bool has_bias;
-    padding pad_type;
-    size_t w_stride;
-    size_t h_stride;
+  connection_table tbl;
+  index3d<cnn_size_t> in;
+  index3d<cnn_size_t> out;
+  index3d<cnn_size_t> out_unpadded;
+  index3d<cnn_size_t> weight;
+  bool has_bias;
+  padding pad_type;
+  size_t w_stride;
+  size_t h_stride;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/params/deconv_params.h
+++ b/tiny_dnn/core/params/deconv_params.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/params/fully_params.h
+++ b/tiny_dnn/core/params/fully_params.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "params.h"

--- a/tiny_dnn/core/params/fully_params.h
+++ b/tiny_dnn/core/params/fully_params.h
@@ -11,14 +11,14 @@ namespace core {
 
 class fully_params : public Params {
  public:
-    cnn_size_t in_size_;
-    cnn_size_t out_size_;
-    bool has_bias_;
+  cnn_size_t in_size_;
+  cnn_size_t out_size_;
+  bool has_bias_;
 };
 
 // TODO(nyanp): can we do better here?
 inline fully_params Params::fully() const {
-    return *(static_cast<const fully_params*>(this));
+  return *(static_cast<const fully_params*>(this));
 }
 
 }  // namespace core

--- a/tiny_dnn/core/params/maxpool_params.h
+++ b/tiny_dnn/core/params/maxpool_params.h
@@ -8,15 +8,15 @@ namespace tiny_dnn {
 namespace core {
 
 struct maxpool_params {
-    index3d<cnn_size_t> in_;
-    index3d<cnn_size_t> out_;
-    size_t              pool_size_;
-    size_t              stride_;
+  index3d<cnn_size_t> in_;
+  index3d<cnn_size_t> out_;
+  size_t pool_size_;
+  size_t stride_;
 };
 
 struct max_pooling_layer_worker_specific_storage {
-    /* mapping out => max_index(in) (1:1) */
-    std::vector<std::vector<cnn_size_t>> out2inmax_;
+  /* mapping out => max_index(in) (1:1) */
+  std::vector<std::vector<cnn_size_t>> out2inmax_;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/params/maxpool_params.h
+++ b/tiny_dnn/core/params/maxpool_params.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -12,9 +12,9 @@ class fully_params;
 /* Base class to model operation parameters */
 class Params {
  public:
-    Params() {}
+  Params() {}
 
-    fully_params fully() const;
+  fully_params fully() const;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 namespace tiny_dnn {

--- a/tiny_dnn/core/session.h
+++ b/tiny_dnn/core/session.h
@@ -14,21 +14,21 @@ namespace core {
 
 class session {
  public:
-    session(const std::string name) : name_(name) {}
+  session(const std::string name) : name_(name) {}
 
-    std::string get_name() const { return name_; }
-    size_t get_num_devices() const { return devices_.size(); }
+  std::string get_name() const { return name_; }
+  size_t get_num_devices() const { return devices_.size(); }
 
-    // will call construct graph
-    // should we here specify the devices to use?
-    void schedule_session(/* network<sequential>& net */);
+  // will call construct graph
+  // should we here specify the devices to use?
+  void schedule_session(/* network<sequential>& net */);
 
-    // will call forward or backward methods
-    void run_session(/* data */);
+  // will call forward or backward methods
+  void run_session(/* data */);
 
  private:
-    std::string name_;
-    std::vector<std::shared_ptr<device>> devices_;
+  std::string name_;
+  std::vector<std::shared_ptr<device>> devices_;
 };
 
 }  // namespace core

--- a/tiny_dnn/core/session.h
+++ b/tiny_dnn/core/session.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
+// Copyright (c) 2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <string>

--- a/tiny_dnn/io/caffe/layer_factory.h
+++ b/tiny_dnn/io/caffe/layer_factory.h
@@ -8,11 +8,11 @@
 #include <google/protobuf/text_format.h>
 #include "caffe.pb.h"
 
-#include "tiny_dnn/network.h"
+#include "tiny_dnn/io/caffe/layer_factory_impl.h"
 #include "tiny_dnn/lossfunctions/loss_function.h"
+#include "tiny_dnn/network.h"
 #include "tiny_dnn/optimizers/optimizer.h"
 #include "tiny_dnn/util/util.h"
-#include "tiny_dnn/io/caffe/layer_factory_impl.h"
 
 namespace tiny_dnn {
 
@@ -22,61 +22,62 @@ namespace tiny_dnn {
 * @param layer [in] netparameter of caffemodel
 * @param data_shape [in] size of input data (width x height x channels)
 */
-inline std::shared_ptr<network<sequential>>
-create_net_from_caffe_net(const caffe::NetParameter& layer, const shape3d& data_shape)
-{
-    detail::caffe_layer_vector src_net(layer);
-    shape_t shape;
+inline std::shared_ptr<network<sequential>> create_net_from_caffe_net(
+    const caffe::NetParameter& layer, const shape3d& data_shape) {
+  detail::caffe_layer_vector src_net(layer);
+  shape_t shape;
 
-    if (data_shape.size() > 0) {
-        shape = data_shape;
+  if (data_shape.size() > 0) {
+    shape = data_shape;
+  } else {
+    if (layer.input_shape_size() > 0) {
+      // input_shape is deprecated in Caffe
+      // blob dimensions are ordered by number N x channel K x height H x width
+      // W
+      int depth = static_cast<int>(layer.input_shape(0).dim(1));
+      int height = static_cast<int>(layer.input_shape(0).dim(2));
+      int width = static_cast<int>(layer.input_shape(0).dim(3));
+      shape = shape3d(width, height, depth);
+    } else if (src_net[0].has_input_param()) {
+      // blob dimensions are ordered by number N x channel K x height H x width
+      // W
+      int depth = static_cast<int>(src_net[0].input_param().shape(0).dim(1));
+      int height = static_cast<int>(src_net[0].input_param().shape(0).dim(2));
+      int width = static_cast<int>(src_net[0].input_param().shape(0).dim(3));
+      shape = shape3d(width, height, depth);
     } else {
-        if (layer.input_shape_size() > 0) {
-            // input_shape is deprecated in Caffe
-            // blob dimensions are ordered by number N x channel K x height H x width W
-            int depth  = static_cast<int>(layer.input_shape(0).dim(1));
-            int height = static_cast<int>(layer.input_shape(0).dim(2));
-            int width  = static_cast<int>(layer.input_shape(0).dim(3));
-            shape = shape3d(width, height, depth);
-        }
-        else if (src_net[0].has_input_param()) {
-            // blob dimensions are ordered by number N x channel K x height H x width W
-            int depth  = static_cast<int>(src_net[0].input_param().shape(0).dim(1));
-            int height = static_cast<int>(src_net[0].input_param().shape(0).dim(2));
-            int width  = static_cast<int>(src_net[0].input_param().shape(0).dim(3));
-            shape = shape3d(width, height, depth);
-        }
-        else {
-            throw nn_error("input_shape not found in caffemodel. must specify input shape explicitly");
-        }
+      throw nn_error(
+          "input_shape not found in caffemodel. must specify input shape "
+          "explicitly");
+    }
+  }
+
+  auto dst_net = std::make_shared<network<sequential>>(layer.name());
+
+  for (size_t i = 0; i < src_net.size(); i++) {
+    auto type = src_net[i].type();
+
+    if (detail::layer_skipped(type)) {
+      continue;
     }
 
-    auto dst_net = std::make_shared<network<sequential>>(layer.name());
-
-    for (size_t i = 0; i < src_net.size(); i++) {
-        auto type = src_net[i].type();
-
-        if (detail::layer_skipped(type)) {
-            continue;
-        }
-
-        if (!detail::layer_supported(type)) {
-            throw nn_error("error: tiny-dnn does not support this layer type:" + type);
-        }
-
-        shape_t shape_next = shape;
-        auto layer = detail::create(src_net[i], shape, &shape_next);
-
-        nn_info("convert " + type + " => " + typeid(*layer).name());
-        nn_info("shape:" + to_string(shape_next));
-
-        *dst_net << layer;
-        shape = shape_next;
+    if (!detail::layer_supported(type)) {
+      throw nn_error("error: tiny-dnn does not support this layer type:" +
+                     type);
     }
 
-    return dst_net;
+    shape_t shape_next = shape;
+    auto layer = detail::create(src_net[i], shape, &shape_next);
+
+    nn_info("convert " + type + " => " + typeid(*layer).name());
+    nn_info("shape:" + to_string(shape_next));
+
+    *dst_net << layer;
+    shape = shape_next;
+  }
+
+  return dst_net;
 }
-
 
 /**
  * create whole network and load weights from caffe's netparameter
@@ -84,13 +85,12 @@ create_net_from_caffe_net(const caffe::NetParameter& layer, const shape3d& data_
  * @param layer [in] netparameter of caffemodel
  * @param data_shape [in] size of input data (width x height x channels)
  */
-inline std::shared_ptr<network<sequential>>
-create_net_from_caffe_protobinary(const std::string& caffebinarymodel, const shape3d& data_shape)
-{
-    caffe::NetParameter np;
+inline std::shared_ptr<network<sequential>> create_net_from_caffe_protobinary(
+    const std::string& caffebinarymodel, const shape3d& data_shape) {
+  caffe::NetParameter np;
 
-    detail::read_proto_from_binary(caffebinarymodel, &np);
-    return create_net_from_caffe_net(np, data_shape);
+  detail::read_proto_from_binary(caffebinarymodel, &np);
+  return create_net_from_caffe_net(np, data_shape);
 }
 
 /**
@@ -98,13 +98,12 @@ create_net_from_caffe_protobinary(const std::string& caffebinarymodel, const sha
  *
  * @param layer [in] netparameter of caffe prototxt
  */
-inline std::shared_ptr<network<sequential>>
-create_net_from_caffe_prototxt(const std::string& caffeprototxt, const shape3d& shape =shape3d())
-{
-    caffe::NetParameter np;
+inline std::shared_ptr<network<sequential>> create_net_from_caffe_prototxt(
+    const std::string& caffeprototxt, const shape3d& shape = shape3d()) {
+  caffe::NetParameter np;
 
-    detail::read_proto_from_text(caffeprototxt, &np);
-    return create_net_from_caffe_net(np, shape);
+  detail::read_proto_from_text(caffeprototxt, &np);
+  return create_net_from_caffe_net(np, shape);
 }
 
 /**
@@ -115,30 +114,34 @@ create_net_from_caffe_prototxt(const std::string& caffeprototxt, const shape3d& 
  * @param net [out] tiny-dnn's network
  */
 template <typename N>
-inline void reload_weight_from_caffe_net(const caffe::NetParameter& layer, network<N> *net)
-{
-    detail::caffe_layer_vector src_net(layer);
+inline void reload_weight_from_caffe_net(const caffe::NetParameter& layer,
+                                         network<N>* net) {
+  detail::caffe_layer_vector src_net(layer);
 
-    size_t tinycnn_layer_idx = 0;
+  size_t tinycnn_layer_idx = 0;
 
-    for (size_t caffe_layer_idx = 0; caffe_layer_idx < src_net.size(); caffe_layer_idx++) {
-        auto type = src_net[caffe_layer_idx].type();
+  for (size_t caffe_layer_idx = 0; caffe_layer_idx < src_net.size();
+       caffe_layer_idx++) {
+    auto type = src_net[caffe_layer_idx].type();
 
-        if (detail::layer_skipped(type) || !detail::layer_has_weights(type)) {
-            continue;
-        }
-
-        if (!detail::layer_supported(type))
-            throw nn_error("error: tiny-dnn does not support this layer type:" + type);
-
-        while (tinycnn_layer_idx < net->depth() && !detail::layer_match(type, (*net)[tinycnn_layer_idx]->layer_type())) {
-            tinycnn_layer_idx++;
-        }
-        if (tinycnn_layer_idx >= net->depth()) break;
-
-        // load weight
-        detail::load(src_net[caffe_layer_idx], (*net)[tinycnn_layer_idx++]);
+    if (detail::layer_skipped(type) || !detail::layer_has_weights(type)) {
+      continue;
     }
+
+    if (!detail::layer_supported(type))
+      throw nn_error("error: tiny-dnn does not support this layer type:" +
+                     type);
+
+    while (
+        tinycnn_layer_idx < net->depth() &&
+        !detail::layer_match(type, (*net)[tinycnn_layer_idx]->layer_type())) {
+      tinycnn_layer_idx++;
+    }
+    if (tinycnn_layer_idx >= net->depth()) break;
+
+    // load weight
+    detail::load(src_net[caffe_layer_idx], (*net)[tinycnn_layer_idx++]);
+  }
 }
 
 /**
@@ -149,12 +152,12 @@ inline void reload_weight_from_caffe_net(const caffe::NetParameter& layer, netwo
  * @param net [out] tiny-dnn's network
  */
 template <typename N>
-inline void reload_weight_from_caffe_protobinary(const std::string& caffebinary, network<N> *net)
-{
-    caffe::NetParameter np;
+inline void reload_weight_from_caffe_protobinary(const std::string& caffebinary,
+                                                 network<N>* net) {
+  caffe::NetParameter np;
 
-    detail::read_proto_from_binary(caffebinary, &np);
-    reload_weight_from_caffe_net(np, net);
+  detail::read_proto_from_binary(caffebinary, &np);
+  reload_weight_from_caffe_net(np, net);
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/io/caffe/layer_factory.h
+++ b/tiny_dnn/io/caffe/layer_factory.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -4,39 +4,39 @@
 
 #pragma once
 #include <algorithm>
-#include <memory>
-#include <vector>
-#include <map>
-#include <string>
 #include <limits>
+#include <map>
+#include <memory>
+#include <string>
 #include <unordered_map>
+#include <vector>
 
 #include "caffe.pb.h"
 
+#include "tiny_dnn/layers/average_pooling_layer.h"
 #include "tiny_dnn/layers/convolutional_layer.h"
 #include "tiny_dnn/layers/deconvolutional_layer.h"
+#include "tiny_dnn/layers/dropout_layer.h"
 #include "tiny_dnn/layers/fully_connected_layer.h"
-#include "tiny_dnn/layers/average_pooling_layer.h"
-#include "tiny_dnn/layers/max_pooling_layer.h"
 #include "tiny_dnn/layers/linear_layer.h"
 #include "tiny_dnn/layers/lrn_layer.h"
-#include "tiny_dnn/layers/dropout_layer.h"
+#include "tiny_dnn/layers/max_pooling_layer.h"
 
 typedef tiny_dnn::shape3d shape_t;
 
 #ifdef _MSC_VER
 #define _NOMINMAX
-#include <io.h>
 #include <fcntl.h>
-#define CNN_OPEN_BINARY(filename) open(filename, _O_RDONLY|_O_BINARY)
+#include <io.h>
+#define CNN_OPEN_BINARY(filename) open(filename, _O_RDONLY | _O_BINARY)
 #define CNN_OPEN_TXT(filename) open(filename, _O_RDONLY)
 #pragma warning(push)
-#pragma warning(disable:4996)
+#pragma warning(disable : 4996)
 #else
-#include <unistd.h>
-#include <sys/types.h>
-#include <sys/stat.h>
 #include <fcntl.h>
+#include <sys/stat.h>
+#include <sys/types.h>
+#include <unistd.h>
 #define CNN_OPEN_BINARY(filename) open(filename, O_RDONLY)
 #define CNN_OPEN_TXT(filename) open(filename, O_RDONLY)
 #endif
@@ -45,1084 +45,1072 @@ namespace tiny_dnn {
 namespace detail {
 
 inline void read_proto_from_text(const std::string& prototxt,
-                                 google::protobuf::Message *message) {
-    int fd = CNN_OPEN_TXT(prototxt.c_str());
-    if (fd == -1) {
-        throw nn_error("file not fonud: " + prototxt);
-    }
+                                 google::protobuf::Message* message) {
+  int fd = CNN_OPEN_TXT(prototxt.c_str());
+  if (fd == -1) {
+    throw nn_error("file not fonud: " + prototxt);
+  }
 
-    google::protobuf::io::FileInputStream input(fd);
-    input.SetCloseOnDelete(true);
+  google::protobuf::io::FileInputStream input(fd);
+  input.SetCloseOnDelete(true);
 
-    if (!google::protobuf::TextFormat::Parse(&input, message)) {
-        throw nn_error("failed to parse");
-    }
+  if (!google::protobuf::TextFormat::Parse(&input, message)) {
+    throw nn_error("failed to parse");
+  }
 }
 
 inline void read_proto_from_binary(const std::string& protobinary,
-                                   google::protobuf::Message *message) {
-    int fd = CNN_OPEN_BINARY(protobinary.c_str());
-    google::protobuf::io::FileInputStream rawstr(fd);
-    google::protobuf::io::CodedInputStream codedstr(&rawstr);
+                                   google::protobuf::Message* message) {
+  int fd = CNN_OPEN_BINARY(protobinary.c_str());
+  google::protobuf::io::FileInputStream rawstr(fd);
+  google::protobuf::io::CodedInputStream codedstr(&rawstr);
 
-    rawstr.SetCloseOnDelete(true);
-    codedstr.SetTotalBytesLimit(std::numeric_limits<int>::max(),
-                                std::numeric_limits<int>::max() / 2);
+  rawstr.SetCloseOnDelete(true);
+  codedstr.SetTotalBytesLimit(std::numeric_limits<int>::max(),
+                              std::numeric_limits<int>::max() / 2);
 
-    if (!message->ParseFromCodedStream(&codedstr)) {
-        throw nn_error("failed to parse");
-    }
+  if (!message->ParseFromCodedStream(&codedstr)) {
+    throw nn_error("failed to parse");
+  }
 }
 
-inline std::shared_ptr<weight_init::function>
-create_filler(const std::string& filler) {
-    if (filler == "xavier") {
-        return std::make_shared<weight_init::xavier>();
-    } else if (filler == "constant") {
-        return std::make_shared<weight_init::constant>();
-    } else if (filler == "gaussian") {
-        return std::make_shared<weight_init::gaussian>();
-    } else {
-        throw nn_error("unsupported filler type");
-    }
+inline std::shared_ptr<weight_init::function> create_filler(
+    const std::string& filler) {
+  if (filler == "xavier") {
+    return std::make_shared<weight_init::xavier>();
+  } else if (filler == "constant") {
+    return std::make_shared<weight_init::constant>();
+  } else if (filler == "gaussian") {
+    return std::make_shared<weight_init::gaussian>();
+  } else {
+    throw nn_error("unsupported filler type");
+  }
 }
 
 template <typename param>
-inline bool get_kernel_size_2d(const param& p, layer_size_t *kernel) {
-    if (p.has_kernel_w() && p.has_kernel_w()) {
-        if (p.kernel_w() != p.kernel_h()) {
-            throw nn_error("unsupported kernel shape");
-        }
-        *kernel = p.kernel_w();
-        return true;
+inline bool get_kernel_size_2d(const param& p, layer_size_t* kernel) {
+  if (p.has_kernel_w() && p.has_kernel_w()) {
+    if (p.kernel_w() != p.kernel_h()) {
+      throw nn_error("unsupported kernel shape");
     }
-    return false;
+    *kernel = p.kernel_w();
+    return true;
+  }
+  return false;
 }
 
 inline layer_size_t get_kernel_size_2d(const caffe::ConvolutionParameter& p) {
-    layer_size_t window_size;
-    if (!get_kernel_size_2d(p, &window_size)) {
-        if (p.kernel_size_size() > 1) {
-            throw nn_error("unsupported kernel shape");
-        }
-        window_size = p.kernel_size(0);
+  layer_size_t window_size;
+  if (!get_kernel_size_2d(p, &window_size)) {
+    if (p.kernel_size_size() > 1) {
+      throw nn_error("unsupported kernel shape");
     }
-    return window_size;
+    window_size = p.kernel_size(0);
+  }
+  return window_size;
 }
 
-inline std::shared_ptr<layer> create_max_pool(int pool_size,
-                                              int stride,
+inline std::shared_ptr<layer> create_max_pool(int pool_size, int stride,
                                               const shape_t& bottom_shape,
-                                              shape_t *top_shape) {
-    using max_pool = max_pooling_layer<activation::identity>;
-    auto mp = std::make_shared<max_pool>(bottom_shape.width_,
-                                         bottom_shape.height_,
-                                         bottom_shape.depth_,
-                                         pool_size, stride);
-    // TODO
-    //  *top_shape = mp->out_shape();
-    *top_shape = mp->out_shape()[0];  // check this
-    mp->init_weight();
+                                              shape_t* top_shape) {
+  using max_pool = max_pooling_layer<activation::identity>;
+  auto mp =
+      std::make_shared<max_pool>(bottom_shape.width_, bottom_shape.height_,
+                                 bottom_shape.depth_, pool_size, stride);
+  // TODO
+  //  *top_shape = mp->out_shape();
+  *top_shape = mp->out_shape()[0];  // check this
+  mp->init_weight();
 
-    return mp;
+  return mp;
 }
 
-inline std::shared_ptr<layer> create_ave_pool(int pool_size,
-                                              int stride,
+inline std::shared_ptr<layer> create_ave_pool(int pool_size, int stride,
                                               const shape_t& bottom_shape,
-                                              shape_t *top_shape) {
-    using ave_pool = average_pooling_layer<activation::identity>;
-    auto ap = std::make_shared<ave_pool>(bottom_shape.width_,
-                                         bottom_shape.height_,
-                                         bottom_shape.depth_,
-                                         pool_size, stride);
+                                              shape_t* top_shape) {
+  using ave_pool = average_pooling_layer<activation::identity>;
+  auto ap =
+      std::make_shared<ave_pool>(bottom_shape.width_, bottom_shape.height_,
+                                 bottom_shape.depth_, pool_size, stride);
+
+  // tiny-dnn has trainable parameter in average-pooling layer
+  float_t weight = float_t(1) / sqr(pool_size);
+
+  vec_t& w = *ap->weights()[0];
+  vec_t& b = *ap->weights()[1];
+
+  // std::fill(ap->weight().begin(), ap->weight().end(), weight);
+  // std::fill(ap->bias().begin(), ap->bias().end(), float_t(0));
+
+  std::fill(w.begin(), w.end(), weight);
+  std::fill(b.begin(), b.end(), float_t(0));
+
+  // TODO: check if this works
+  *top_shape = ap->out_shape()[0];
+  ap->init_weight();
+
+  return ap;
+}
+
+inline std::shared_ptr<layer> create_softmax(const caffe::LayerParameter& layer,
+                                             const shape_t& bottom_shape,
+                                             shape_t*) {
+  auto sm =
+      std::make_shared<linear_layer<activation::softmax>>(bottom_shape.size());
+  sm->init_weight();
+  return sm;
+}
+
+inline std::shared_ptr<layer> create_sigmoid(const caffe::LayerParameter& layer,
+                                             const shape_t& bottom_shape,
+                                             shape_t*) {
+  auto ce =
+      std::make_shared<linear_layer<activation::sigmoid>>(bottom_shape.size());
+  return ce;
+}
+
+inline std::shared_ptr<layer> create_tanh(const caffe::LayerParameter& layer,
+                                          const shape_t& bottom_shape,
+                                          shape_t*) {
+  auto tanh =
+      std::make_shared<linear_layer<activation::tan_h>>(bottom_shape.size());
+  return tanh;
+}
+
+inline std::shared_ptr<layer> create_power(const caffe::LayerParameter& layer,
+                                           const shape_t& bottom_shape,
+                                           shape_t*) {
+  auto power = std::make_shared<power_layer>(
+      bottom_shape, layer.power_param().power(), layer.power_param().scale());
+  return power;
+}
+
+inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter& layer,
+                                             const shape_t& bottom_shape,
+                                             shape_t* top_shape) {
+  if (!layer.has_pooling_param()) {
+    throw nn_error("pool param missing");
+  }
+
+  auto pool_param = layer.pooling_param();
+
+  layer_size_t h_stride = 0;
+  layer_size_t w_stride = 0;
+  layer_size_t pool_size = 0;
+
+  if (!get_kernel_size_2d(pool_param, &pool_size)) {
+    pool_size = pool_param.kernel_size();
+  }
+
+  if (pool_param.has_stride() || pool_param.has_stride_h()) {
+    h_stride =
+        pool_param.has_stride() ? pool_param.stride() : pool_param.stride_h();
+  }
+
+  if (pool_param.has_stride() || pool_param.has_stride_w()) {
+    w_stride =
+        pool_param.has_stride() ? pool_param.stride() : pool_param.stride_w();
+  }
+
+  if (h_stride != w_stride) {  // || h_stride != pool_size)
+    throw nn_error("unsupported pool shape");
+  }
+
+  if (pool_param.has_pool()) {
+    auto type = pool_param.pool();
+
+    switch (type) {
+      case caffe::PoolingParameter_PoolMethod_MAX:
+        return create_max_pool(pool_size, h_stride, bottom_shape, top_shape);
+      case caffe::PoolingParameter_PoolMethod_AVE:
+        return create_ave_pool(pool_size, h_stride, bottom_shape, top_shape);
+      default:
+        throw nn_error("unsupported layer type");
+    }
+  }
+
+  // default: max-pool
+  return create_max_pool(pool_size, h_stride, bottom_shape, top_shape);
+}
+
+inline std::shared_ptr<layer> create_relu(const caffe::LayerParameter& layer,
+                                          const shape_t& bottom_shape,
+                                          shape_t*) {
+  auto relu =
+      std::make_shared<linear_layer<activation::relu>>(bottom_shape.size());
+  return relu;
+}
+
+inline std::shared_ptr<layer> create_batchnorm(
+    const caffe::LayerParameter& layer, const shape_t& bottom_shape,
+    shape_t* top_shape) {
+  using bn_layer = batch_normalization_layer;
+
+  *top_shape = bottom_shape;
+
+  float_t eps = 1e-5f;
+  float_t momentum = 0.999f;
+
+  if (layer.has_batch_norm_param()) {
+    auto bn_param = layer.batch_norm_param();
+
+    if (bn_param.has_eps()) {
+      eps = bn_param.eps();
+    }
+    if (bn_param.has_moving_average_fraction()) {
+      momentum = bn_param.moving_average_fraction();
+    }
+  }
+
+  auto bn = std::make_shared<bn_layer>(bottom_shape.area(), bottom_shape.depth_,
+                                       eps, momentum, net_phase::test);
+
+  // weight
+  if (layer.blobs_size() > 0) {
+    auto global_stats = layer.blobs();
+    if (global_stats.size() != 3) {
+      throw std::runtime_error("unexpected bn stored statistics");
+    }
+
+    float_t scale_factor =
+        global_stats.Get(2).data(0) == 0 ? 0 : 1 / global_stats.Get(2).data(0);
+    vec_t mean(bottom_shape.depth_);
+    vec_t variance(bottom_shape.depth_);
+
+    for (size_t i = 0; i < mean.size(); i++) {
+      mean[i] = global_stats.Get(0).data(i) * scale_factor;
+      variance[i] = global_stats.Get(1).data(i) * scale_factor;
+    }
+    bn->set_mean(mean);
+    bn->set_variance(variance);
+  }
+
+  return bn;
+}
+
+inline void load_weights_fullyconnected(const caffe::LayerParameter& src,
+                                        layer* dst) {
+  auto weights = src.blobs(0);
+  int curr = 0;
+
+  if (dst->out_size() * dst->in_size() !=
+      static_cast<cnn_size_t>(weights.data_size())) {
+    throw nn_error(std::string("layer size mismatch!") + "caffe(" + src.name() +
+                   "):" + to_string(weights.data_size()) + "\n" + "tiny-dnn(" +
+                   dst->layer_type() + "):" + to_string(dst->weights().size()));
+  }
+
+  vec_t& w = *dst->weights()[0];
+  vec_t& b = *dst->weights()[1];
+
+  // fill weights
+  for (size_t o = 0; o < dst->out_size(); o++) {
+    for (size_t i = 0; i < dst->in_size(); i++) {
+      // TODO: how to access to weights?
+      // dst->weight()[i * dst->out_size() + o] = weights.data(curr++); //
+      // transpose
+      w[i * dst->out_size() + o] = weights.data(curr++);  // transpose
+    }
+  }
+
+  // fill bias
+  if (src.inner_product_param().bias_term()) {
+    auto biases = src.blobs(1);
+    for (size_t o = 0; o < dst->out_size(); o++) {
+      // TODO: how to access to biases?
+      // dst->bias()[o] = biases.data(o);
+      b[o] = biases.data(o);
+    }
+  }
+}
+
+inline std::shared_ptr<layer> create_fullyconnected(
+    const caffe::LayerParameter& layer, const shape_t& bottom_shape,
+    shape_t* top_shape) {
+  using fc_layer = fully_connected_layer<activation::identity>;
+
+  if (!layer.has_inner_product_param()) {
+    throw nn_error("inner-product param missing");
+  }
+
+  layer_size_t dim_input = 0, dim_output = 0;
+  bool has_bias = true;
+
+  auto ip_param = layer.inner_product_param();
+  has_bias = ip_param.bias_term();
+
+  dim_output = ip_param.num_output();
+  dim_input = bottom_shape.size();
+
+  auto ip = std::make_shared<fc_layer>(dim_input, dim_output, has_bias);
+
+  // filler
+  if (ip_param.has_weight_filler()) {
+    ip->weight_init(create_filler(ip_param.weight_filler().type()));
+  }
+
+  if (ip_param.has_bias_filler()) {
+    ip->bias_init(create_filler(ip_param.bias_filler().type()));
+  }
+
+  // weight
+  if (layer.blobs_size() > 0) {
+    load_weights_fullyconnected(layer, ip.get());
+  }
+
+  // TODO: check if it works
+  *top_shape = ip->out_shape()[0];
+  return ip;
+}
+
+inline void load_weights_conv(const caffe::LayerParameter& src, layer* dst) {
+  // fill weight
+  auto weights = src.blobs(0);
+
+  // TODO: check if it works
+  // int out_channels = dst->out_shape().depth_;
+  // int in_channels = dst->in_shape().depth_;
+  int out_channels = dst->out_data_shape()[0].depth_;
+  int in_channels = dst->in_data_shape()[0].depth_;
+
+  connection_table table;
+  auto conv_param = src.convolution_param();
+  int dst_idx = 0;
+  int src_idx = 0;
+  int window_size = get_kernel_size_2d(conv_param);
+
+  if (conv_param.has_group()) {
+    table = connection_table(conv_param.group(), in_channels, out_channels);
+  }
+
+  vec_t& w = *dst->weights()[0];
+  vec_t& b = *dst->weights()[1];
+
+  // fill weights
+  for (int o = 0; o < out_channels; o++) {
+    for (int i = 0; i < in_channels; i++) {
+      if (!table.is_connected(o, i)) {
+        dst_idx += window_size * window_size;
+        continue;
+      }
+      for (int x = 0; x < window_size * window_size; x++) {
+        // TODO
+        // dst->weight()[dst_idx++] = weights.data(src_idx++);
+        w[dst_idx++] = weights.data(src_idx++);
+      }
+    }
+  }
+
+  // fill bias
+  if (conv_param.bias_term()) {
+    auto biases = src.blobs(1);
+    for (int o = 0; o < out_channels; o++) {
+      // TODO
+      // dst->bias()[o] = biases.data(o);
+      b[o] = biases.data(o);
+    }
+  }
+}
+
+inline void load_weights_deconv(const caffe::LayerParameter& src, layer* dst) {
+  // fill weight
+  auto weights = src.blobs(0);
+
+  // TODO: check if it works
+  // int out_channels = dst->out_shape().depth_;
+  // int in_channels = dst->in_shape().depth_;
+  int out_channels = dst->out_data_shape()[0].depth_;
+  int in_channels = dst->in_data_shape()[0].depth_;
+
+  connection_table table;
+  auto deconv_param = src.convolution_param();
+  int dst_idx = 0;
+  int src_idx = 0;
+  int window_size = get_kernel_size_2d(deconv_param);
+
+  if (deconv_param.has_group()) {
+    table = connection_table(deconv_param.group(), in_channels, out_channels);
+  }
+
+  vec_t& w = *dst->weights()[0];
+  vec_t& b = *dst->weights()[1];
+
+  // fill weights
+  for (int o = 0; o < out_channels; o++) {
+    for (int i = 0; i < in_channels; i++) {
+      if (!table.is_connected(o, i)) {
+        dst_idx += window_size * window_size;
+        continue;
+      }
+      for (int x = 0; x < window_size * window_size; x++) {
+        // TODO
+        // dst->weight()[dst_idx++] = weights.data(src_idx++);
+        w[dst_idx++] = weights.data(src_idx++);
+      }
+    }
+  }
+
+  // fill bias
+  if (deconv_param.bias_term()) {
+    auto biases = src.blobs(1);
+    for (int o = 0; o < out_channels; o++) {
+      // TODO
+      // dst->bias()[o] = biases.data(o);
+      b[o] = biases.data(o);
+    }
+  }
+}
+
+inline void load_weights_pool(const caffe::LayerParameter& src, layer* dst) {
+  auto pool_param = src.pooling_param();
+
+  // TODO
+  // if (dst->weight().size()) {
+  if (dst->weights().size()) {
+    layer_size_t pool_size = 0;
+
+    if (!get_kernel_size_2d(pool_param, &pool_size)) {
+      pool_size = pool_param.kernel_size();
+    }
 
     // tiny-dnn has trainable parameter in average-pooling layer
     float_t weight = float_t(1) / sqr(pool_size);
 
-    vec_t& w = *ap->weights()[0];
-    vec_t& b = *ap->weights()[1];
-
-    //std::fill(ap->weight().begin(), ap->weight().end(), weight);
-    //std::fill(ap->bias().begin(), ap->bias().end(), float_t(0));
-
-    std::fill(w.begin(), w.end(), weight);
-    std::fill(b.begin(), b.end(), float_t(0));
-
-    // TODO: check if this works
-    *top_shape = ap->out_shape()[0];
-    ap->init_weight();
-
-    return ap;
-}
-
-inline
-std::shared_ptr<layer> create_softmax(const caffe::LayerParameter& layer,
-                                      const shape_t& bottom_shape, shape_t *) {
-    auto sm = std::make_shared<linear_layer<activation::softmax>>(
-        bottom_shape.size());
-    sm->init_weight();
-    return sm;
-}
-
-inline
-std::shared_ptr<layer> create_sigmoid(const caffe::LayerParameter& layer,
-                                      const shape_t& bottom_shape, shape_t *) {
-    auto ce = std::make_shared<linear_layer<activation::sigmoid>>(
-        bottom_shape.size());
-    return ce;
-}
-
-inline
-std::shared_ptr<layer> create_tanh(const caffe::LayerParameter& layer,
-                                   const shape_t& bottom_shape, shape_t *) {
-    auto tanh = std::make_shared<linear_layer<activation::tan_h>>(
-        bottom_shape.size());
-    return tanh;
-}
-
-inline
-std::shared_ptr<layer> create_power(const caffe::LayerParameter& layer,
-                                    const shape_t& bottom_shape, shape_t *) {
-    auto power = std::make_shared<power_layer>(bottom_shape, layer.power_param().power(), layer.power_param().scale());
-    return power;
-}
-
-    
-inline
-std::shared_ptr<layer> create_pooling(const caffe::LayerParameter& layer,
-                                      const shape_t& bottom_shape,
-                                      shape_t *top_shape) {
-    if (!layer.has_pooling_param()) {
-        throw nn_error("pool param missing");
+    // TODO
+    /*if (!dst->weight().empty()) {
+        std::fill(dst->weight().begin(), dst->weight().end(), weight);
     }
-
-    auto pool_param = layer.pooling_param();
-
-    layer_size_t h_stride = 0;
-    layer_size_t w_stride = 0;
-    layer_size_t pool_size = 0;
-
-    if (!get_kernel_size_2d(pool_param, &pool_size)) {
-        pool_size = pool_param.kernel_size();
-    }
-
-    if (pool_param.has_stride() || pool_param.has_stride_h()) {
-        h_stride = pool_param.has_stride() ?
-                   pool_param.stride() : pool_param.stride_h();
-    }
-
-    if (pool_param.has_stride() || pool_param.has_stride_w()) {
-        w_stride = pool_param.has_stride() ?
-                   pool_param.stride() : pool_param.stride_w();
-    }
-
-    if (h_stride != w_stride) {  // || h_stride != pool_size)
-        throw nn_error("unsupported pool shape");
-    }
-
-    if (pool_param.has_pool()) {
-        auto type = pool_param.pool();
-
-        switch (type) {
-            case caffe::PoolingParameter_PoolMethod_MAX:
-                return create_max_pool(pool_size, h_stride,
-                                       bottom_shape, top_shape);
-            case caffe::PoolingParameter_PoolMethod_AVE:
-                return create_ave_pool(pool_size, h_stride,
-                                       bottom_shape, top_shape);
-            default:
-                throw nn_error("unsupported layer type");
-        }
-    }
-
-    // default: max-pool
-    return create_max_pool(pool_size, h_stride, bottom_shape, top_shape);
-}
-
-inline
-std::shared_ptr<layer> create_relu(const caffe::LayerParameter& layer,
-                                   const shape_t& bottom_shape, shape_t *) {
-    auto relu = std::make_shared<linear_layer<activation::relu>>(
-        bottom_shape.size());
-    return relu;
-}
-
-inline std::shared_ptr<layer> create_batchnorm(const caffe::LayerParameter& layer,
-    const shape_t& bottom_shape, shape_t *top_shape) {
-    using bn_layer = batch_normalization_layer;
-
-    *top_shape = bottom_shape;
-
-    float_t eps = 1e-5f;
-    float_t momentum = 0.999f;
-
-    if (layer.has_batch_norm_param()) {
-        auto bn_param = layer.batch_norm_param();
-
-        if (bn_param.has_eps()) {
-            eps = bn_param.eps();
-        }
-        if (bn_param.has_moving_average_fraction()) {
-            momentum = bn_param.moving_average_fraction();
-        }
-    }
-
-    auto bn = std::make_shared<bn_layer>(bottom_shape.area(), bottom_shape.depth_, eps, momentum, net_phase::test);
-
-    // weight
-    if (layer.blobs_size() > 0) {
-        auto global_stats = layer.blobs();
-        if (global_stats.size() != 3) {
-            throw std::runtime_error("unexpected bn stored statistics");
-        }       
-
-        float_t scale_factor = global_stats.Get(2).data(0) == 0 ? 0 : 1 / global_stats.Get(2).data(0);
-        vec_t mean(bottom_shape.depth_);
-        vec_t variance(bottom_shape.depth_);
-
-        for (size_t i = 0; i < mean.size(); i++) {
-            mean[i]     = global_stats.Get(0).data(i) * scale_factor;
-            variance[i] = global_stats.Get(1).data(i) * scale_factor;
-        }
-        bn->set_mean(mean);
-        bn->set_variance(variance);
-    }
-
-    return bn;
-}
-
-
-inline void load_weights_fullyconnected(const caffe::LayerParameter& src,
-                                        layer *dst) {
-    auto weights = src.blobs(0);
-    int curr = 0;
-
-    if (dst->out_size() * dst->in_size() !=
-        static_cast<cnn_size_t>(weights.data_size())) {
-        throw nn_error(
-            std::string("layer size mismatch!") +
-            "caffe(" + src.name() + "):" + to_string(weights.data_size()) + "\n" +
-            "tiny-dnn(" + dst->layer_type() + "):" + to_string(dst->weights().size()));
-    }
+    if (!dst->bias().empty()) {
+        std::fill(dst->bias().begin(), dst->bias().end(), float_t(0));
+        dst->init_bias();
+    }*/
 
     vec_t& w = *dst->weights()[0];
     vec_t& b = *dst->weights()[1];
 
-    // fill weights
-    for (size_t o = 0; o < dst->out_size(); o++) {
-        for (size_t i = 0; i < dst->in_size(); i++) {
-            // TODO: how to access to weights?
-            //dst->weight()[i * dst->out_size() + o] = weights.data(curr++); // transpose
-            w[i * dst->out_size() + o] = weights.data(curr++); // transpose
-        }
+    if (!w.empty()) {
+      std::fill(w.begin(), w.end(), weight);
     }
-
-    // fill bias
-    if (src.inner_product_param().bias_term()) {
-        auto biases = src.blobs(1);
-        for (size_t o = 0; o < dst->out_size(); o++) {
-            // TODO: how to access to biases?
-            //dst->bias()[o] = biases.data(o);
-            b[o] = biases.data(o);
-        }
+    if (!b.empty()) {
+      std::fill(b.begin(), b.end(), float_t(0));
+      // dst->init_bias();
     }
+  }
 }
 
-inline std::shared_ptr<layer> create_fullyconnected(
-        const caffe::LayerParameter& layer,
-        const shape_t& bottom_shape, shape_t *top_shape) {
-    using fc_layer = fully_connected_layer<activation::identity>;
+inline std::shared_ptr<layer> create_lrn(const caffe::LayerParameter& layer,
+                                         const shape_t& bottom_shape,
+                                         shape_t* top_shape) {
+  using lrn_layer = lrn_layer<activation::identity>;
 
-    if (!layer.has_inner_product_param()) {
-        throw nn_error("inner-product param missing");
-    }
+  if (!layer.has_lrn_param()) {
+    throw nn_error("lrn param missing");
+  }
 
-    layer_size_t dim_input = 0, dim_output = 0;
-    bool has_bias = true;
+  auto lrn_param = layer.lrn_param();
+  layer_size_t local_size = 5;
+  float_t alpha = 1;
+  float_t beta = 5;
+  norm_region region = norm_region::across_channels;
 
-    auto ip_param = layer.inner_product_param();
-    has_bias = ip_param.bias_term();
+  if (lrn_param.has_local_size()) local_size = lrn_param.local_size();
+  if (lrn_param.has_alpha()) alpha = lrn_param.alpha();
+  if (lrn_param.has_beta()) beta = lrn_param.beta();
+  if (lrn_param.has_norm_region()) {
+    if (lrn_param.norm_region() ==
+        caffe::LRNParameter_NormRegion_WITHIN_CHANNEL)  // NOLINT
+      region = norm_region::within_channels;
+  }
 
-    dim_output = ip_param.num_output();
-    dim_input = bottom_shape.size();
-
-    auto ip = std::make_shared<fc_layer>(dim_input, dim_output, has_bias);
-
-    // filler
-    if (ip_param.has_weight_filler()) {
-        ip->weight_init(create_filler(ip_param.weight_filler().type()));
-    }
-
-    if (ip_param.has_bias_filler()) {
-        ip->bias_init(create_filler(ip_param.bias_filler().type()));
-    }
-
-    // weight
-    if (layer.blobs_size() > 0) {
-        load_weights_fullyconnected(layer, ip.get());
-    }
-
-    // TODO: check if it works
-    *top_shape = ip->out_shape()[0];
-    return ip;
+  auto lrn = std::make_shared<lrn_layer>(
+      bottom_shape.width_, bottom_shape.height_, local_size,
+      bottom_shape.depth_, alpha, beta, region);
+  return lrn;
 }
 
-inline void load_weights_conv(const caffe::LayerParameter& src, layer *dst) {
-    // fill weight
-    auto weights = src.blobs(0);
+inline std::shared_ptr<layer> create_dropout(const caffe::LayerParameter& layer,
+                                             const shape_t& bottom_shape,
+                                             shape_t* top_shape) {
+  if (!layer.has_dropout_param()) {
+    throw nn_error("dropout param missing");
+  }
 
-    //TODO: check if it works
-    //int out_channels = dst->out_shape().depth_;
-    //int in_channels = dst->in_shape().depth_;
-    int out_channels = dst->out_data_shape()[0].depth_;
-    int in_channels = dst->in_data_shape()[0].depth_;
+  float_t dropout_rate = float_t(0.5);
 
-    connection_table table;
-    auto conv_param = src.convolution_param();
-    int dst_idx = 0;
-    int src_idx = 0;
-    int window_size = get_kernel_size_2d(conv_param);
+  if (layer.dropout_param().has_dropout_ratio()) {
+    dropout_rate = layer.dropout_param().dropout_ratio();
+  }
 
-    if (conv_param.has_group()) {
-        table = connection_table(conv_param.group(), in_channels, out_channels);
-    }
-
-    vec_t& w = *dst->weights()[0];
-    vec_t& b = *dst->weights()[1];
-
-    // fill weights
-    for (int o = 0; o < out_channels; o++) {
-        for (int i = 0; i < in_channels; i++) {
-            if (!table.is_connected(o, i)) {
-                dst_idx += window_size * window_size;
-                continue;
-            }
-            for (int x = 0; x < window_size * window_size; x++) {
-                //TODO
-                //dst->weight()[dst_idx++] = weights.data(src_idx++);
-                w[dst_idx++] =  weights.data(src_idx++);
-            }
-        }
-    }
-
-    // fill bias
-    if (conv_param.bias_term()) {
-        auto biases = src.blobs(1);
-        for (int o = 0; o < out_channels; o++) {
-            //TODO
-            //dst->bias()[o] = biases.data(o);
-            b[o] = biases.data(o);
-        }
-    }
+  auto dropout = std::make_shared<dropout_layer>(bottom_shape.size(),
+                                                 dropout_rate, net_phase::test);
+  return dropout;
 }
 
-inline void load_weights_deconv(const caffe::LayerParameter& src, layer *dst) {
-    // fill weight
-    auto weights = src.blobs(0);
+inline std::shared_ptr<layer> create_convlayer(
+    const caffe::LayerParameter& layer, const shape_t& bottom_shape,
+    shape_t* top_shape) {
+  using conv_layer = convolutional_layer<activation::identity>;
 
-    //TODO: check if it works
-    //int out_channels = dst->out_shape().depth_;
-    //int in_channels = dst->in_shape().depth_;
-    int out_channels = dst->out_data_shape()[0].depth_;
-    int in_channels = dst->in_data_shape()[0].depth_;
+  if (!layer.has_convolution_param()) {
+    throw nn_error("convolution param missing");
+  }
 
-    connection_table table;
-    auto deconv_param = src.convolution_param();
-    int dst_idx = 0;
-    int src_idx = 0;
-    int window_size = get_kernel_size_2d(deconv_param);
+  // layer parameters
+  layer_size_t in_width = 0, in_height = 0, window_size = 0;
+  layer_size_t in_channels = 0, out_channels = 0;
+  layer_size_t w_stride = 1, h_stride = 1;
+  bool has_bias = true;
+  padding pad_type = padding::valid;
+  connection_table table;
 
-    if (deconv_param.has_group()) {
-        table = connection_table(deconv_param.group(), in_channels, out_channels);
+  auto conv_param = layer.convolution_param();
+
+  // shape
+  out_channels = conv_param.num_output();
+  in_channels = bottom_shape.depth_;
+  in_width = bottom_shape.width_;
+  in_height = bottom_shape.height_;
+  has_bias = conv_param.bias_term();
+  window_size = get_kernel_size_2d(conv_param);
+
+  // padding
+  if (conv_param.pad_size() == 1 ||
+      (conv_param.has_pad_w() && conv_param.has_pad_h())) {
+    uint32_t pad_w =
+        conv_param.pad_size() == 1 ? conv_param.pad(0) : conv_param.pad_w();
+
+    uint32_t pad_h =
+        conv_param.pad_size() == 1 ? conv_param.pad(0) : conv_param.pad_h();
+
+    if (pad_w != pad_h) {
+      throw nn_error("conv:not supported padding size");
     }
 
-    vec_t& w = *dst->weights()[0];
-    vec_t& b = *dst->weights()[1];
-
-    // fill weights
-    for (int o = 0; o < out_channels; o++) {
-        for (int i = 0; i < in_channels; i++) {
-            if (!table.is_connected(o, i)) {
-                dst_idx += window_size * window_size;
-                continue;
-            }
-            for (int x = 0; x < window_size * window_size; x++) {
-                //TODO
-                //dst->weight()[dst_idx++] = weights.data(src_idx++);
-                w[dst_idx++] =  weights.data(src_idx++);
-            }
-        }
+    // 0 ... valid, (window_size-1)/2 ... same
+    if (pad_w == (window_size - 1) / 2) {
+      pad_type = padding::same;
+    } else if (pad_w == 0) {
+      pad_type = padding::valid;
+    } else {
+      throw nn_error("conv:not supported padding size");
     }
+  }
 
-    // fill bias
-    if (deconv_param.bias_term()) {
-        auto biases = src.blobs(1);
-        for (int o = 0; o < out_channels; o++) {
-            //TODO
-            //dst->bias()[o] = biases.data(o);
-            b[o] = biases.data(o);
-        }
-    }
+  // stride
+  if (conv_param.stride_size() == 1 || conv_param.has_stride_h()) {
+    h_stride = conv_param.stride_size() == 1 ? conv_param.stride(0)
+                                             : conv_param.stride_h();
+  }
+
+  if (conv_param.stride_size() == 1 || conv_param.has_stride_w()) {
+    w_stride = conv_param.stride_size() == 1 ? conv_param.stride(0)
+                                             : conv_param.stride_w();
+  }
+
+  // group
+  if (conv_param.has_group()) {
+    table = connection_table(conv_param.group(), in_channels, out_channels);
+  }
+
+  auto conv = std::make_shared<conv_layer>(
+      in_width, in_height, window_size, in_channels, out_channels, table,
+      pad_type, has_bias, w_stride, h_stride);
+  // filler
+  if (conv_param.has_weight_filler()) {
+    conv->weight_init(create_filler(conv_param.weight_filler().type()));
+  }
+
+  if (conv_param.has_bias_filler()) {
+    conv->bias_init(create_filler(conv_param.bias_filler().type()));
+  }
+
+  // set weight (optional)
+  if (layer.blobs_size() > 0) {  // blobs(0)...weight, blobs(1)...bias
+    load_weights_conv(layer, conv.get());
+  }
+  // TODO
+  //*top_shape = conv->out_shape();
+  *top_shape = conv->out_shape()[0];
+  return conv;
 }
 
-inline void load_weights_pool(const caffe::LayerParameter& src, layer *dst) {
-    auto pool_param = src.pooling_param();
+inline std::shared_ptr<layer> create_deconvlayer(
+    const caffe::LayerParameter& layer, const shape_t& bottom_shape,
+    shape_t* top_shape) {
+  using deconv_layer = deconvolutional_layer<activation::identity>;
 
-    //TODO
-    //if (dst->weight().size()) {
-    if (dst->weights().size()) {
-        layer_size_t pool_size = 0;
+  if (!layer.has_convolution_param()) {
+    throw nn_error("deconvolution param missing");
+  }
 
-        if (!get_kernel_size_2d(pool_param, &pool_size)) {
-            pool_size = pool_param.kernel_size();
-        }
+  // layer parameters
+  layer_size_t in_width = 0, in_height = 0, window_size = 0;
+  layer_size_t in_channels = 0, out_channels = 0;
+  layer_size_t w_stride = 1, h_stride = 1;
+  bool has_bias = true;
+  padding pad_type = padding::valid;
+  connection_table table;
 
-        // tiny-dnn has trainable parameter in average-pooling layer
-        float_t weight = float_t(1) / sqr(pool_size);
+  auto deconv_param = layer.convolution_param();
 
-        //TODO
-        /*if (!dst->weight().empty()) {
-            std::fill(dst->weight().begin(), dst->weight().end(), weight);
-        }
-        if (!dst->bias().empty()) {
-            std::fill(dst->bias().begin(), dst->bias().end(), float_t(0));
-            dst->init_bias();
-        }*/
+  // shape
+  out_channels = deconv_param.num_output();
+  in_channels = bottom_shape.depth_;
+  in_width = bottom_shape.width_;
+  in_height = bottom_shape.height_;
+  has_bias = deconv_param.bias_term();
+  window_size = get_kernel_size_2d(deconv_param);
 
-        vec_t& w = *dst->weights()[0];
-        vec_t& b = *dst->weights()[1];
+  // unpadding
+  if (deconv_param.pad_size() == 1 ||
+      (deconv_param.has_pad_w() && deconv_param.has_pad_h())) {
+    uint32_t unpad_w = deconv_param.pad_size() == 1 ? deconv_param.pad(0)
+                                                    : deconv_param.pad_w();
 
-        if (!w.empty()) {
-            std::fill(w.begin(), w.end(), weight);
-        }
-        if (!b.empty()) {
-            std::fill(b.begin(), b.end(), float_t(0));
-            //dst->init_bias();
-        }
-    }
-}
+    uint32_t unpad_h = deconv_param.pad_size() == 1 ? deconv_param.pad(0)
+                                                    : deconv_param.pad_h();
 
-inline
-std::shared_ptr<layer> create_lrn(const caffe::LayerParameter& layer,
-                                  const shape_t& bottom_shape,
-                                  shape_t *top_shape) {
-    using lrn_layer = lrn_layer<activation::identity>;
-
-    if (!layer.has_lrn_param()) {
-        throw nn_error("lrn param missing");
+    if (unpad_w != unpad_h) {
+      throw nn_error("deconv:not supported unpadding size");
     }
 
-    auto lrn_param = layer.lrn_param();
-    layer_size_t local_size = 5;
-    float_t alpha = 1;
-    float_t beta = 5;
-    norm_region region = norm_region::across_channels;
-
-    if (lrn_param.has_local_size()) local_size = lrn_param.local_size();
-    if (lrn_param.has_alpha()) alpha = lrn_param.alpha();
-    if (lrn_param.has_beta()) beta = lrn_param.beta();
-    if (lrn_param.has_norm_region()) {
-        if (lrn_param.norm_region() == caffe::LRNParameter_NormRegion_WITHIN_CHANNEL) // NOLINT
-            region = norm_region::within_channels;
+    // 0 ... valid, (window_size-1)/2 ... same
+    if (unpad_w == (window_size - 1) / 2) {
+      pad_type = padding::same;
+    } else if (unpad_w == 0) {
+      pad_type = padding::valid;
+    } else {
+      throw nn_error("deconv:not supported unpadding size");
     }
+  }
 
-    auto lrn = std::make_shared<lrn_layer>(bottom_shape.width_,
-                                           bottom_shape.height_,
-                                           local_size,
-                                           bottom_shape.depth_,
-                                           alpha, beta, region);
-    return lrn;
-}
+  // stride
+  if (deconv_param.stride_size() == 1 || deconv_param.has_stride_h()) {
+    h_stride = deconv_param.stride_size() == 1 ? deconv_param.stride(0)
+                                               : deconv_param.stride_h();
+  }
 
-inline
-std::shared_ptr<layer> create_dropout(const caffe::LayerParameter& layer,
-                                      const shape_t& bottom_shape,
-                                      shape_t *top_shape) {
-    if (!layer.has_dropout_param()) {
-        throw nn_error("dropout param missing");
-    }
+  if (deconv_param.stride_size() == 1 || deconv_param.has_stride_w()) {
+    w_stride = deconv_param.stride_size() == 1 ? deconv_param.stride(0)
+                                               : deconv_param.stride_w();
+  }
 
-    float_t dropout_rate = float_t(0.5);
+  // group
+  if (deconv_param.has_group()) {
+    table = connection_table(deconv_param.group(), in_channels, out_channels);
+  }
 
-    if (layer.dropout_param().has_dropout_ratio()) {
-        dropout_rate = layer.dropout_param().dropout_ratio();
-    }
+  auto deconv = std::make_shared<deconv_layer>(
+      in_width, in_height, window_size, in_channels, out_channels, table,
+      pad_type, has_bias, w_stride, h_stride);
+  // filler
+  if (deconv_param.has_weight_filler()) {
+    deconv->weight_init(create_filler(deconv_param.weight_filler().type()));
+  }
 
-    auto dropout = std::make_shared<dropout_layer>(bottom_shape.size(),
-                                                   dropout_rate,
-                                                   net_phase::test);
-    return dropout;
-}
+  if (deconv_param.has_bias_filler()) {
+    deconv->bias_init(create_filler(deconv_param.bias_filler().type()));
+  }
 
-inline
-std::shared_ptr<layer> create_convlayer(const caffe::LayerParameter& layer,
-                                        const shape_t& bottom_shape,
-                                        shape_t *top_shape) {
-    using conv_layer = convolutional_layer<activation::identity>;
-
-    if (!layer.has_convolution_param()) {
-        throw nn_error("convolution param missing");
-    }
-
-    // layer parameters
-    layer_size_t in_width = 0, in_height = 0, window_size = 0;
-    layer_size_t in_channels = 0, out_channels = 0;
-    layer_size_t w_stride = 1, h_stride = 1;
-    bool has_bias = true;
-    padding pad_type = padding::valid;
-    connection_table table;
-
-    auto conv_param = layer.convolution_param();
-
-    // shape
-    out_channels = conv_param.num_output();
-    in_channels = bottom_shape.depth_;
-    in_width = bottom_shape.width_;
-    in_height = bottom_shape.height_;
-    has_bias = conv_param.bias_term();
-    window_size = get_kernel_size_2d(conv_param);
-
-    // padding
-    if (conv_param.pad_size() == 1 ||
-       (conv_param.has_pad_w() && conv_param.has_pad_h())) {
-        uint32_t pad_w = conv_param.pad_size() == 1 ?
-                         conv_param.pad(0) : conv_param.pad_w();
-
-        uint32_t pad_h = conv_param.pad_size() == 1 ?
-                         conv_param.pad(0) : conv_param.pad_h();
-
-        if (pad_w != pad_h) {
-            throw nn_error("conv:not supported padding size");
-        }
-
-        // 0 ... valid, (window_size-1)/2 ... same
-        if (pad_w == (window_size - 1) / 2) {
-            pad_type = padding::same;
-        } else if (pad_w == 0) {
-            pad_type = padding::valid;
-        } else {
-            throw nn_error("conv:not supported padding size");
-        }
-    }
-
-    // stride
-    if (conv_param.stride_size() == 1 || conv_param.has_stride_h()) {
-        h_stride = conv_param.stride_size() == 1 ?
-                   conv_param.stride(0) : conv_param.stride_h();
-    }
-
-    if (conv_param.stride_size() == 1 || conv_param.has_stride_w()) {
-        w_stride = conv_param.stride_size() == 1 ?
-                   conv_param.stride(0) : conv_param.stride_w();
-    }
-
-    // group
-    if (conv_param.has_group()) {
-        table = connection_table(conv_param.group(), in_channels, out_channels);
-    }
-
-    auto conv = std::make_shared<conv_layer>(in_width, in_height,
-                                             window_size,
-                                             in_channels, out_channels,
-                                             table,
-                                             pad_type,
-                                             has_bias,
-                                             w_stride, h_stride);
-    // filler
-    if (conv_param.has_weight_filler()) {
-        conv->weight_init(create_filler(conv_param.weight_filler().type()));
-    }
-
-    if (conv_param.has_bias_filler()) {
-        conv->bias_init(create_filler(conv_param.bias_filler().type()));
-    }
-
-    // set weight (optional)
-    if (layer.blobs_size() > 0) {  // blobs(0)...weight, blobs(1)...bias
-        load_weights_conv(layer, conv.get());
-    }
-    //TODO
-    //*top_shape = conv->out_shape();
-    *top_shape = conv->out_shape()[0];
-    return conv;
-}
-
-inline
-std::shared_ptr<layer> create_deconvlayer(const caffe::LayerParameter& layer,
-                                        const shape_t& bottom_shape,
-                                        shape_t *top_shape) {
-    using deconv_layer = deconvolutional_layer<activation::identity>;
-
-    if (!layer.has_convolution_param()) {
-        throw nn_error("deconvolution param missing");
-    }
-
-    // layer parameters
-    layer_size_t in_width = 0, in_height = 0, window_size = 0;
-    layer_size_t in_channels = 0, out_channels = 0;
-    layer_size_t w_stride = 1, h_stride = 1;
-    bool has_bias = true;
-    padding pad_type = padding::valid;
-    connection_table table;
-
-    auto deconv_param = layer.convolution_param();
-
-    // shape
-    out_channels = deconv_param.num_output();
-    in_channels = bottom_shape.depth_;
-    in_width = bottom_shape.width_;
-    in_height = bottom_shape.height_;
-    has_bias = deconv_param.bias_term();
-    window_size = get_kernel_size_2d(deconv_param);
-
-    // unpadding
-    if (deconv_param.pad_size() == 1 ||
-       (deconv_param.has_pad_w() && deconv_param.has_pad_h())) {
-        uint32_t unpad_w = deconv_param.pad_size() == 1 ?
-                         deconv_param.pad(0) : deconv_param.pad_w();
-
-        uint32_t unpad_h = deconv_param.pad_size() == 1 ?
-                         deconv_param.pad(0) : deconv_param.pad_h();
-
-        if (unpad_w != unpad_h) {
-            throw nn_error("deconv:not supported unpadding size");
-        }
-
-        // 0 ... valid, (window_size-1)/2 ... same
-        if (unpad_w == (window_size - 1) / 2) {
-            pad_type = padding::same;
-        } else if (unpad_w == 0) {
-            pad_type = padding::valid;
-        } else {
-            throw nn_error("deconv:not supported unpadding size");
-        }
-    }
-
-    // stride
-    if (deconv_param.stride_size() == 1 || deconv_param.has_stride_h()) {
-        h_stride = deconv_param.stride_size() == 1 ?
-                   deconv_param.stride(0) : deconv_param.stride_h();
-    }
-
-    if (deconv_param.stride_size() == 1 || deconv_param.has_stride_w()) {
-        w_stride = deconv_param.stride_size() == 1 ?
-                   deconv_param.stride(0) : deconv_param.stride_w();
-    }
-
-    // group
-    if (deconv_param.has_group()) {
-        table = connection_table(deconv_param.group(), in_channels, out_channels);
-    }
-
-    auto deconv = std::make_shared<deconv_layer>(in_width, in_height,
-                                             window_size,
-                                             in_channels, out_channels,
-                                             table,
-                                             pad_type,
-                                             has_bias,
-                                             w_stride, h_stride);
-    // filler
-    if (deconv_param.has_weight_filler()) {
-        deconv->weight_init(create_filler(deconv_param.weight_filler().type()));
-    }
-
-    if (deconv_param.has_bias_filler()) {
-        deconv->bias_init(create_filler(deconv_param.bias_filler().type()));
-    }
-
-    // set weight (optional)
-    if (layer.blobs_size() > 0) {  // blobs(0)...weight, blobs(1)...bias
-        load_weights_deconv(layer, deconv.get());
-    }
-    //TODO
-    //*top_shape = deconv->out_shape();
-    *top_shape = deconv->out_shape()[0];
-    return deconv;
+  // set weight (optional)
+  if (layer.blobs_size() > 0) {  // blobs(0)...weight, blobs(1)...bias
+    load_weights_deconv(layer, deconv.get());
+  }
+  // TODO
+  //*top_shape = deconv->out_shape();
+  *top_shape = deconv->out_shape()[0];
+  return deconv;
 }
 
 inline bool layer_skipped(const std::string& type) {
-    if (type == "Data" || type == "EuclideanLoss" || type == "Input") return true;
-    return false;
+  if (type == "Data" || type == "EuclideanLoss" || type == "Input") return true;
+  return false;
 }
 
 inline bool layer_has_weights(const std::string& type) {
-    static const char* activations[] = {
-        "SoftmaxWithLoss", "SigmoidCrossEntropyLoss", "LRN", "Dropout",
-        "ReLU", "Sigmoid", "TanH", "Softmax"
-    };
-    for (unsigned int i = 0; i < sizeof(activations) / sizeof(activations[0]); i++) {
-        if (activations[i] == type) return false;
-    }
-    return true;
+  static const char* activations[] = {"SoftmaxWithLoss",
+                                      "SigmoidCrossEntropyLoss",
+                                      "LRN",
+                                      "Dropout",
+                                      "ReLU",
+                                      "Sigmoid",
+                                      "TanH",
+                                      "Softmax"};
+  for (unsigned int i = 0; i < sizeof(activations) / sizeof(activations[0]);
+       i++) {
+    if (activations[i] == type) return false;
+  }
+  return true;
 }
 
 inline bool layer_supported(const std::string& type) {
-    static const char* supported[] = {
-        "InnerProduct", "Convolution", "Deconvolution", "Pooling",
-        "LRN", "Dropout",
-        "SoftmaxWithLoss", "SigmoidCrossEntropyLoss",
-        "ReLU", "Sigmoid", "TanH", "Softmax", "BatchNorm", "Power"
-    };
+  static const char* supported[] = {"InnerProduct",
+                                    "Convolution",
+                                    "Deconvolution",
+                                    "Pooling",
+                                    "LRN",
+                                    "Dropout",
+                                    "SoftmaxWithLoss",
+                                    "SigmoidCrossEntropyLoss",
+                                    "ReLU",
+                                    "Sigmoid",
+                                    "TanH",
+                                    "Softmax",
+                                    "BatchNorm",
+                                    "Power"};
 
-    for (size_t i = 0; i < sizeof(supported) / sizeof(supported[0]); i++) {
-        if (supported[i] == type) return true;
-    }
-    return false;
+  for (size_t i = 0; i < sizeof(supported) / sizeof(supported[0]); i++) {
+    if (supported[i] == type) return true;
+  }
+  return false;
 }
 
 inline bool layer_match(const std::string& caffetype,
                         const std::string& tiny_dnn_type) {
-    const char* conversions[][2] = {
-        { "InnerProduct", "fully-connected" },
-        { "Convolution", "conv" },
-        { "Deconvolution", "deconv" },
-        { "Pooling", "ave-pool" },
-        { "Pooling", "max-pool" }
-    };
+  const char* conversions[][2] = {{"InnerProduct", "fully-connected"},
+                                  {"Convolution", "conv"},
+                                  {"Deconvolution", "deconv"},
+                                  {"Pooling", "ave-pool"},
+                                  {"Pooling", "max-pool"}};
 
-    for (size_t i = 0; i < sizeof(conversions) / sizeof(conversions[0]); i++) {
-        if (conversions[i][0] == caffetype &&
-            conversions[i][1] == tiny_dnn_type) return true;
-    }
-    return false;
+  for (size_t i = 0; i < sizeof(conversions) / sizeof(conversions[0]); i++) {
+    if (conversions[i][0] == caffetype && conversions[i][1] == tiny_dnn_type)
+      return true;
+  }
+  return false;
 }
 
 inline std::shared_ptr<layer> create(const caffe::LayerParameter& layer,
                                      const shape_t& in_shape,
                                      shape_t* out_shape) {
-    const std::string layer_type = layer.type();
+  const std::string layer_type = layer.type();
 
-    if (layer_type == "Convolution") {
-        return detail::create_convlayer(layer, in_shape, out_shape);
-    }
+  if (layer_type == "Convolution") {
+    return detail::create_convlayer(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "Deconvolution") {
-        return detail::create_deconvlayer(layer, in_shape, out_shape);
-    }
+  if (layer_type == "Deconvolution") {
+    return detail::create_deconvlayer(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "InnerProduct") {
-        return detail::create_fullyconnected(layer, in_shape, out_shape);
-    }
+  if (layer_type == "InnerProduct") {
+    return detail::create_fullyconnected(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "Pooling") {
-        return detail::create_pooling(layer, in_shape, out_shape);
-    }
+  if (layer_type == "Pooling") {
+    return detail::create_pooling(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "BatchNorm") {
-        return detail::create_batchnorm(layer, in_shape, out_shape);
-    }
+  if (layer_type == "BatchNorm") {
+    return detail::create_batchnorm(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "LRN") {
-        return detail::create_lrn(layer, in_shape, out_shape);
-    }
+  if (layer_type == "LRN") {
+    return detail::create_lrn(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "Dropout") {
-        return detail::create_dropout(layer, in_shape, out_shape);
-    }
+  if (layer_type == "Dropout") {
+    return detail::create_dropout(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "SoftmaxWithLoss" ||
-        layer_type == "Softmax") {
-        return detail::create_softmax(layer, in_shape, out_shape);
-    }
+  if (layer_type == "SoftmaxWithLoss" || layer_type == "Softmax") {
+    return detail::create_softmax(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "SigmoidCrossEntropyLoss" ||
-        layer_type == "Sigmoid") {
-        return detail::create_sigmoid(layer, in_shape, out_shape);
-    }
+  if (layer_type == "SigmoidCrossEntropyLoss" || layer_type == "Sigmoid") {
+    return detail::create_sigmoid(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "ReLU") {
-        return detail::create_relu(layer, in_shape, out_shape);
-    }
+  if (layer_type == "ReLU") {
+    return detail::create_relu(layer, in_shape, out_shape);
+  }
 
-    if (layer_type == "TanH") {
-        return detail::create_tanh(layer, in_shape, out_shape);
-    }
-    
-    if (layer_type == "Power") {
-        return detail::create_power(layer, in_shape, out_shape);
-    }
+  if (layer_type == "TanH") {
+    return detail::create_tanh(layer, in_shape, out_shape);
+  }
 
+  if (layer_type == "Power") {
+    return detail::create_power(layer, in_shape, out_shape);
+  }
+
+  throw nn_error("layer parser not found");
+
+  /*typedef std::function<std::shared_ptr<layer>(
+      const caffe::LayerParameter&, const shape_t&, shape_t*)> factoryimpl;
+
+  std::unordered_map<std::string, factoryimpl> factory_registry;
+
+  factory_registry["Convolution"] = detail::create_convlayer;
+  factory_registry["Deconvolution"] = detail::create_deconvlayer;
+  factory_registry["InnerProduct"] = detail::create_fullyconnected;
+  factory_registry["Pooling"] = detail::create_pooling;
+  factory_registry["LRN"] = detail::create_lrn;
+  factory_registry["Dropout"] = detail::create_dropout;
+  factory_registry["SoftmaxWithLoss"] = detail::create_softmax;
+  factory_registry["SigmoidCrossEntropyLoss"] = detail::create_sigmoid;
+  factory_registry["ReLU"] = detail::create_relu;
+  factory_registry["Sigmoid"] = detail::create_sigmoid;
+  factory_registry["TanH"] = detail::create_tanh;
+  factory_registry["Softmax"] = detail::create_softmax;
+
+  if (factory_registry.find(layer.type()) == factory_registry.end()) {
+      throw nn_error("layer parser not found");
+  }
+
+  return factory_registry[layer.type()](layer, in_shape, out_shape);*/
+}
+
+inline void load(const caffe::LayerParameter& src, layer* dst) {
+  typedef std::function<void(const caffe::LayerParameter&, layer*)>
+      factoryimpl;  // NOLINT
+  std::unordered_map<std::string, factoryimpl> factory_registry;
+
+  factory_registry["Convolution"] = detail::load_weights_conv;
+  factory_registry["Deconvolution"] = detail::load_weights_deconv;
+  factory_registry["InnerProduct"] = detail::load_weights_fullyconnected;
+  factory_registry["Pooling"] = detail::load_weights_pool;
+
+  if (factory_registry.find(src.type()) == factory_registry.end()) {
     throw nn_error("layer parser not found");
+  }
 
-    /*typedef std::function<std::shared_ptr<layer>(
-        const caffe::LayerParameter&, const shape_t&, shape_t*)> factoryimpl;
-
-    std::unordered_map<std::string, factoryimpl> factory_registry;
-
-    factory_registry["Convolution"] = detail::create_convlayer;
-    factory_registry["Deconvolution"] = detail::create_deconvlayer;
-    factory_registry["InnerProduct"] = detail::create_fullyconnected;
-    factory_registry["Pooling"] = detail::create_pooling;
-    factory_registry["LRN"] = detail::create_lrn;
-    factory_registry["Dropout"] = detail::create_dropout;
-    factory_registry["SoftmaxWithLoss"] = detail::create_softmax;
-    factory_registry["SigmoidCrossEntropyLoss"] = detail::create_sigmoid;
-    factory_registry["ReLU"] = detail::create_relu;
-    factory_registry["Sigmoid"] = detail::create_sigmoid;
-    factory_registry["TanH"] = detail::create_tanh;
-    factory_registry["Softmax"] = detail::create_softmax;
-
-    if (factory_registry.find(layer.type()) == factory_registry.end()) {
-        throw nn_error("layer parser not found");
-    }
-
-    return factory_registry[layer.type()](layer, in_shape, out_shape);*/
+  return factory_registry[src.type()](src, dst);
 }
-
-inline void load(const caffe::LayerParameter& src, layer *dst) {
-    typedef std::function<void(const caffe::LayerParameter&, layer*)> factoryimpl; // NOLINT
-    std::unordered_map<std::string, factoryimpl> factory_registry;
-
-    factory_registry["Convolution"] = detail::load_weights_conv;
-    factory_registry["Deconvolution"] = detail::load_weights_deconv;
-    factory_registry["InnerProduct"] = detail::load_weights_fullyconnected;
-    factory_registry["Pooling"] = detail::load_weights_pool;
-
-    if (factory_registry.find(src.type()) == factory_registry.end()) {
-        throw nn_error("layer parser not found");
-    }
-
-    return factory_registry[src.type()](src, dst);
-}
-
 
 struct layer_node {
-    const caffe::LayerParameter *layer;
-    const layer_node *next;  // top-side
-    const layer_node *prev;  // bottom-side
+  const caffe::LayerParameter* layer;
+  const layer_node* next;  // top-side
+  const layer_node* prev;  // bottom-side
 
-    layer_node() : layer(0), next(0), prev(0) {}
-    explicit layer_node(const caffe::LayerParameter *l)
-        : layer(l), next(0), prev(0) {}
+  layer_node() : layer(0), next(0), prev(0) {}
+  explicit layer_node(const caffe::LayerParameter* l)
+      : layer(l), next(0), prev(0) {}
 };
 
 // parse caffe net and interpret as single layer vector
 class caffe_layer_vector {
  public:
-    explicit caffe_layer_vector(const caffe::NetParameter& net_orig)
-            : net(net_orig) {
-        if (net.layers_size() > 0) {
-            upgradev1net(net_orig, &net);
-        }
-
-        nodes.reserve(net.layer_size());
-
-        for (int i = 0; i < net.layer_size(); i++) {
-            auto& l = net.layer(i);
-
-            if (layer_table.find(l.name()) != layer_table.end()) continue;
-
-            nodes.emplace_back(&l);
-            layer_table[l.name()] = &nodes.back();
-        }
-
-        for (size_t i = 0; i < nodes.size(); i++) {
-            auto& l = nodes[i];
-
-            if (l.layer->bottom_size() > 0 && blob_table[l.layer->bottom(0)]) {
-                auto& bottom = blob_table[l.layer->bottom(0)];
-                l.prev = bottom;
-                layer_table[bottom->layer->name()]->next = &l;
-            }
-
-            if (l.layer->top_size() > 0) {
-                blob_table[l.layer->top(0)] = &l;
-            }
-        }
-
-        auto root = std::find_if(nodes.begin(),
-                                 nodes.end(), [](const layer_node& n) {
-            return n.prev == 0;
-        });
-
-        if (root == nodes.end()) {
-            throw nn_error("root layer not found");
-        }
-
-        root_node = &*root;
-        const layer_node *current = &*root;
-
-        while (current) {
-            node_list.push_back(current->layer);
-            current = current->next;
-        }
+  explicit caffe_layer_vector(const caffe::NetParameter& net_orig)
+      : net(net_orig) {
+    if (net.layers_size() > 0) {
+      upgradev1net(net_orig, &net);
     }
 
-    size_t size() const {
-        return node_list.size();
+    nodes.reserve(net.layer_size());
+
+    for (int i = 0; i < net.layer_size(); i++) {
+      auto& l = net.layer(i);
+
+      if (layer_table.find(l.name()) != layer_table.end()) continue;
+
+      nodes.emplace_back(&l);
+      layer_table[l.name()] = &nodes.back();
     }
 
-    const caffe::LayerParameter& operator[] (size_t index) const {
-        return *(node_list[index]);
+    for (size_t i = 0; i < nodes.size(); i++) {
+      auto& l = nodes[i];
+
+      if (l.layer->bottom_size() > 0 && blob_table[l.layer->bottom(0)]) {
+        auto& bottom = blob_table[l.layer->bottom(0)];
+        l.prev = bottom;
+        layer_table[bottom->layer->name()]->next = &l;
+      }
+
+      if (l.layer->top_size() > 0) {
+        blob_table[l.layer->top(0)] = &l;
+      }
     }
+
+    auto root = std::find_if(nodes.begin(), nodes.end(),
+                             [](const layer_node& n) { return n.prev == 0; });
+
+    if (root == nodes.end()) {
+      throw nn_error("root layer not found");
+    }
+
+    root_node = &*root;
+    const layer_node* current = &*root;
+
+    while (current) {
+      node_list.push_back(current->layer);
+      current = current->next;
+    }
+  }
+
+  size_t size() const { return node_list.size(); }
+
+  const caffe::LayerParameter& operator[](size_t index) const {
+    return *(node_list[index]);
+  }
 
  private:
-    void upgradev1net(const caffe::NetParameter& old,
-                      caffe::NetParameter *dst) const {
-        dst->CopyFrom(old);
-        dst->clear_layers();
-        dst->clear_layer();
+  void upgradev1net(const caffe::NetParameter& old,
+                    caffe::NetParameter* dst) const {
+    dst->CopyFrom(old);
+    dst->clear_layers();
+    dst->clear_layer();
 
-        for (int i = 0; i < old.layers_size(); i++) {
-            upgradev1layer(old.layers(i), dst->add_layer());
-        }
+    for (int i = 0; i < old.layers_size(); i++) {
+      upgradev1layer(old.layers(i), dst->add_layer());
+    }
+  }
+
+  const char* v1type2name(caffe::V1LayerParameter_LayerType type) const {
+    switch (type) {
+      case caffe::V1LayerParameter_LayerType_NONE:
+        return "";
+      case caffe::V1LayerParameter_LayerType_ABSVAL:
+        return "AbsVal";
+      case caffe::V1LayerParameter_LayerType_ACCURACY:
+        return "Accuracy";
+      case caffe::V1LayerParameter_LayerType_ARGMAX:
+        return "ArgMax";
+      case caffe::V1LayerParameter_LayerType_BNLL:
+        return "BNLL";
+      case caffe::V1LayerParameter_LayerType_CONCAT:
+        return "Concat";
+      case caffe::V1LayerParameter_LayerType_CONTRASTIVE_LOSS:
+        return "ContrastiveLoss";
+      case caffe::V1LayerParameter_LayerType_CONVOLUTION:
+        return "Convolution";
+      case caffe::V1LayerParameter_LayerType_DECONVOLUTION:
+        return "Deconvolution";
+      case caffe::V1LayerParameter_LayerType_DATA:
+        return "Data";
+      case caffe::V1LayerParameter_LayerType_DROPOUT:
+        return "Dropout";
+      case caffe::V1LayerParameter_LayerType_DUMMY_DATA:
+        return "DummyData";
+      case caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS:
+        return "EuclideanLoss";
+      case caffe::V1LayerParameter_LayerType_ELTWISE:
+        return "Eltwise";
+      case caffe::V1LayerParameter_LayerType_EXP:
+        return "Exp";
+      case caffe::V1LayerParameter_LayerType_FLATTEN:
+        return "Flatten";
+      case caffe::V1LayerParameter_LayerType_HDF5_DATA:
+        return "HDF5Data";
+      case caffe::V1LayerParameter_LayerType_HDF5_OUTPUT:
+        return "HDF5Output";
+      case caffe::V1LayerParameter_LayerType_HINGE_LOSS:
+        return "HingeLoss";
+      case caffe::V1LayerParameter_LayerType_IM2COL:
+        return "Im2col";
+      case caffe::V1LayerParameter_LayerType_IMAGE_DATA:
+        return "ImageData";
+      case caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS:
+        return "InfogainLoss";
+      case caffe::V1LayerParameter_LayerType_INNER_PRODUCT:
+        return "InnerProduct";
+      case caffe::V1LayerParameter_LayerType_LRN:
+        return "LRN";
+      case caffe::V1LayerParameter_LayerType_MEMORY_DATA:
+        return "MemoryData";
+      case caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS:
+        return "MultinomialLogisticLoss";
+      case caffe::V1LayerParameter_LayerType_MVN:
+        return "MVN";
+      case caffe::V1LayerParameter_LayerType_POOLING:
+        return "Pooling";
+      case caffe::V1LayerParameter_LayerType_POWER:
+        return "Power";
+      case caffe::V1LayerParameter_LayerType_RELU:
+        return "ReLU";
+      case caffe::V1LayerParameter_LayerType_SIGMOID:
+        return "Sigmoid";
+      case caffe::V1LayerParameter_LayerType_SIGMOID_CROSS_ENTROPY_LOSS:
+        return "SigmoidCrossEntropyLoss";
+      case caffe::V1LayerParameter_LayerType_SILENCE:
+        return "Silence";
+      case caffe::V1LayerParameter_LayerType_SOFTMAX:
+        return "Softmax";
+      case caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS:
+        return "SoftmaxWithLoss";
+      case caffe::V1LayerParameter_LayerType_SPLIT:
+        return "Split";
+      case caffe::V1LayerParameter_LayerType_SLICE:
+        return "Slice";
+      case caffe::V1LayerParameter_LayerType_TANH:
+        return "TanH";
+      case caffe::V1LayerParameter_LayerType_WINDOW_DATA:
+        return "WindowData";
+      case caffe::V1LayerParameter_LayerType_THRESHOLD:
+        return "Threshold";
+      default:
+        throw nn_error("unknown v1 layer-type");
+    }
+  }
+
+  void upgradev1layer(const caffe::V1LayerParameter& old,
+                      caffe::LayerParameter* dst) const {
+    dst->Clear();
+
+    for (int i = 0; i < old.bottom_size(); i++) {
+      dst->add_bottom(old.bottom(i));
     }
 
-    const char* v1type2name(caffe::V1LayerParameter_LayerType type) const {
-        switch (type) {
-        case caffe::V1LayerParameter_LayerType_NONE:
-            return "";
-        case caffe::V1LayerParameter_LayerType_ABSVAL:
-            return "AbsVal";
-        case caffe::V1LayerParameter_LayerType_ACCURACY:
-            return "Accuracy";
-        case caffe::V1LayerParameter_LayerType_ARGMAX:
-            return "ArgMax";
-        case caffe::V1LayerParameter_LayerType_BNLL:
-            return "BNLL";
-        case caffe::V1LayerParameter_LayerType_CONCAT:
-            return "Concat";
-        case caffe::V1LayerParameter_LayerType_CONTRASTIVE_LOSS:
-            return "ContrastiveLoss";
-        case caffe::V1LayerParameter_LayerType_CONVOLUTION:
-            return "Convolution";
-        case caffe::V1LayerParameter_LayerType_DECONVOLUTION:
-            return "Deconvolution";
-        case caffe::V1LayerParameter_LayerType_DATA:
-            return "Data";
-        case caffe::V1LayerParameter_LayerType_DROPOUT:
-            return "Dropout";
-        case caffe::V1LayerParameter_LayerType_DUMMY_DATA:
-            return "DummyData";
-        case caffe::V1LayerParameter_LayerType_EUCLIDEAN_LOSS:
-            return "EuclideanLoss";
-        case caffe::V1LayerParameter_LayerType_ELTWISE:
-            return "Eltwise";
-        case caffe::V1LayerParameter_LayerType_EXP:
-            return "Exp";
-        case caffe::V1LayerParameter_LayerType_FLATTEN:
-            return "Flatten";
-        case caffe::V1LayerParameter_LayerType_HDF5_DATA:
-            return "HDF5Data";
-        case caffe::V1LayerParameter_LayerType_HDF5_OUTPUT:
-            return "HDF5Output";
-        case caffe::V1LayerParameter_LayerType_HINGE_LOSS:
-            return "HingeLoss";
-        case caffe::V1LayerParameter_LayerType_IM2COL:
-            return "Im2col";
-        case caffe::V1LayerParameter_LayerType_IMAGE_DATA:
-            return "ImageData";
-        case caffe::V1LayerParameter_LayerType_INFOGAIN_LOSS:
-            return "InfogainLoss";
-        case caffe::V1LayerParameter_LayerType_INNER_PRODUCT:
-            return "InnerProduct";
-        case caffe::V1LayerParameter_LayerType_LRN:
-            return "LRN";
-        case caffe::V1LayerParameter_LayerType_MEMORY_DATA:
-            return "MemoryData";
-        case caffe::V1LayerParameter_LayerType_MULTINOMIAL_LOGISTIC_LOSS:
-            return "MultinomialLogisticLoss";
-        case caffe::V1LayerParameter_LayerType_MVN:
-            return "MVN";
-        case caffe::V1LayerParameter_LayerType_POOLING:
-            return "Pooling";
-        case caffe::V1LayerParameter_LayerType_POWER:
-            return "Power";
-        case caffe::V1LayerParameter_LayerType_RELU:
-            return "ReLU";
-        case caffe::V1LayerParameter_LayerType_SIGMOID:
-            return "Sigmoid";
-        case caffe::V1LayerParameter_LayerType_SIGMOID_CROSS_ENTROPY_LOSS:
-            return "SigmoidCrossEntropyLoss";
-        case caffe::V1LayerParameter_LayerType_SILENCE:
-            return "Silence";
-        case caffe::V1LayerParameter_LayerType_SOFTMAX:
-            return "Softmax";
-        case caffe::V1LayerParameter_LayerType_SOFTMAX_LOSS:
-            return "SoftmaxWithLoss";
-        case caffe::V1LayerParameter_LayerType_SPLIT:
-            return "Split";
-        case caffe::V1LayerParameter_LayerType_SLICE:
-            return "Slice";
-        case caffe::V1LayerParameter_LayerType_TANH:
-            return "TanH";
-        case caffe::V1LayerParameter_LayerType_WINDOW_DATA:
-            return "WindowData";
-        case caffe::V1LayerParameter_LayerType_THRESHOLD:
-            return "Threshold";
-        default:
-            throw nn_error("unknown v1 layer-type");
-        }
+    for (int i = 0; i < old.top_size(); i++) {
+      dst->add_top(old.top(i));
     }
 
-    void upgradev1layer(const caffe::V1LayerParameter& old,
-                        caffe::LayerParameter *dst) const {
-        dst->Clear();
+    if (old.has_name()) dst->set_name(old.name());
+    if (old.has_type()) dst->set_type(v1type2name(old.type()));
 
-        for (int i = 0; i < old.bottom_size(); i++) {
-            dst->add_bottom(old.bottom(i));
-        }
-
-        for (int i = 0; i < old.top_size(); i++) {
-            dst->add_top(old.top(i));
-        }
-
-        if (old.has_name()) dst->set_name(old.name());
-        if (old.has_type()) dst->set_type(v1type2name(old.type()));
-
-        for (int i = 0; i < old.blobs_size(); i++) {
-            dst->add_blobs()->CopyFrom(old.blobs(i));
-        }
-
-        for (int i = 0; i < old.param_size(); i++) {
-            while (dst->param_size() <= i) dst->add_param();
-            dst->mutable_param(i)->set_name(old.param(i));
-        }
-
-        #define COPY_PARAM(name) if (old.has_##name##_param()) dst->mutable_##name##_param()->CopyFrom(old.name##_param())
-
-        COPY_PARAM(accuracy);
-        COPY_PARAM(argmax);
-        COPY_PARAM(concat);
-        COPY_PARAM(contrastive_loss);
-        COPY_PARAM(convolution);
-        COPY_PARAM(data);
-        COPY_PARAM(dropout);
-        COPY_PARAM(dummy_data);
-        COPY_PARAM(eltwise);
-        COPY_PARAM(exp);
-        COPY_PARAM(hdf5_data);
-        COPY_PARAM(hdf5_output);
-        COPY_PARAM(hinge_loss);
-        COPY_PARAM(image_data);
-        COPY_PARAM(infogain_loss);
-        COPY_PARAM(inner_product);
-        COPY_PARAM(lrn);
-        COPY_PARAM(memory_data);
-        COPY_PARAM(mvn);
-        COPY_PARAM(pooling);
-        COPY_PARAM(power);
-        COPY_PARAM(relu);
-        COPY_PARAM(sigmoid);
-        COPY_PARAM(softmax);
-        COPY_PARAM(slice);
-        COPY_PARAM(tanh);
-        COPY_PARAM(threshold);
-        COPY_PARAM(window_data);
-        COPY_PARAM(transform);
-        COPY_PARAM(loss);
-        #undef COPY_PARAM
+    for (int i = 0; i < old.blobs_size(); i++) {
+      dst->add_blobs()->CopyFrom(old.blobs(i));
     }
 
-    caffe::NetParameter net;
-    layer_node *root_node;
-    /* layer name -> layer */
-    std::map<std::string, layer_node*> layer_table;
-    /* blob name -> bottom holder */
-    std::map<std::string, layer_node*> blob_table;
-    std::vector<layer_node> nodes;
-    std::vector<const caffe::LayerParameter*> node_list;
+    for (int i = 0; i < old.param_size(); i++) {
+      while (dst->param_size() <= i) dst->add_param();
+      dst->mutable_param(i)->set_name(old.param(i));
+    }
+
+#define COPY_PARAM(name)        \
+  if (old.has_##name##_param()) \
+  dst->mutable_##name##_param()->CopyFrom(old.name##_param())
+
+    COPY_PARAM(accuracy);
+    COPY_PARAM(argmax);
+    COPY_PARAM(concat);
+    COPY_PARAM(contrastive_loss);
+    COPY_PARAM(convolution);
+    COPY_PARAM(data);
+    COPY_PARAM(dropout);
+    COPY_PARAM(dummy_data);
+    COPY_PARAM(eltwise);
+    COPY_PARAM(exp);
+    COPY_PARAM(hdf5_data);
+    COPY_PARAM(hdf5_output);
+    COPY_PARAM(hinge_loss);
+    COPY_PARAM(image_data);
+    COPY_PARAM(infogain_loss);
+    COPY_PARAM(inner_product);
+    COPY_PARAM(lrn);
+    COPY_PARAM(memory_data);
+    COPY_PARAM(mvn);
+    COPY_PARAM(pooling);
+    COPY_PARAM(power);
+    COPY_PARAM(relu);
+    COPY_PARAM(sigmoid);
+    COPY_PARAM(softmax);
+    COPY_PARAM(slice);
+    COPY_PARAM(tanh);
+    COPY_PARAM(threshold);
+    COPY_PARAM(window_data);
+    COPY_PARAM(transform);
+    COPY_PARAM(loss);
+#undef COPY_PARAM
+  }
+
+  caffe::NetParameter net;
+  layer_node* root_node;
+  /* layer name -> layer */
+  std::map<std::string, layer_node*> layer_table;
+  /* blob name -> bottom holder */
+  std::map<std::string, layer_node*> blob_table;
+  std::vector<layer_node> nodes;
+  std::vector<const caffe::LayerParameter*> node_list;
 };
 
 }  // namespace detail

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <algorithm>
 #include <memory>

--- a/tiny_dnn/io/cifar10_parser.h
+++ b/tiny_dnn/io/cifar10_parser.h
@@ -3,17 +3,16 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
-#include <fstream>
-#include <cstdint>
 #include <algorithm>
+#include <cstdint>
+#include <fstream>
+#include "tiny_dnn/util/util.h"
 
 #define CIFAR10_IMAGE_DEPTH (3)
 #define CIFAR10_IMAGE_WIDTH (32)
 #define CIFAR10_IMAGE_HEIGHT (32)
-#define CIFAR10_IMAGE_AREA (CIFAR10_IMAGE_WIDTH*CIFAR10_IMAGE_HEIGHT)
-#define CIFAR10_IMAGE_SIZE (CIFAR10_IMAGE_AREA*CIFAR10_IMAGE_DEPTH)
-
+#define CIFAR10_IMAGE_AREA (CIFAR10_IMAGE_WIDTH * CIFAR10_IMAGE_HEIGHT)
+#define CIFAR10_IMAGE_SIZE (CIFAR10_IMAGE_AREA * CIFAR10_IMAGE_DEPTH)
 
 namespace tiny_dnn {
 
@@ -28,56 +27,54 @@ namespace tiny_dnn {
  * @param x_padding  [in]  adding border width (left,right)
  * @param y_padding  [in]  adding border width (top,bottom)
  **/
-inline void parse_cifar10(const std::string& filename,
+inline void parse_cifar10(const std::string &filename,
                           std::vector<vec_t> *train_images,
-                          std::vector<label_t> *train_labels,
-                          float_t scale_min,
-                          float_t scale_max,
-                          int x_padding,
-                          int y_padding)
-{
-    if (x_padding < 0 || y_padding < 0)
-        throw nn_error("padding size must not be negative");
-    if (scale_min >= scale_max)
-        throw nn_error("scale_max must be greater than scale_min");
+                          std::vector<label_t> *train_labels, float_t scale_min,
+                          float_t scale_max, int x_padding, int y_padding) {
+  if (x_padding < 0 || y_padding < 0)
+    throw nn_error("padding size must not be negative");
+  if (scale_min >= scale_max)
+    throw nn_error("scale_max must be greater than scale_min");
 
-    std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary);
-    if (ifs.fail() || ifs.bad())
-        throw nn_error("failed to open file:" + filename);
+  std::ifstream ifs(filename.c_str(), std::ios::in | std::ios::binary);
+  if (ifs.fail() || ifs.bad())
+    throw nn_error("failed to open file:" + filename);
 
-    uint8_t label;
-    std::vector<unsigned char> buf(CIFAR10_IMAGE_SIZE);
+  uint8_t label;
+  std::vector<unsigned char> buf(CIFAR10_IMAGE_SIZE);
 
-    while (ifs.read((char*) &label, 1)) {
-        vec_t img;
+  while (ifs.read((char *)&label, 1)) {
+    vec_t img;
 
-        if (!ifs.read((char*) &buf[0], CIFAR10_IMAGE_SIZE)) break;
+    if (!ifs.read((char *)&buf[0], CIFAR10_IMAGE_SIZE)) break;
 
-        if (x_padding || y_padding)
-        {
-            int w = CIFAR10_IMAGE_WIDTH + 2 * x_padding;
-            int h = CIFAR10_IMAGE_HEIGHT + 2 * y_padding;
+    if (x_padding || y_padding) {
+      int w = CIFAR10_IMAGE_WIDTH + 2 * x_padding;
+      int h = CIFAR10_IMAGE_HEIGHT + 2 * y_padding;
 
-            img.resize(w * h * CIFAR10_IMAGE_DEPTH, scale_min);
+      img.resize(w * h * CIFAR10_IMAGE_DEPTH, scale_min);
 
-            for (int c = 0; c < CIFAR10_IMAGE_DEPTH; c++) {
-                for (int y = 0; y < CIFAR10_IMAGE_HEIGHT; y++) {
-                    for (int x = 0; x < CIFAR10_IMAGE_WIDTH; x++) {
-                        img[c * w * h + (y + y_padding) * w + x + x_padding]
-                            = scale_min + (scale_max - scale_min) * buf[c * CIFAR10_IMAGE_AREA + y * CIFAR10_IMAGE_WIDTH + x] / 255;
-                    }
-                }
-            }
+      for (int c = 0; c < CIFAR10_IMAGE_DEPTH; c++) {
+        for (int y = 0; y < CIFAR10_IMAGE_HEIGHT; y++) {
+          for (int x = 0; x < CIFAR10_IMAGE_WIDTH; x++) {
+            img[c * w * h + (y + y_padding) * w + x + x_padding] =
+                scale_min +
+                (scale_max - scale_min) *
+                    buf[c * CIFAR10_IMAGE_AREA + y * CIFAR10_IMAGE_WIDTH + x] /
+                    255;
+          }
         }
-        else
-        {
-            std::transform(buf.begin(), buf.end(), std::back_inserter(img),
-                [=](unsigned char c) { return scale_min + (scale_max - scale_min) * c / 255; });
-        }
-
-        train_images->push_back(img);
-        train_labels->push_back(label);
+      }
+    } else {
+      std::transform(buf.begin(), buf.end(), std::back_inserter(img),
+                     [=](unsigned char c) {
+                       return scale_min + (scale_max - scale_min) * c / 255;
+                     });
     }
+
+    train_images->push_back(img);
+    train_labels->push_back(label);
+  }
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/io/cifar10_parser.h
+++ b/tiny_dnn/io/cifar10_parser.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <fstream>

--- a/tiny_dnn/io/display.h
+++ b/tiny_dnn/io/display.h
@@ -1,47 +1,57 @@
-//addapted from boost progress.hpp, made c++11 only//
-
+// addapted from boost progress.hpp, made c++11 only//
 
 #ifndef PROGRESS_H
 #define PROGRESS_H
 
-#include <iostream>           // for ostream, cout, etc
-#include <string>             // for string
 #include <chrono>
+#include <iostream>  // for ostream, cout, etc
+#include <string>    // for string
 
 namespace tiny_dnn {
 
-class timer
-{
+class timer {
  public:
-    timer():  t1(std::chrono::high_resolution_clock::now()){};
-    float_t elapsed(){return std::chrono::duration_cast<std::chrono::duration<float_t>>(std::chrono::high_resolution_clock::now() - t1).count();}
-    void restart(){t1 = std::chrono::high_resolution_clock::now();}
-    void start(){t1 = std::chrono::high_resolution_clock::now();}
-    void stop(){t2 = std::chrono::high_resolution_clock::now();}
-    float_t total(){stop();return std::chrono::duration_cast<std::chrono::duration<float_t>>(t2 - t1).count();}
-    ~timer(){}
- private:
-    std::chrono::high_resolution_clock::time_point t1, t2;
-};
+  timer() : t1(std::chrono::high_resolution_clock::now()){};
+  float_t elapsed() {
+    return std::chrono::duration_cast<std::chrono::duration<float_t>>(
+               std::chrono::high_resolution_clock::now() - t1)
+        .count();
+  }
+  void restart() { t1 = std::chrono::high_resolution_clock::now(); }
+  void start() { t1 = std::chrono::high_resolution_clock::now(); }
+  void stop() { t2 = std::chrono::high_resolution_clock::now(); }
+  float_t total() {
+    stop();
+    return std::chrono::duration_cast<std::chrono::duration<float_t>>(t2 - t1)
+        .count();
+  }
+  ~timer() {}
 
+ private:
+  std::chrono::high_resolution_clock::time_point t1, t2;
+};
 
 //  progress_display  --------------------------------------------------------//
 
 //  progress_display displays an appropriate indication of
 //  progress at an appropriate place in an appropriate form.
 
-class progress_display
-{
+class progress_display {
  public:
-  explicit progress_display( size_t expected_count_,
-                             std::ostream & os = std::cout,
-                             const std::string & s1 = "\n", //leading strings
-                             const std::string & s2 = "",
-                             const std::string & s3 = "" )
-   // os is hint; implementation may ignore, particularly in embedded systems
-   :  m_os(os), m_s1(s1), m_s2(s2), m_s3(s3) { restart(expected_count_); }
+  explicit progress_display(size_t expected_count_,
+                            std::ostream &os = std::cout,
+                            const std::string &s1 = "\n",  // leading strings
+                            const std::string &s2 = "",
+                            const std::string &s3 = "")
+      // os is hint; implementation may ignore, particularly in embedded systems
+      : m_os(os),
+        m_s1(s1),
+        m_s2(s2),
+        m_s3(s3) {
+    restart(expected_count_);
+  }
 
-  void           restart( size_t expected_count_ )
+  void restart(size_t expected_count_)
   //  Effects: display appropriate scale
   //  Postconditions: count()==0, expected_count()==expected_count_
   {
@@ -52,50 +62,51 @@ class progress_display
          << m_s2 << "|----|----|----|----|----|----|----|----|----|----|"
          << std::endl  // endl implies flush, which ensures display
          << m_s3;
-    if ( !_expected_count ) _expected_count = 1;  // prevent divide by zero
-  } // restart
+    if (!_expected_count) _expected_count = 1;  // prevent divide by zero
+  }                                             // restart
 
-  size_t  operator+=( size_t increment )
+  size_t operator+=(size_t increment)
   //  Effects: Display appropriate progress tic if needed.
   //  Postconditions: count()== original count() + increment
   //  Returns: count().
   {
-    if ( (_count += increment) >= _next_tic_count ) { display_tic(); }
+    if ((_count += increment) >= _next_tic_count) {
+      display_tic();
+    }
     return _count;
   }
 
-  size_t  operator++()           { return operator+=( 1 ); }
-  size_t  count() const          { return _count; }
-  size_t  expected_count() const { return _expected_count; }
+  size_t operator++() { return operator+=(1); }
+  size_t count() const { return _count; }
+  size_t expected_count() const { return _expected_count; }
 
-  private:
-  std::ostream &     m_os;  // may not be present in all imps
-  const std::string  m_s1;  // string is more general, safer than 
-  const std::string  m_s2;  //  const char *, and efficiency or size are
-  const std::string  m_s3;  //  not issues
+ private:
+  std::ostream &m_os;      // may not be present in all imps
+  const std::string m_s1;  // string is more general, safer than
+  const std::string m_s2;  //  const char *, and efficiency or size are
+  const std::string m_s3;  //  not issues
 
-  size_t  _count, _expected_count, _next_tic_count;
-  size_t  _tic;
-  void display_tic()
-  {
+  size_t _count, _expected_count, _next_tic_count;
+  size_t _tic;
+  void display_tic() {
     // use of floating point ensures that both large and small counts
     // work correctly.  static_cast<>() is also used several places
-    // to suppress spurious compiler warnings. 
-    size_t tics_needed =
-      static_cast<size_t>(
-        (static_cast<double>(_count)/_expected_count)*50.0 );
-    do { m_os << '*' << std::flush; } while ( ++_tic < tics_needed );
-    _next_tic_count = 
-      static_cast<size_t>((_tic/50.0)*_expected_count);
-    if ( _count == _expected_count ) {
-      if ( _tic < 51 ) m_os << '*';
+    // to suppress spurious compiler warnings.
+    size_t tics_needed = static_cast<size_t>(
+        (static_cast<double>(_count) / _expected_count) * 50.0);
+    do {
+      m_os << '*' << std::flush;
+    } while (++_tic < tics_needed);
+    _next_tic_count = static_cast<size_t>((_tic / 50.0) * _expected_count);
+    if (_count == _expected_count) {
+      if (_tic < 51) m_os << '*';
       m_os << std::endl;
     }
-  } // display_tic
+  }  // display_tic
 
-  progress_display &operator = (const progress_display &) = delete;
+  progress_display &operator=(const progress_display &) = delete;
 };
 
-} // namespace
+}  // namespace
 
 #endif

--- a/tiny_dnn/io/layer_factory.h
+++ b/tiny_dnn/io/layer_factory.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/fully_connected_layer.h"

--- a/tiny_dnn/io/layer_factory.h
+++ b/tiny_dnn/io/layer_factory.h
@@ -3,32 +3,31 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/fully_connected_layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
 /**
 * create multi-layer perceptron
 */
-template<typename activation, typename Iter>
+template <typename activation, typename Iter>
 network<sequential> make_mlp(Iter first, Iter last) {
-    typedef network<sequential> net_t;
-    net_t n;
+  typedef network<sequential> net_t;
+  net_t n;
 
-    Iter next = first + 1;
-    for (; next != last; ++first, ++next)
-        n << fully_connected_layer<activation>(*first, *next);
-    return n;
+  Iter next = first + 1;
+  for (; next != last; ++first, ++next)
+    n << fully_connected_layer<activation>(*first, *next);
+  return n;
 }
 
 /**
  * create multi-layer perceptron
  */
-template<typename activation>
+template <typename activation>
 network<sequential> make_mlp(const std::vector<cnn_size_t>& units) {
-    return make_mlp<activation>(units.begin(), units.end());
+  return make_mlp<activation>(units.begin(), units.end());
 }
 
-
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/io/mnist_parser.h
+++ b/tiny_dnn/io/mnist_parser.h
@@ -3,62 +3,59 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
-#include <fstream>
 #include <cstdint>
+#include <fstream>
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 namespace detail {
 
 struct mnist_header {
-    uint32_t magic_number;
-    uint32_t num_items;
-    uint32_t num_rows;
-    uint32_t num_cols;
+  uint32_t magic_number;
+  uint32_t num_items;
+  uint32_t num_rows;
+  uint32_t num_cols;
 };
 
 inline void parse_mnist_header(std::ifstream& ifs, mnist_header& header) {
-    ifs.read((char*) &header.magic_number, 4);
-    ifs.read((char*) &header.num_items, 4);
-    ifs.read((char*) &header.num_rows, 4);
-    ifs.read((char*) &header.num_cols, 4);
+  ifs.read((char*)&header.magic_number, 4);
+  ifs.read((char*)&header.num_items, 4);
+  ifs.read((char*)&header.num_rows, 4);
+  ifs.read((char*)&header.num_cols, 4);
 
-    if (is_little_endian()) {
-        reverse_endian(&header.magic_number);
-        reverse_endian(&header.num_items);
-        reverse_endian(&header.num_rows);
-        reverse_endian(&header.num_cols);
-    }
+  if (is_little_endian()) {
+    reverse_endian(&header.magic_number);
+    reverse_endian(&header.num_items);
+    reverse_endian(&header.num_rows);
+    reverse_endian(&header.num_cols);
+  }
 
-    if (header.magic_number != 0x00000803 || header.num_items <= 0)
-        throw nn_error("MNIST label-file format error");
-    if (ifs.fail() || ifs.bad())
-        throw nn_error("file error");
+  if (header.magic_number != 0x00000803 || header.num_items <= 0)
+    throw nn_error("MNIST label-file format error");
+  if (ifs.fail() || ifs.bad()) throw nn_error("file error");
 }
 
-inline void parse_mnist_image(std::ifstream& ifs,
-    const mnist_header& header,
-    float_t scale_min,
-    float_t scale_max,
-    int x_padding,
-    int y_padding,
-    vec_t& dst) {
-    const int width = header.num_cols + 2 * x_padding;
-    const int height = header.num_rows + 2 * y_padding;
+inline void parse_mnist_image(std::ifstream& ifs, const mnist_header& header,
+                              float_t scale_min, float_t scale_max,
+                              int x_padding, int y_padding, vec_t& dst) {
+  const int width = header.num_cols + 2 * x_padding;
+  const int height = header.num_rows + 2 * y_padding;
 
-    std::vector<uint8_t> image_vec(header.num_rows * header.num_cols);
+  std::vector<uint8_t> image_vec(header.num_rows * header.num_cols);
 
-    ifs.read((char*) &image_vec[0], header.num_rows * header.num_cols);
+  ifs.read((char*)&image_vec[0], header.num_rows * header.num_cols);
 
-    dst.resize(width * height, scale_min);
+  dst.resize(width * height, scale_min);
 
-    for (uint32_t y = 0; y < header.num_rows; y++)
-        for (uint32_t x = 0; x < header.num_cols; x++)
-            dst[width * (y + y_padding) + x + x_padding]
-            = (image_vec[y * header.num_cols + x] / float_t(255)) * (scale_max - scale_min) + scale_min;
+  for (uint32_t y = 0; y < header.num_rows; y++)
+    for (uint32_t x = 0; x < header.num_cols; x++)
+      dst[width * (y + y_padding) + x + x_padding] =
+          (image_vec[y * header.num_cols + x] / float_t(255)) *
+              (scale_max - scale_min) +
+          scale_min;
 }
 
-} // namespace detail
+}  // namespace detail
 
 /**
  * parse MNIST database format labels with rescaling/resizing
@@ -67,36 +64,38 @@ inline void parse_mnist_image(std::ifstream& ifs,
  * @param label_file [in]  filename of database (i.e.train-labels-idx1-ubyte)
  * @param labels     [out] parsed label data
  **/
-inline void parse_mnist_labels(const std::string& label_file, std::vector<label_t> *labels) {
-    std::ifstream ifs(label_file.c_str(), std::ios::in | std::ios::binary);
+inline void parse_mnist_labels(const std::string& label_file,
+                               std::vector<label_t>* labels) {
+  std::ifstream ifs(label_file.c_str(), std::ios::in | std::ios::binary);
 
-    if (ifs.bad() || ifs.fail())
-        throw nn_error("failed to open file:" + label_file);
+  if (ifs.bad() || ifs.fail())
+    throw nn_error("failed to open file:" + label_file);
 
-    uint32_t magic_number, num_items;
+  uint32_t magic_number, num_items;
 
-    ifs.read((char*) &magic_number, 4);
-    ifs.read((char*) &num_items, 4);
+  ifs.read((char*)&magic_number, 4);
+  ifs.read((char*)&num_items, 4);
 
-    if (is_little_endian()) { // MNIST data is big-endian format
-        reverse_endian(&magic_number);
-        reverse_endian(&num_items);
-    }
+  if (is_little_endian()) {  // MNIST data is big-endian format
+    reverse_endian(&magic_number);
+    reverse_endian(&num_items);
+  }
 
-    if (magic_number != 0x00000801 || num_items <= 0)
-        throw nn_error("MNIST label-file format error");
+  if (magic_number != 0x00000801 || num_items <= 0)
+    throw nn_error("MNIST label-file format error");
 
-    for (uint32_t i = 0; i < num_items; i++) {
-        uint8_t label;
-        ifs.read((char*) &label, 1);
-        labels->push_back((label_t) label);
-    }
+  for (uint32_t i = 0; i < num_items; i++) {
+    uint8_t label;
+    ifs.read((char*)&label, 1);
+    labels->push_back((label_t)label);
+  }
 }
 
 /**
  * parse MNIST database format images with rescaling/resizing
  * http://yann.lecun.com/exdb/mnist/
- * - if original image size is WxH, output size is (W+2*x_padding)x(H+2*y_padding)
+ * - if original image size is WxH, output size is
+ *(W+2*x_padding)x(H+2*y_padding)
  * - extra padding pixels are filled with scale_min
  *
  * @param image_file [in]  filename of database (i.e.train-images-idx3-ubyte)
@@ -116,31 +115,29 @@ inline void parse_mnist_labels(const std::string& label_file, std::vector<label_
  *
  **/
 inline void parse_mnist_images(const std::string& image_file,
-    std::vector<vec_t> *images,
-    float_t scale_min,
-    float_t scale_max,
-    int x_padding,
-    int y_padding) {
+                               std::vector<vec_t>* images, float_t scale_min,
+                               float_t scale_max, int x_padding,
+                               int y_padding) {
+  if (x_padding < 0 || y_padding < 0)
+    throw nn_error("padding size must not be negative");
+  if (scale_min >= scale_max)
+    throw nn_error("scale_max must be greater than scale_min");
 
-    if (x_padding < 0 || y_padding < 0)
-        throw nn_error("padding size must not be negative");
-    if (scale_min >= scale_max)
-        throw nn_error("scale_max must be greater than scale_min");
+  std::ifstream ifs(image_file.c_str(), std::ios::in | std::ios::binary);
 
-    std::ifstream ifs(image_file.c_str(), std::ios::in | std::ios::binary);
+  if (ifs.bad() || ifs.fail())
+    throw nn_error("failed to open file:" + image_file);
 
-    if (ifs.bad() || ifs.fail())
-        throw nn_error("failed to open file:" + image_file);
+  detail::mnist_header header;
 
-    detail::mnist_header header;
+  detail::parse_mnist_header(ifs, header);
 
-    detail::parse_mnist_header(ifs, header);
-
-    for (uint32_t i = 0; i < header.num_items; i++) {
-        vec_t image;
-        detail::parse_mnist_image(ifs, header, scale_min, scale_max, x_padding, y_padding, image);
-        images->push_back(image);
-    }
+  for (uint32_t i = 0; i < header.num_items; i++) {
+    vec_t image;
+    detail::parse_mnist_image(ifs, header, scale_min, scale_max, x_padding,
+                              y_padding, image);
+    images->push_back(image);
+  }
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/io/mnist_parser.h
+++ b/tiny_dnn/io/mnist_parser.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <fstream>

--- a/tiny_dnn/layers/arithmetic_layer.h
+++ b/tiny_dnn/layers/arithmetic_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/layers/arithmetic_layer.h
+++ b/tiny_dnn/layers/arithmetic_layer.h
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
@@ -12,68 +12,69 @@ namespace tiny_dnn {
  * element-wise add N vectors
  **/
 class elementwise_add_layer : public layer {
-public:
-    elementwise_add_layer(cnn_size_t num_args, cnn_size_t dim)
-    : layer(std::vector<vector_type>(num_args, vector_type::data), {vector_type::data}), num_args_(num_args), dim_(dim) {}
+ public:
+  elementwise_add_layer(cnn_size_t num_args, cnn_size_t dim)
+      : layer(std::vector<vector_type>(num_args, vector_type::data),
+              {vector_type::data}),
+        num_args_(num_args),
+        dim_(dim) {}
 
-    std::string layer_type() const override {
-        return "elementwise-add";
+  std::string layer_type() const override { return "elementwise-add"; }
+
+  std::vector<shape3d> in_shape() const override {
+    return std::vector<shape3d>(num_args_, shape3d(dim_, 1, 1));
+  }
+
+  std::vector<shape3d> out_shape() const override {
+    return {shape3d(dim_, 1, 1)};
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in1 = *in_data[0];
+    tensor_t& out = *out_data[0];
+
+    out = in1;
+
+    // @todo parallelize
+    for (cnn_size_t sample = 0, sample_count = in1.size();
+         sample < sample_count; ++sample) {
+      for (cnn_size_t i = 1; i < num_args_; i++) {
+        std::transform((*in_data[i])[sample].begin(),
+                       (*in_data[i])[sample].end(), out[sample].begin(),
+                       out[sample].begin(),
+                       [](float_t x, float_t y) { return x + y; });
+      }
     }
+  }
 
-    std::vector<shape3d> in_shape() const override {
-        return std::vector<shape3d>(num_args_, shape3d(dim_,1,1));
-    }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    for (cnn_size_t i = 0; i < num_args_; i++) *in_grad[i] = *out_grad[0];
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return{ shape3d(dim_,1,1) };
-    }
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<elementwise_add_layer>& construct) {
+    cnn_size_t num_args, dim;
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        const tensor_t& in1 = *in_data[0];
-        tensor_t& out = *out_data[0];
+    ar(cereal::make_nvp("num_args", num_args), cereal::make_nvp("dim", dim));
+    construct(num_args, dim);
+  }
 
-        out = in1;
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("num_args", num_args_), cereal::make_nvp("dim", dim_));
+  }
 
-        // @todo parallelize
-        for (cnn_size_t sample = 0, sample_count = in1.size(); sample < sample_count; ++sample) {
-            for (cnn_size_t i = 1; i < num_args_; i++) {
-                std::transform((*in_data[i])[sample].begin(),
-                               (*in_data[i])[sample].end(),
-                               out[sample].begin(),
-                               out[sample].begin(),
-                               [](float_t x, float_t y){ return x + y; });
-            }
-        }
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        for (cnn_size_t i = 0; i < num_args_; i++)
-            *in_grad[i] = *out_grad[0];
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<elementwise_add_layer> & construct) {
-        cnn_size_t num_args, dim;
-
-        ar(cereal::make_nvp("num_args", num_args), cereal::make_nvp("dim", dim));
-        construct(num_args, dim);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("num_args", num_args_), cereal::make_nvp("dim", dim_));
-    }
-private:
-    cnn_size_t num_args_;
-    cnn_size_t dim_;
+ private:
+  cnn_size_t num_args_;
+  cnn_size_t dim_;
 };
 
-} // namespace tiny_dnn
-
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -4,276 +4,253 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
-#include "tiny_dnn/layers/partial_connected_layer.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/layers/partial_connected_layer.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
 // forward_propagation
 template <typename Activation>
-void tiny_average_pooling_kernel(bool parallelize,
-                                 const std::vector<tensor_t*>& in_data,
-                                 std::vector<tensor_t*>&       out_data,
-                                 const shape3d&                out_dim,
-                                 float_t                       scale_factor,
-                                 std::vector<typename partial_connected_layer<Activation>::wi_connections>& out2wi,
-                                 Activation&                   h) {
- 
-    for_i(in_data[0]->size(), [&](size_t sample) {
-        const vec_t& in = (*in_data[0])[sample];
-        const vec_t& W = (*in_data[1])[0];
-        const vec_t& b = (*in_data[2])[0];
-        vec_t&       out = (*out_data[0])[sample];
-        vec_t&       a = (*out_data[1])[sample];
+void tiny_average_pooling_kernel(
+    bool parallelize, const std::vector<tensor_t*>& in_data,
+    std::vector<tensor_t*>& out_data, const shape3d& out_dim,
+    float_t scale_factor,
+    std::vector<typename partial_connected_layer<Activation>::wi_connections>&
+        out2wi,
+    Activation& h) {
+  for_i(in_data[0]->size(), [&](size_t sample) {
+    const vec_t& in = (*in_data[0])[sample];
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& b = (*in_data[2])[0];
+    vec_t& out = (*out_data[0])[sample];
+    vec_t& a = (*out_data[1])[sample];
 
-        auto oarea = out_dim.area();
-        size_t idx = 0;
-        for (size_t d = 0; d < out_dim.depth_; ++d) {
-            float_t weight = W[d] * scale_factor;
-            float_t bias = b[d];
-            for (size_t i = 0; i < oarea; ++i, ++idx) {
-                const auto& connections = out2wi[idx];
-                float_t value = float_t(0);
-                for (auto connection : connections)// 13.1%
-                    value += in[connection.second]; // 3.2%
-                value *= weight;
-                value += bias;
-                a[idx] = value;
-            }
-        }
+    auto oarea = out_dim.area();
+    size_t idx = 0;
+    for (size_t d = 0; d < out_dim.depth_; ++d) {
+      float_t weight = W[d] * scale_factor;
+      float_t bias = b[d];
+      for (size_t i = 0; i < oarea; ++i, ++idx) {
+        const auto& connections = out2wi[idx];
+        float_t value = float_t(0);
+        for (auto connection : connections)  // 13.1%
+          value += in[connection.second];    // 3.2%
+        value *= weight;
+        value += bias;
+        a[idx] = value;
+      }
+    }
 
-        assert(out.size() == out2wi.size());
-        for (size_t i = 0; i < out2wi.size(); i++) {
-            out[i] = h.f(a, i);
-        }
-    });
+    assert(out.size() == out2wi.size());
+    for (size_t i = 0; i < out2wi.size(); i++) {
+      out[i] = h.f(a, i);
+    }
+  });
 }
 
 // back_propagation
-template<typename Activation>
-void tiny_average_pooling_back_kernel(const std::vector<tensor_t*>&   in_data,
-                                      const std::vector<tensor_t*>&   out_data,
-                                      std::vector<tensor_t*>&         out_grad,
-                                      std::vector<tensor_t*>&         in_grad,
-                                      const shape3d&                  in_dim,
-                                      float_t                         scale_factor,
-                                      std::vector<typename partial_connected_layer<Activation>::io_connections>& weight2io,
-                                      std::vector<typename partial_connected_layer<Activation>::wo_connections>& in2wo,
-                                      std::vector<std::vector<cnn_size_t>>& bias2out) {
+template <typename Activation>
+void tiny_average_pooling_back_kernel(
+    const std::vector<tensor_t*>& in_data,
+    const std::vector<tensor_t*>& out_data, std::vector<tensor_t*>& out_grad,
+    std::vector<tensor_t*>& in_grad, const shape3d& in_dim,
+    float_t scale_factor,
+    std::vector<typename partial_connected_layer<Activation>::io_connections>&
+        weight2io,
+    std::vector<typename partial_connected_layer<Activation>::wo_connections>&
+        in2wo,
+    std::vector<std::vector<cnn_size_t>>& bias2out) {
+  for_i(in_data[0]->size(), [&](size_t sample) {
+    const vec_t& prev_out = (*in_data[0])[sample];
+    const vec_t& W = (*in_data[1])[0];
+    vec_t& dW = (*in_grad[1])[sample];
+    vec_t& db = (*in_grad[2])[sample];
+    vec_t& prev_delta = (*in_grad[0])[sample];
+    vec_t& curr_delta = (*out_grad[0])[sample];
 
-    for_i(in_data[0]->size(), [&](size_t sample) {
-        const vec_t& prev_out   = (*in_data[0])[sample];
-        const vec_t& W          = (*in_data[1])[0];
-        vec_t&       dW         = (*in_grad[1])[sample];
-        vec_t&       db         = (*in_grad[2])[sample];
-        vec_t&       prev_delta = (*in_grad[0])[sample];
-        vec_t&       curr_delta = (*out_grad[0])[sample];
+    auto inarea = in_dim.area();
+    size_t idx = 0;
+    for (size_t i = 0; i < in_dim.depth_; ++i) {
+      float_t weight = W[i] * scale_factor;
+      for (size_t j = 0; j < inarea; ++j, ++idx) {
+        prev_delta[idx] = weight * curr_delta[in2wo[idx][0].second];
+      }
+    }
 
-        auto inarea = in_dim.area();
-        size_t idx = 0;
-        for (size_t i = 0; i < in_dim.depth_; ++i) {
-            float_t weight = W[i] * scale_factor;
-            for (size_t j = 0; j < inarea; ++j, ++idx) {
-                prev_delta[idx] = weight * curr_delta[in2wo[idx][0].second];
-            }
-        }
+    for (size_t i = 0; i < weight2io.size(); ++i) {
+      const auto& connections = weight2io[i];
+      float_t diff = float_t(0);
 
-        for (size_t i = 0; i < weight2io.size(); ++i) {
-            const auto& connections = weight2io[i];
-            float_t diff = float_t(0);
+      for (auto connection : connections)
+        diff += prev_out[connection.first] * curr_delta[connection.second];
 
-            for (auto connection : connections)
-                diff += prev_out[connection.first] * curr_delta[connection.second];
+      dW[i] += diff * scale_factor;
+    }
 
-            dW[i] += diff * scale_factor;
-        }
+    for (size_t i = 0; i < bias2out.size(); i++) {
+      const std::vector<cnn_size_t>& outs = bias2out[i];
+      float_t diff = float_t(0);
 
-        for (size_t i = 0; i < bias2out.size(); i++) {
-            const std::vector<cnn_size_t>& outs = bias2out[i];
-            float_t diff = float_t(0);
+      for (auto o : outs) diff += curr_delta[o];
 
-            for (auto o : outs)
-                diff += curr_delta[o];
-
-            db[i] += diff;
-        }
-    });
+      db[i] += diff;
+    }
+  });
 }
-
 
 /**
  * average pooling with trainable weights
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class average_pooling_layer : public partial_connected_layer<Activation> {
  public:
-    typedef partial_connected_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+  typedef partial_connected_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pooling_size [in] factor by which to downscale
-     **/
-    average_pooling_layer(cnn_size_t in_width,
-                          cnn_size_t in_height,
-                          cnn_size_t in_channels,
-                          cnn_size_t pooling_size)
-            : average_pooling_layer(in_width, in_height, in_channels, pooling_size, pooling_size)
-    {}
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pooling_size [in] factor by which to downscale
+   **/
+  average_pooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t in_channels, cnn_size_t pooling_size)
+      : average_pooling_layer(in_width, in_height, in_channels, pooling_size,
+                              pooling_size) {}
 
-    average_pooling_layer(const shape3d& in_shape,
-                          cnn_size_t pooling_size,
-                          cnn_size_t stride)
-        : average_pooling_layer(in_shape.width_, in_shape.width_, in_shape.depth_, pooling_size, stride)
-    {}
+  average_pooling_layer(const shape3d& in_shape, cnn_size_t pooling_size,
+                        cnn_size_t stride)
+      : average_pooling_layer(in_shape.width_, in_shape.width_, in_shape.depth_,
+                              pooling_size, stride) {}
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pool_size    [in] factor by which to downscale
-     * @param stride       [in] interval at which to apply the filters to the input
-    **/
-    average_pooling_layer(cnn_size_t in_width,
-                          cnn_size_t in_height,
-                          cnn_size_t in_channels,
-                          cnn_size_t pool_size,
-                          cnn_size_t stride)
-        : Base(in_width * in_height * in_channels,
-               pool_out_dim(in_width, pool_size, stride) *
-               pool_out_dim(in_height, pool_size, stride) * in_channels,
-               in_channels, in_channels, float_t(1) / sqr(pool_size)),
-          stride_(stride),
-          pool_size_(pool_size),
-          in_(in_width, in_height, in_channels),
-          out_(pool_out_dim(in_width, pool_size, stride),
-               pool_out_dim(in_height, pool_size, stride), in_channels),
-          w_(pool_size, pool_size, in_channels) {
-        if ((in_width % pool_size) || (in_height % pool_size)) {
-            pooling_size_mismatch(in_width, in_height, pool_size);
-        }
-
-        init_connection(pool_size);
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pool_size    [in] factor by which to downscale
+   * @param stride       [in] interval at which to apply the filters to the
+   *input
+  **/
+  average_pooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t in_channels, cnn_size_t pool_size,
+                        cnn_size_t stride)
+      : Base(in_width * in_height * in_channels,
+             pool_out_dim(in_width, pool_size, stride) *
+                 pool_out_dim(in_height, pool_size, stride) * in_channels,
+             in_channels, in_channels, float_t(1) / sqr(pool_size)),
+        stride_(stride),
+        pool_size_(pool_size),
+        in_(in_width, in_height, in_channels),
+        out_(pool_out_dim(in_width, pool_size, stride),
+             pool_out_dim(in_height, pool_size, stride), in_channels),
+        w_(pool_size, pool_size, in_channels) {
+    if ((in_width % pool_size) || (in_height % pool_size)) {
+      pooling_size_mismatch(in_width, in_height, pool_size);
     }
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        return { in_, w_, index3d<cnn_size_t>(1, 1, out_.depth_) };
-    }
+    init_connection(pool_size);
+  }
 
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return { out_, out_ };
-    }
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    return {in_, w_, index3d<cnn_size_t>(1, 1, out_.depth_)};
+  }
 
-    std::string layer_type() const override { return "ave-pool"; }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {out_, out_};
+  }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
+  std::string layer_type() const override { return "ave-pool"; }
 
-        tiny_average_pooling_kernel<Activation>(
-            parallelize_,
-            in_data,
-            out_data,
-            out_,
-            Base::scale_factor_,
-            Base::out2wi_,
-            Base::h_);
-        
-    }
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    tiny_average_pooling_kernel<Activation>(parallelize_, in_data, out_data,
+                                            out_, Base::scale_factor_,
+                                            Base::out2wi_, Base::h_);
+  }
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    tensor_t& curr_delta = *out_grad[0];
+    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-        tensor_t& curr_delta = *out_grad[0];
-        this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
+    tiny_average_pooling_back_kernel<Activation>(
+        in_data, out_data, out_grad, in_grad, in_, Base::scale_factor_,
+        Base::weight2io_, Base::in2wo_, Base::bias2out_);
+  }
 
-        tiny_average_pooling_back_kernel<Activation>(
-            in_data,
-            out_data,
-            out_grad,
-            in_grad,
-            in_,
-            Base::scale_factor_,
-            Base::weight2io_,
-            Base::in2wo_,
-            Base::bias2out_);
-    }
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<average_pooling_layer>& construct) {
+    shape3d in;
+    size_t stride, pool_size;
 
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<average_pooling_layer> & construct) {
-        shape3d in;
-        size_t stride, pool_size;
+    ar(cereal::make_nvp("in_size", in),
+       cereal::make_nvp("pool_size", pool_size),
+       cereal::make_nvp("stride", stride));
+    construct(in, pool_size, stride);
+  }
 
-        ar(cereal::make_nvp("in_size", in), cereal::make_nvp("pool_size", pool_size), cereal::make_nvp("stride", stride));
-        construct(in, pool_size, stride);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_), cereal::make_nvp("pool_size", pool_size_), cereal::make_nvp("stride", stride_));
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", in_),
+       cereal::make_nvp("pool_size", pool_size_),
+       cereal::make_nvp("stride", stride_));
+  }
 
  private:
-    size_t stride_;
-    size_t pool_size_;
-    shape3d in_;
-    shape3d out_;
-    shape3d w_;
+  size_t stride_;
+  size_t pool_size_;
+  shape3d in_;
+  shape3d out_;
+  shape3d w_;
 
-    static cnn_size_t pool_out_dim(cnn_size_t in_size,
-                                   cnn_size_t pooling_size,
-                                   cnn_size_t stride) {
-        return static_cast<int>(std::ceil((
-            static_cast<float_t>(in_size) - pooling_size) / stride) + 1);
+  static cnn_size_t pool_out_dim(cnn_size_t in_size, cnn_size_t pooling_size,
+                                 cnn_size_t stride) {
+    return static_cast<int>(
+        std::ceil((static_cast<float_t>(in_size) - pooling_size) / stride) + 1);
+  }
+
+  void init_connection(cnn_size_t pooling_size) {
+    for (cnn_size_t c = 0; c < in_.depth_; ++c) {
+      for (cnn_size_t y = 0; y < in_.height_ - pooling_size + 1; y += stride_) {
+        for (cnn_size_t x = 0; x < in_.width_ - pooling_size + 1;
+             x += stride_) {
+          connect_kernel(pooling_size, x, y, c);
+        }
+      }
     }
 
-    void init_connection(cnn_size_t pooling_size) {
-        for (cnn_size_t c = 0; c < in_.depth_; ++c) {
-            for (cnn_size_t y = 0; y < in_.height_ - pooling_size + 1; y += stride_) {
-                for (cnn_size_t x = 0; x < in_.width_ - pooling_size + 1; x += stride_) {
-                    connect_kernel(pooling_size, x, y, c);
-                }
-            }
+    for (cnn_size_t c = 0; c < in_.depth_; ++c) {
+      for (cnn_size_t y = 0; y < out_.height_; ++y) {
+        for (cnn_size_t x = 0; x < out_.width_; ++x) {
+          this->connect_bias(c, out_.get_index(x, y, c));
         }
-
-        for (cnn_size_t c = 0; c < in_.depth_; ++c) {
-            for (cnn_size_t y = 0; y < out_.height_; ++y) {
-                for (cnn_size_t x = 0; x < out_.width_; ++x) {
-                    this->connect_bias(c, out_.get_index(x, y, c));
-                }
-            }
-        }
+      }
     }
+  }
 
-    void connect_kernel(cnn_size_t pooling_size,
-                        cnn_size_t x,
-                        cnn_size_t y,
-                        cnn_size_t inc) {
-        cnn_size_t dymax = std::min(pooling_size, in_.height_ - y);
-        cnn_size_t dxmax = std::min(pooling_size, in_.width_ - x);
-        cnn_size_t dstx = x / stride_;
-        cnn_size_t dsty = y / stride_;
-        cnn_size_t outidx = out_.get_index(dstx, dsty, inc);
-        for (cnn_size_t dy = 0; dy < dymax; ++dy) {
-            for (cnn_size_t dx = 0; dx < dxmax; ++dx) {
-                this->connect_weight(
-                    in_.get_index(x + dx, y + dy, inc),
-                    outidx,
-                    inc);
-            }
-        }
+  void connect_kernel(cnn_size_t pooling_size, cnn_size_t x, cnn_size_t y,
+                      cnn_size_t inc) {
+    cnn_size_t dymax = std::min(pooling_size, in_.height_ - y);
+    cnn_size_t dxmax = std::min(pooling_size, in_.width_ - x);
+    cnn_size_t dstx = x / stride_;
+    cnn_size_t dsty = y / stride_;
+    cnn_size_t outidx = out_.get_index(dstx, dsty, inc);
+    for (cnn_size_t dy = 0; dy < dymax; ++dy) {
+      for (cnn_size_t dx = 0; dx < dxmax; ++dx) {
+        this->connect_weight(in_.get_index(x + dx, y + dy, inc), outidx, inc);
+      }
     }
+  }
 };
 
 }  // namespace tiny_dnn
-

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <string>

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <string>

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -4,253 +4,226 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
-#include "tiny_dnn/layers/partial_connected_layer.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/layers/partial_connected_layer.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
 // forward_propagation
 template <typename Activation>
-void tiny_average_unpooling_kernel(bool parallelize,
-                                   const std::vector<tensor_t*>& in_data,
-                                   std::vector<tensor_t*>&       out_data,
-                                   const shape3d&                out_dim,
-                                   float_t                       scale_factor,
-                                   std::vector<typename partial_connected_layer<Activation>::wi_connections>& out2wi,
-                                   Activation&                   h) {
-    for (size_t sample = 0; sample < in_data[0]->size(); sample++) {
-        const vec_t& in  = (*in_data[0])[sample];
-        const vec_t& W   = (*in_data[1])[0];
-        const vec_t& b   = (*in_data[2])[0];
-        vec_t&       out = (*out_data[0])[sample];
-        vec_t&       a   = (*out_data[1])[sample];
+void tiny_average_unpooling_kernel(
+    bool parallelize, const std::vector<tensor_t*>& in_data,
+    std::vector<tensor_t*>& out_data, const shape3d& out_dim,
+    float_t scale_factor,
+    std::vector<typename partial_connected_layer<Activation>::wi_connections>&
+        out2wi,
+    Activation& h) {
+  for (size_t sample = 0; sample < in_data[0]->size(); sample++) {
+    const vec_t& in = (*in_data[0])[sample];
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& b = (*in_data[2])[0];
+    vec_t& out = (*out_data[0])[sample];
+    vec_t& a = (*out_data[1])[sample];
 
-        auto oarea = out_dim.area();
-        size_t idx = 0;
-        for (size_t d = 0; d < out_dim.depth_; ++d) {
-            float_t weight = W[d];// * scale_factor;
-            float_t bias = b[d];
-            for (size_t i = 0; i < oarea; ++i, ++idx) {
-                const auto& connections = out2wi[idx];
-                float_t value = float_t(0);
-                for (auto connection : connections)// 13.1%
-                    value += in[connection.second]; // 3.2%
-                value *= weight;
-                value += bias;
-                a[idx] = value;
-            }
-        }
-
-        assert(out.size() == out2wi.size());
-        for_i(parallelize, out2wi.size(), [&](int i) {
-            out[i] = h.f(a, i);
-        });
+    auto oarea = out_dim.area();
+    size_t idx = 0;
+    for (size_t d = 0; d < out_dim.depth_; ++d) {
+      float_t weight = W[d];  // * scale_factor;
+      float_t bias = b[d];
+      for (size_t i = 0; i < oarea; ++i, ++idx) {
+        const auto& connections = out2wi[idx];
+        float_t value = float_t(0);
+        for (auto connection : connections)  // 13.1%
+          value += in[connection.second];    // 3.2%
+        value *= weight;
+        value += bias;
+        a[idx] = value;
+      }
     }
+
+    assert(out.size() == out2wi.size());
+    for_i(parallelize, out2wi.size(), [&](int i) { out[i] = h.f(a, i); });
+  }
 }
 
 // back_propagation
-template<typename Activation>
-void tiny_average_unpooling_back_kernel(const std::vector<tensor_t*>&   in_data,
-                                        const std::vector<tensor_t*>&   out_data,
-                                        std::vector<tensor_t*>&         out_grad,
-                                        std::vector<tensor_t*>&         in_grad,
-                                        const shape3d&                  in_dim,
-                                        float_t                         scale_factor,
-                                        std::vector<typename partial_connected_layer<Activation>::io_connections>& weight2io,
-                                        std::vector<typename partial_connected_layer<Activation>::wo_connections>& in2wo,
-                                        std::vector<std::vector<cnn_size_t>>& bias2out) {
+template <typename Activation>
+void tiny_average_unpooling_back_kernel(
+    const std::vector<tensor_t*>& in_data,
+    const std::vector<tensor_t*>& out_data, std::vector<tensor_t*>& out_grad,
+    std::vector<tensor_t*>& in_grad, const shape3d& in_dim,
+    float_t scale_factor,
+    std::vector<typename partial_connected_layer<Activation>::io_connections>&
+        weight2io,
+    std::vector<typename partial_connected_layer<Activation>::wo_connections>&
+        in2wo,
+    std::vector<std::vector<cnn_size_t>>& bias2out) {
+  for (size_t sample = 0; sample < in_data[0]->size(); sample++) {
+    const vec_t& prev_out = (*in_data[0])[sample];
+    const vec_t& W = (*in_data[1])[0];
+    vec_t& dW = (*in_grad[1])[sample];
+    vec_t& db = (*in_grad[2])[sample];
+    vec_t& prev_delta = (*in_grad[0])[sample];
+    vec_t& curr_delta = (*out_grad[0])[sample];
 
-    for (size_t sample = 0; sample < in_data[0]->size(); sample++) {
-        const vec_t& prev_out   = (*in_data[0])[sample];
-        const vec_t& W          = (*in_data[1])[0];
-        vec_t&       dW         = (*in_grad[1])[sample];
-        vec_t&       db         = (*in_grad[2])[sample];
-        vec_t&       prev_delta = (*in_grad[0])[sample];
-        vec_t&       curr_delta = (*out_grad[0])[sample];
-
-        auto inarea = in_dim.area();
-        size_t idx = 0;
-        for (size_t i = 0; i < in_dim.depth_; ++i) {
-            float_t weight = W[i];// * scale_factor;
-            for (size_t j = 0; j < inarea; ++j, ++idx) {
-                prev_delta[idx] = weight * curr_delta[in2wo[idx][0].second];
-            }
-        }
-
-        for (size_t i = 0; i < weight2io.size(); ++i) {
-            const auto& connections = weight2io[i];
-            float_t diff = float_t(0);
-
-            for (auto connection : connections)
-                diff += prev_out[connection.first] * curr_delta[connection.second];
-
-            dW[i] += diff;// * scale_factor;
-        }
-
-        for (size_t i = 0; i < bias2out.size(); i++) {
-            const std::vector<cnn_size_t>& outs = bias2out[i];
-            float_t diff = float_t(0);
-
-            for (auto o : outs)
-                diff += curr_delta[o];
-
-            db[i] += diff;
-        }
+    auto inarea = in_dim.area();
+    size_t idx = 0;
+    for (size_t i = 0; i < in_dim.depth_; ++i) {
+      float_t weight = W[i];  // * scale_factor;
+      for (size_t j = 0; j < inarea; ++j, ++idx) {
+        prev_delta[idx] = weight * curr_delta[in2wo[idx][0].second];
+      }
     }
+
+    for (size_t i = 0; i < weight2io.size(); ++i) {
+      const auto& connections = weight2io[i];
+      float_t diff = float_t(0);
+
+      for (auto connection : connections)
+        diff += prev_out[connection.first] * curr_delta[connection.second];
+
+      dW[i] += diff;  // * scale_factor;
+    }
+
+    for (size_t i = 0; i < bias2out.size(); i++) {
+      const std::vector<cnn_size_t>& outs = bias2out[i];
+      float_t diff = float_t(0);
+
+      for (auto o : outs) diff += curr_delta[o];
+
+      db[i] += diff;
+    }
+  }
 }
 
 /**
  * average pooling with trainable weights
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class average_unpooling_layer : public partial_connected_layer<Activation> {
  public:
-    typedef partial_connected_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+  typedef partial_connected_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pooling_size [in] factor by which to upscale
-     **/
-    average_unpooling_layer(cnn_size_t in_width,
-                            cnn_size_t in_height,
-                            cnn_size_t in_channels,
-                            cnn_size_t pooling_size)
-            : Base(in_width * in_height * in_channels,
-                   in_width * in_height * in_channels * sqr(pooling_size),
-                   in_channels, in_channels, float_t(1) * sqr(pooling_size)),
-              stride_(pooling_size),
-              in_(in_width, in_height, in_channels),
-              out_(in_width*pooling_size, in_height*pooling_size, in_channels),
-              w_(pooling_size, pooling_size, in_channels) {
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pooling_size [in] factor by which to upscale
+   **/
+  average_unpooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                          cnn_size_t in_channels, cnn_size_t pooling_size)
+      : Base(in_width * in_height * in_channels,
+             in_width * in_height * in_channels * sqr(pooling_size),
+             in_channels, in_channels, float_t(1) * sqr(pooling_size)),
+        stride_(pooling_size),
+        in_(in_width, in_height, in_channels),
+        out_(in_width * pooling_size, in_height * pooling_size, in_channels),
+        w_(pooling_size, pooling_size, in_channels) {
+    init_connection(pooling_size);
+  }
 
-        init_connection(pooling_size);
-    }
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pooling_size [in] factor by which to upscale
+   * @param stride       [in] interval at which to apply the filters to the
+   *input
+  **/
+  average_unpooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                          cnn_size_t in_channels, cnn_size_t pooling_size,
+                          cnn_size_t stride)
+      : Base(in_width * in_height * in_channels,
+             unpool_out_dim(in_width, pooling_size, stride) *
+                 unpool_out_dim(in_height, pooling_size, stride) * in_channels,
+             in_channels, in_channels, float_t(1) * sqr(pooling_size)),
+        stride_(stride),
+        in_(in_width, in_height, in_channels),
+        out_(unpool_out_dim(in_width, pooling_size, stride),
+             unpool_out_dim(in_height, pooling_size, stride), in_channels),
+        w_(pooling_size, pooling_size, in_channels) {
+    init_connection(pooling_size);
+  }
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pooling_size [in] factor by which to upscale
-     * @param stride       [in] interval at which to apply the filters to the input
-    **/
-    average_unpooling_layer(cnn_size_t in_width,
-                            cnn_size_t in_height,
-                            cnn_size_t in_channels,
-                            cnn_size_t pooling_size,
-                            cnn_size_t stride)
-        : Base(in_width * in_height * in_channels,
-               unpool_out_dim(in_width, pooling_size, stride) *
-               unpool_out_dim(in_height, pooling_size, stride) * in_channels,
-               in_channels, in_channels, float_t(1) * sqr(pooling_size)),
-          stride_(stride),
-          in_(in_width, in_height, in_channels),
-          out_(unpool_out_dim(in_width, pooling_size, stride),
-               unpool_out_dim(in_height, pooling_size, stride), in_channels),
-          w_(pooling_size, pooling_size, in_channels) {
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    return {in_, w_, index3d<cnn_size_t>(1, 1, out_.depth_)};
+  }
 
-        init_connection(pooling_size);
-    }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {out_, out_};
+  }
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        return { in_, w_, index3d<cnn_size_t>(1, 1, out_.depth_) };
-    }
+  std::string layer_type() const override { return "ave-unpool"; }
 
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return { out_, out_ };
-    }
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    tiny_average_unpooling_kernel<Activation>(parallelize_, in_data, out_data,
+                                              out_, Base::scale_factor_,
+                                              Base::out2wi_, Base::h_);
+  }
 
-    std::string layer_type() const override { return "ave-unpool"; }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    tensor_t& curr_delta = *out_grad[0];
+    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-
-        tiny_average_unpooling_kernel<Activation>(
-            parallelize_,
-            in_data,
-            out_data,
-            out_,
-            Base::scale_factor_,
-            Base::out2wi_,
-            Base::h_);
-
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        tensor_t& curr_delta = *out_grad[0];
-        this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        tiny_average_unpooling_back_kernel<Activation>(
-            in_data,
-            out_data,
-            out_grad,
-            in_grad,
-            in_,
-            Base::scale_factor_,
-            Base::weight2io_,
-            Base::in2wo_,
-            Base::bias2out_);
-    }
+    tiny_average_unpooling_back_kernel<Activation>(
+        in_data, out_data, out_grad, in_grad, in_, Base::scale_factor_,
+        Base::weight2io_, Base::in2wo_, Base::bias2out_);
+  }
 
  private:
-    size_t stride_;
-    shape3d in_;
-    shape3d out_;
-    shape3d w_;
+  size_t stride_;
+  shape3d in_;
+  shape3d out_;
+  shape3d w_;
 
-    static cnn_size_t unpool_out_dim(cnn_size_t in_size,
-                                     cnn_size_t pooling_size,
-                                     cnn_size_t stride) {
-        return static_cast<int>((in_size-1) * stride + pooling_size);
+  static cnn_size_t unpool_out_dim(cnn_size_t in_size, cnn_size_t pooling_size,
+                                   cnn_size_t stride) {
+    return static_cast<int>((in_size - 1) * stride + pooling_size);
+  }
+
+  void init_connection(cnn_size_t pooling_size) {
+    for (cnn_size_t c = 0; c < in_.depth_; ++c) {
+      for (cnn_size_t y = 0; y < in_.height_; ++y) {
+        for (cnn_size_t x = 0; x < in_.width_; ++x) {
+          connect_kernel(pooling_size, x, y, c);
+        }
+      }
     }
 
-    void init_connection(cnn_size_t pooling_size) {
-        for (cnn_size_t c = 0; c < in_.depth_; ++c) {
-            for (cnn_size_t y = 0; y < in_.height_; ++y) {
-                for (cnn_size_t x = 0; x < in_.width_; ++x) {
-                    connect_kernel(pooling_size, x, y, c);
-                }
-            }
+    for (cnn_size_t c = 0; c < in_.depth_; ++c) {
+      for (cnn_size_t y = 0; y < out_.height_; ++y) {
+        for (cnn_size_t x = 0; x < out_.width_; ++x) {
+          this->connect_bias(c, out_.get_index(x, y, c));
         }
-
-        for (cnn_size_t c = 0; c < in_.depth_; ++c) {
-            for (cnn_size_t y = 0; y < out_.height_; ++y) {
-                for (cnn_size_t x = 0; x < out_.width_; ++x) {
-                    this->connect_bias(c, out_.get_index(x, y, c));
-                }
-            }
-        }
+      }
     }
+  }
 
-    void connect_kernel(cnn_size_t pooling_size,
-                        cnn_size_t x,
-                        cnn_size_t y,
-                        cnn_size_t inc) {
-        cnn_size_t dymax = std::min(pooling_size, out_.height_ - y);
-        cnn_size_t dxmax = std::min(pooling_size, out_.width_ - x);
-        cnn_size_t dstx = x * stride_;
-        cnn_size_t dsty = y * stride_;
-        cnn_size_t inidx = in_.get_index(x, y, inc);
-        for (cnn_size_t dy = 0; dy < dymax; ++dy) {
-            for (cnn_size_t dx = 0; dx < dxmax; ++dx) {
-                this->connect_weight(
-                    inidx,
-                    out_.get_index(dstx + dx, dsty + dy, inc),
-                    inc);
-            }
-        }
+  void connect_kernel(cnn_size_t pooling_size, cnn_size_t x, cnn_size_t y,
+                      cnn_size_t inc) {
+    cnn_size_t dymax = std::min(pooling_size, out_.height_ - y);
+    cnn_size_t dxmax = std::min(pooling_size, out_.width_ - x);
+    cnn_size_t dstx = x * stride_;
+    cnn_size_t dsty = y * stride_;
+    cnn_size_t inidx = in_.get_index(x, y, inc);
+    for (cnn_size_t dy = 0; dy < dymax; ++dy) {
+      for (cnn_size_t dx = 0; dx < dxmax; ++dx) {
+        this->connect_weight(inidx, out_.get_index(dstx + dx, dsty + dy, inc),
+                             inc);
+      }
     }
+  }
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/util/math_functions.h"

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -3,14 +3,13 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/math_functions.h"
 #include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/math_functions.h"
+#include "tiny_dnn/util/util.h"
 
 #include <algorithm>
 
 namespace tiny_dnn {
-
 
 /**
  * Batch Normalization
@@ -18,274 +17,257 @@ namespace tiny_dnn {
  * Normalize the activations of the previous layer at each batch
  **/
 class batch_normalization_layer : public layer {
-public:
-    typedef layer Base;
+ public:
+  typedef layer Base;
 
-    /**
-    * @param prev_layer      [in] previous layer to be connected with this layer
-    * @param epsilon         [in] small positive value to avoid zero-division
-    * @param momentum        [in] momentum in the computation of the exponential average of the mean/stddev of the data
-    * @param phase           [in] specify the current context (train/test)
-    **/
-    batch_normalization_layer(const layer& prev_layer,
-                              float_t epsilon = 1e-5,
-                              float_t momentum = 0.999,
-                              net_phase phase = net_phase::train)
-        : Base({ vector_type::data }, { vector_type::data }),
+  /**
+  * @param prev_layer      [in] previous layer to be connected with this layer
+  * @param epsilon         [in] small positive value to avoid zero-division
+  * @param momentum        [in] momentum in the computation of the exponential
+  *average of the mean/stddev of the data
+  * @param phase           [in] specify the current context (train/test)
+  **/
+  batch_normalization_layer(const layer& prev_layer, float_t epsilon = 1e-5,
+                            float_t momentum = 0.999,
+                            net_phase phase = net_phase::train)
+      : Base({vector_type::data}, {vector_type::data}),
         in_channels_(prev_layer.out_shape()[0].depth_),
         in_spatial_size_(prev_layer.out_shape()[0].area()),
         phase_(phase),
         momentum_(momentum),
         eps_(epsilon),
-        update_immidiately_(false)
-    {
-        init();
-    }
+        update_immidiately_(false) {
+    init();
+  }
 
-    /**
-    * @param in_spatial_size [in] spatial size (WxH) of the input data
-    * @param in_channels     [in] channels of the input data
-    * @param epsilon         [in] small positive value to avoid zero-division
-    * @param momentum        [in] momentum in the computation of the exponential average of the mean/stddev of the data
-    * @param phase           [in] specify the current context (train/test)
-    **/
-    batch_normalization_layer(cnn_size_t in_spatial_size, 
-                              cnn_size_t in_channels,                        
-                              float_t epsilon = 1e-5,
-                              float_t momentum = 0.999,
-                              net_phase phase = net_phase::train)
-        : Base({ vector_type::data }, { vector_type::data }),
+  /**
+  * @param in_spatial_size [in] spatial size (WxH) of the input data
+  * @param in_channels     [in] channels of the input data
+  * @param epsilon         [in] small positive value to avoid zero-division
+  * @param momentum        [in] momentum in the computation of the exponential
+  *average of the mean/stddev of the data
+  * @param phase           [in] specify the current context (train/test)
+  **/
+  batch_normalization_layer(cnn_size_t in_spatial_size, cnn_size_t in_channels,
+                            float_t epsilon = 1e-5, float_t momentum = 0.999,
+                            net_phase phase = net_phase::train)
+      : Base({vector_type::data}, {vector_type::data}),
         in_channels_(in_channels),
         in_spatial_size_(in_spatial_size),
         phase_(phase),
         momentum_(momentum),
         eps_(epsilon),
-        update_immidiately_(false)
-    {
-        init();
+        update_immidiately_(false) {
+    init();
+  }
+
+  virtual ~batch_normalization_layer() {}
+
+  ///< number of incoming connections for each output unit
+  size_t fan_in_size() const override { return 1; }
+
+  ///< number of outgoing connections for each input unit
+  size_t fan_out_size() const override { return 1; }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    return {index3d<cnn_size_t>(in_spatial_size_, 1, in_channels_)};
+  }
+
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {index3d<cnn_size_t>(in_spatial_size_, 1, in_channels_)};
+  }
+
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[0];
+    const tensor_t& curr_out = *out_data[0];
+    cnn_size_t num_samples = curr_out.size();
+
+    CNN_UNREFERENCED_PARAMETER(in_data);
+
+    tensor_t delta_dot_y = curr_out;
+    vec_t mean_delta_dot_y, mean_delta, mean_Y;
+
+    for (cnn_size_t i = 0; i < num_samples; i++) {
+      for (cnn_size_t j = 0; j < curr_out[0].size(); j++) {
+        delta_dot_y[i][j] *= curr_delta[i][j];
+      }
     }
+    moments(delta_dot_y, in_spatial_size_, in_channels_, &mean_delta_dot_y,
+            nullptr);
+    moments(curr_delta, in_spatial_size_, in_channels_, &mean_delta, nullptr);
 
-    virtual ~batch_normalization_layer(){}
+    // if Y = (X-mean(X))/(sqrt(var(X)+eps)), then
+    //
+    // dE(Y)/dX =
+    //   (dE/dY - mean(dE/dY) - mean(dE/dY \cdot Y) \cdot Y)
+    //     ./ sqrt(var(X) + eps)
+    //
+    for_i(num_samples, [&](int i) {
+      for (cnn_size_t j = 0; j < in_channels_; j++) {
+        for (cnn_size_t k = 0; k < in_spatial_size_; k++) {
+          cnn_size_t index = j * in_spatial_size_ + k;
 
-    ///< number of incoming connections for each output unit
-    size_t fan_in_size() const override {
-        return 1;
-    }
+          prev_delta[i][index] = curr_delta[i][index] - mean_delta[j] -
+                                 mean_delta_dot_y[j] * curr_out[i][index];
 
-    ///< number of outgoing connections for each input unit
-    size_t fan_out_size() const override {
-        return 1;
-    }
-
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        return{ index3d<cnn_size_t>(in_spatial_size_, 1, in_channels_) };
-    }
-
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return{ index3d<cnn_size_t>(in_spatial_size_, 1, in_channels_) };
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        tensor_t& prev_delta     = *in_grad[0];
-        tensor_t& curr_delta     = *out_grad[0];
-        const tensor_t& curr_out = *out_data[0];
-        cnn_size_t num_samples   = curr_out.size();
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-
-        tensor_t delta_dot_y = curr_out;
-        vec_t mean_delta_dot_y, mean_delta, mean_Y;
-
-        for (cnn_size_t i = 0; i < num_samples; i++) {
-            for (cnn_size_t j = 0; j < curr_out[0].size(); j++) {
-                delta_dot_y[i][j] *= curr_delta[i][j];
-            }
+          // stddev_ is calculated in the forward pass
+          prev_delta[i][index] /= stddev_[j];
         }
-        moments(delta_dot_y, in_spatial_size_, in_channels_, &mean_delta_dot_y, nullptr);
-        moments(curr_delta, in_spatial_size_, in_channels_, &mean_delta, nullptr);
- 
-        // if Y = (X-mean(X))/(sqrt(var(X)+eps)), then
-        //
-        // dE(Y)/dX =
-        //   (dE/dY - mean(dE/dY) - mean(dE/dY \cdot Y) \cdot Y)
-        //     ./ sqrt(var(X) + eps)
-        //
-        for_i(num_samples, [&](int i) {
-            for (cnn_size_t j = 0; j < in_channels_; j++) {
-                for (cnn_size_t k = 0; k < in_spatial_size_; k++) {
-                    cnn_size_t index = j*in_spatial_size_ + k;
+      }
+    });
+  }
 
-                    prev_delta[i][index]
-                        = curr_delta[i][index] - mean_delta[j] - mean_delta_dot_y[j] * curr_out[i][index];
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    vec_t* mean = nullptr;
+    vec_t* variance = nullptr;
+    tensor_t& in = *in_data[0];
+    tensor_t& out = *out_data[0];
 
-                    // stddev_ is calculated in the forward pass 
-                    prev_delta[i][index] /= stddev_[j];
-                }            
-            }
-        });
+    if (phase_ == net_phase::train) {
+      // calculate mean/variance from this batch in train phase
+      mean = &mean_current_;
+      variance = &variance_current_;
+      moments(*in_data[0], in_spatial_size_, in_channels_, mean, variance);
+    } else {
+      // use stored mean/variance in test phase
+      mean = &mean_;
+      variance = &variance_;
     }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-        std::vector<tensor_t*>& out_data) override {
-        vec_t* mean = nullptr;
-        vec_t* variance = nullptr;
-        tensor_t& in = *in_data[0];
-        tensor_t& out = *out_data[0];
+    // y = (x - mean) ./ sqrt(variance + eps)
+    calc_stddev(*variance);
 
-        if (phase_ == net_phase::train) {
-            // calculate mean/variance from this batch in train phase
-            mean = &mean_current_;
-            variance = &variance_current_;
-            moments(*in_data[0], in_spatial_size_, in_channels_, mean, variance);
+    for_i(parallelize_, in_data[0]->size(), [&](int i) {
+      const float_t* inptr = &in[i][0];
+      float_t* outptr = &out[i][0];
+
+      for (cnn_size_t j = 0; j < in_channels_; j++) {
+        float_t m = (*mean)[j];
+
+        for (cnn_size_t k = 0; k < in_spatial_size_; k++) {
+          *outptr++ = (*inptr++ - m) / stddev_[j];
         }
-        else {
-            // use stored mean/variance in test phase
-            mean = &mean_;
-            variance = &variance_;
-        }
+      }
+    });
 
-        // y = (x - mean) ./ sqrt(variance + eps)
-        calc_stddev(*variance);
-
-        for_i(parallelize_, in_data[0]->size(), [&](int i) {
-            const float_t* inptr  = &in[i][0];
-            float_t*       outptr = &out[i][0];
-
-            for (cnn_size_t j = 0; j < in_channels_; j++) {
-                float_t m = (*mean)[j];
-
-                for (cnn_size_t k = 0; k < in_spatial_size_; k++) {
-                    *outptr++ = (*inptr++ - m) / stddev_[j];
-                }
-            }
-        });
-
-        if (phase_ == net_phase::train && update_immidiately_) {
-            mean_ = mean_current_;
-            variance_ = variance_current_;
-        }
+    if (phase_ == net_phase::train && update_immidiately_) {
+      mean_ = mean_current_;
+      variance_ = variance_current_;
     }
+  }
 
-    void set_context(net_phase ctx) override
-    {
-        phase_ = ctx;
+  void set_context(net_phase ctx) override { phase_ = ctx; }
+
+  std::string layer_type() const override { return "batch-norm"; }
+
+  virtual void post_update() override {
+    for (cnn_size_t i = 0; i < mean_.size(); i++) {
+      mean_[i] = momentum_ * mean_[i] + (1 - momentum_) * mean_current_[i];
+      variance_[i] =
+          momentum_ * variance_[i] + (1 - momentum_) * variance_current_[i];
     }
+  }
 
-    std::string layer_type() const override { return "batch-norm"; }
+  virtual void save(std::ostream& os) const override {
+    Base::save(os);
+    for (auto m : mean_) os << m << " ";
+    for (auto v : variance_) os << v << " ";
+  }
 
-    virtual void post_update() override {
-        for (cnn_size_t i = 0; i < mean_.size(); i++) {
-            mean_[i] = momentum_ * mean_[i] + (1 - momentum_) * mean_current_[i];
-            variance_[i] = momentum_ * variance_[i] + (1 - momentum_) * variance_current_[i];
-        }
+  virtual void load(std::istream& is) override {
+    Base::load(is);
+    for (auto& m : mean_) is >> m;
+    for (auto& v : variance_) is >> v;
+  }
+
+  virtual void load(const std::vector<float_t>& src, int& idx) override {
+    Base::load(src, idx);
+    for (auto& m : mean_) m = src[idx++];
+    for (auto& v : variance_) v = src[idx++];
+  }
+
+  void update_immidiately(bool update) { update_immidiately_ = update; }
+
+  void set_stddev(const vec_t& stddev) { stddev_ = stddev; }
+
+  void set_mean(const vec_t& mean) { mean_ = mean; }
+
+  void set_variance(const vec_t& variance) {
+    variance_ = variance;
+    calc_stddev(variance);
+  }
+
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<batch_normalization_layer>& construct) {
+    shape3d in;
+    size_t in_spatial_size, in_channels;
+    float_t eps, momentum;
+    net_phase phase;
+    vec_t mean, variance;
+
+    ar(cereal::make_nvp("in_spatial_size", in_spatial_size),
+       cereal::make_nvp("in_channels", in_channels),
+       cereal::make_nvp("epsilon", eps), cereal::make_nvp("momentum", momentum),
+       cereal::make_nvp("phase", phase), cereal::make_nvp("mean", mean),
+       cereal::make_nvp("variance", variance));
+    construct(in_spatial_size, in_channels, eps, momentum, phase);
+    construct->set_mean(mean);
+    construct->set_variance(variance);
+  }
+
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_spatial_size", in_spatial_size_),
+       cereal::make_nvp("in_channels", in_channels_),
+       cereal::make_nvp("epsilon", eps_),
+       cereal::make_nvp("momentum", momentum_),
+       cereal::make_nvp("phase", phase_), cereal::make_nvp("mean", mean_),
+       cereal::make_nvp("variance", variance_));
+  }
+
+ private:
+  void calc_stddev(const vec_t& variance) {
+    for (size_t i = 0; i < in_channels_; i++) {
+      stddev_[i] = sqrt(variance[i] + eps_);
     }
+  }
 
-    virtual void save(std::ostream& os) const override {
-        Base::save(os);
-        for (auto m : mean_) os << m << " ";
-        for (auto v : variance_) os << v << " ";
-    }
+  void init() {
+    mean_current_.resize(in_channels_);
+    mean_.resize(in_channels_);
+    variance_current_.resize(in_channels_);
+    variance_.resize(in_channels_);
+    tmp_mean_.resize(in_channels_);
+    stddev_.resize(in_channels_);
+  }
 
-    virtual void load(std::istream& is) override {
-        Base::load(is);
-        for (auto& m : mean_) is >> m;
-        for (auto& v : variance_) is >> v;
-    }
+  cnn_size_t in_channels_;
+  cnn_size_t in_spatial_size_;
 
-    virtual void load(const std::vector<float_t>& src, int& idx) override {
-        Base::load(src, idx);
-        for (auto& m : mean_) m = src[idx++];
-        for (auto& v : variance_) v = src[idx++];
-    }
+  net_phase phase_;
+  float_t momentum_;
+  float_t eps_;
 
-    void update_immidiately(bool update) {
-        update_immidiately_ = update;
-    }
+  // mean/variance for this mini-batch
+  vec_t mean_current_;
+  vec_t variance_current_;
 
-    void set_stddev(const vec_t& stddev) {
-        stddev_ = stddev;
-    }
+  vec_t tmp_mean_;
 
-    void set_mean(const vec_t& mean) {
-        mean_ = mean;
-    }
+  // moving average of mean/variance
+  vec_t mean_;
+  vec_t variance_;
+  vec_t stddev_;
 
-    void set_variance(const vec_t& variance) {
-        variance_ = variance;
-        calc_stddev(variance);
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<batch_normalization_layer> & construct) {
-        shape3d in;
-        size_t in_spatial_size, in_channels;
-        float_t eps, momentum;
-        net_phase phase;
-        vec_t mean, variance;
-        
-        ar(cereal::make_nvp("in_spatial_size", in_spatial_size),
-            cereal::make_nvp("in_channels", in_channels),
-            cereal::make_nvp("epsilon", eps),
-            cereal::make_nvp("momentum", momentum),
-            cereal::make_nvp("phase", phase),
-            cereal::make_nvp("mean", mean),
-            cereal::make_nvp("variance", variance));
-        construct(in_spatial_size, in_channels, eps, momentum, phase);
-        construct->set_mean(mean);
-        construct->set_variance(variance);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_spatial_size", in_spatial_size_),
-           cereal::make_nvp("in_channels", in_channels_),
-           cereal::make_nvp("epsilon", eps_),
-           cereal::make_nvp("momentum", momentum_),
-           cereal::make_nvp("phase", phase_),
-           cereal::make_nvp("mean", mean_),
-           cereal::make_nvp("variance", variance_));
-    }
-
-private:
-    void calc_stddev(const vec_t& variance) {
-        for (size_t i = 0; i < in_channels_; i++) {
-            stddev_[i] = sqrt(variance[i] + eps_);
-        }
-    }
-
-    void init() {
-        mean_current_.resize(in_channels_);
-        mean_.resize(in_channels_);
-        variance_current_.resize(in_channels_);
-        variance_.resize(in_channels_);
-        tmp_mean_.resize(in_channels_);
-        stddev_.resize(in_channels_);
-    }
-
-    cnn_size_t in_channels_;
-    cnn_size_t in_spatial_size_;
-
-    net_phase phase_;
-    float_t momentum_;
-    float_t eps_;
-
-    // mean/variance for this mini-batch
-    vec_t mean_current_;
-    vec_t variance_current_;
-
-    vec_t tmp_mean_;
-
-    // moving average of mean/variance
-    vec_t mean_;
-    vec_t variance_;
-    vec_t stddev_;
-
-    // for test
-    bool update_immidiately_;
+  // for test
+  bool update_immidiately_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -3,8 +3,8 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
@@ -12,93 +12,90 @@ namespace tiny_dnn {
  * concat N layers along depth
  **/
 class concat_layer : public layer {
-public:
-    concat_layer(const std::vector<shape3d>& in_shapes)
-    : layer(std::vector<vector_type>(in_shapes.size(), vector_type::data), {vector_type::data}),
-      in_shapes_(in_shapes) {
-        set_outshape();
+ public:
+  concat_layer(const std::vector<shape3d>& in_shapes)
+      : layer(std::vector<vector_type>(in_shapes.size(), vector_type::data),
+              {vector_type::data}),
+        in_shapes_(in_shapes) {
+    set_outshape();
+  }
+
+  concat_layer(cnn_size_t num_args, cnn_size_t ndim)
+      : layer(std::vector<vector_type>(num_args, vector_type::data),
+              {vector_type::data}),
+        in_shapes_(std::vector<shape3d>(num_args, shape3d(ndim, 1, 1))) {
+    set_outshape();
+  }
+
+  void set_outshape() {
+    out_shape_ = in_shapes_.front();
+    for (size_t i = 1; i < in_shapes_.size(); i++) {
+      if (in_shapes_[i].area() != out_shape_.area())
+        throw nn_error("each input shapes to concat must have same WxH size");
+      out_shape_.depth_ += in_shapes_[i].depth_;
     }
+  }
 
-    concat_layer(cnn_size_t num_args, cnn_size_t ndim)
-        : layer(std::vector<vector_type>(num_args, vector_type::data), { vector_type::data }),
-        in_shapes_(std::vector<shape3d>(num_args, shape3d(ndim,1,1))) {
-        set_outshape();
+  std::string layer_type() const override { return "concat"; }
+
+  std::vector<shape3d> in_shape() const override { return in_shapes_; }
+
+  std::vector<shape3d> out_shape() const override { return {out_shape_}; }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    cnn_size_t num_samples = (*out_data[0]).size();
+
+    for (cnn_size_t s = 0; s < num_samples; s++) {
+      float_t* outs = &(*out_data[0])[s][0];
+
+      for (cnn_size_t i = 0; i < in_shapes_.size(); i++) {
+        const float_t* ins = &(*in_data[i])[s][0];
+        cnn_size_t dim = in_shapes_[i].size();
+        outs = std::copy(ins, ins + dim, outs);
+      }
     }
+  }
 
-    void set_outshape() {
-        out_shape_ = in_shapes_.front();
-        for (size_t i = 1; i < in_shapes_.size(); i++) {
-            if (in_shapes_[i].area() != out_shape_.area())
-                throw nn_error("each input shapes to concat must have same WxH size");
-            out_shape_.depth_ += in_shapes_[i].depth_;
-        }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+
+    cnn_size_t num_samples = (*out_grad[0]).size();
+
+    for (cnn_size_t s = 0; s < num_samples; s++) {
+      const float_t* outs = &(*out_grad[0])[s][0];
+
+      for (cnn_size_t i = 0; i < in_shapes_.size(); i++) {
+        cnn_size_t dim = in_shapes_[i].size();
+        float_t* ins = &(*in_grad[i])[s][0];
+        std::copy(outs, outs + dim, ins);
+        outs += dim;
+      }
     }
+  }
 
-    std::string layer_type() const override {
-        return "concat";
-    }
+  template <class Archive>
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<concat_layer>& construct) {
+    std::vector<shape3d> in_shapes;
 
-    std::vector<shape3d> in_shape() const override {
-        return in_shapes_;
-    }
+    ar(in_shapes);
+    construct(in_shapes);
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return {out_shape_};
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(in_shapes_);
+  }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        cnn_size_t num_samples = (*out_data[0]).size();
-        
-        for (cnn_size_t s = 0; s < num_samples; s++) {
-            float_t* outs = &(*out_data[0])[s][0];
-            
-            for (cnn_size_t i = 0; i < in_shapes_.size(); i++) {
-                const float_t* ins = &(*in_data[i])[s][0];
-                cnn_size_t dim = in_shapes_[i].size();
-                outs = std::copy(ins, ins + dim, outs);
-            }
-        }
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-
-        cnn_size_t num_samples = (*out_grad[0]).size();
-        
-        for (cnn_size_t s = 0; s < num_samples; s++) {
-            const float_t* outs = &(*out_grad[0])[s][0];
-            
-            for (cnn_size_t i = 0; i < in_shapes_.size(); i++) {
-                cnn_size_t dim = in_shapes_[i].size();
-                float_t* ins = &(*in_grad[i])[s][0];
-                std::copy(outs, outs + dim, ins);
-                outs += dim;
-            }
-        }
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<concat_layer> & construct) {
-        std::vector<shape3d> in_shapes;
-
-        ar(in_shapes);
-        construct(in_shapes);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(in_shapes_);
-    }
-
-private:
-    std::vector<shape3d> in_shapes_;
-    shape3d out_shape_;
+ private:
+  std::vector<shape3d> in_shapes_;
+  shape3d out_shape_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -4,18 +4,18 @@
 
 #pragma once
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
-#include "tiny_dnn/core/kernels/conv2d_op.h"
 #include "tiny_dnn/core/kernels/conv2d_grad_op.h"
-#include "tiny_dnn/core/kernels/conv2d_op_opencl.h"
+#include "tiny_dnn/core/kernels/conv2d_op.h"
 #include "tiny_dnn/core/kernels/conv2d_op_libdnn.h"
+#include "tiny_dnn/core/kernels/conv2d_op_opencl.h"
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 using namespace tiny_dnn::core;
 
@@ -26,565 +26,545 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class convolutional_layer : public feedforward_layer<Activation> {
  public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width     [in] input image width
-    * @param in_height    [in] input image height
-    * @param window_size  [in] window(kernel) size of convolution
-    * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels [in] output image channels
-    * @param padding      [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    convolutional_layer(cnn_size_t     in_width,
-                        cnn_size_t     in_height,
-                        cnn_size_t     window_size,
-                        cnn_size_t     in_channels,
-                        cnn_size_t     out_channels,
-                        padding        pad_type = padding::valid,
-                        bool           has_bias = true,
-                        cnn_size_t     w_stride = 1,
-                        cnn_size_t     h_stride = 1,
-                        backend_t      backend_type = core::default_engine(),
-                        backend_params b_params = backend_params())
-        : convolutional_layer(in_width, in_height, window_size, window_size, in_channels, out_channels,
-                              connection_table(), pad_type, has_bias, w_stride, h_stride,
-                              backend_type, b_params)
-    {}
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width     [in] input image width
+  * @param in_height    [in] input image height
+  * @param window_size  [in] window(kernel) size of convolution
+  * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels [in] output image channels
+  * @param padding      [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t window_size, cnn_size_t in_channels,
+                      cnn_size_t out_channels,
+                      padding pad_type = padding::valid, bool has_bias = true,
+                      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                      backend_t backend_type = core::default_engine(),
+                      backend_params b_params = backend_params())
+      : convolutional_layer(in_width, in_height, window_size, window_size,
+                            in_channels, out_channels, connection_table(),
+                            pad_type, has_bias, w_stride, h_stride,
+                            backend_type, b_params) {}
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width      [in] input image width
-    * @param in_height     [in] input image height
-    * @param window_width  [in] window_width(kernel) size of convolution
-    * @param window_height [in] window_height(kernel) size of convolution
-    * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels  [in] output image channels
-    * @param padding       [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_width + 1) * (in-height - window_height + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    convolutional_layer(cnn_size_t     in_width,
-                        cnn_size_t     in_height,
-                        cnn_size_t     window_width,
-                        cnn_size_t     window_height,
-                        cnn_size_t     in_channels,
-                        cnn_size_t     out_channels,
-                        padding        pad_type = padding::valid,
-                        bool           has_bias = true,
-                        cnn_size_t     w_stride = 1,
-                        cnn_size_t     h_stride = 1,
-                        backend_t      backend_type = core::default_engine(),
-                        backend_params b_params = backend_params())
-        : convolutional_layer(in_width, in_height, window_width, window_height, in_channels, out_channels,
-            connection_table(), pad_type, has_bias, w_stride, h_stride,
-            backend_type, b_params)
-    {}
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width      [in] input image width
+  * @param in_height     [in] input image height
+  * @param window_width  [in] window_width(kernel) size of convolution
+  * @param window_height [in] window_height(kernel) size of convolution
+  * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels  [in] output image channels
+  * @param padding       [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_width + 1) * (in-height - window_height + 1) *
+  *out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t window_width, cnn_size_t window_height,
+                      cnn_size_t in_channels, cnn_size_t out_channels,
+                      padding pad_type = padding::valid, bool has_bias = true,
+                      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                      backend_t backend_type = core::default_engine(),
+                      backend_params b_params = backend_params())
+      : convolutional_layer(in_width, in_height, window_width, window_height,
+                            in_channels, out_channels, connection_table(),
+                            pad_type, has_bias, w_stride, h_stride,
+                            backend_type, b_params) {}
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_size      [in] window(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    convolutional_layer(cnn_size_t              in_width,
-                        cnn_size_t              in_height,
-                        cnn_size_t              window_size,
-                        cnn_size_t              in_channels,
-                        cnn_size_t              out_channels,
-                        const connection_table& connection_table,
-                        padding                 pad_type = padding::valid,
-                        bool                    has_bias = true,
-                        cnn_size_t              w_stride = 1,
-                        cnn_size_t              h_stride = 1,
-                        backend_t      backend_type = core::default_engine(),
-                        backend_params b_params = backend_params())
-        : convolutional_layer(in_width, in_height, window_size, window_size, in_channels, out_channels,
-            connection_table, pad_type, has_bias, w_stride, h_stride,
-            backend_type, b_params)
-    {}
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_size      [in] window(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t window_size, cnn_size_t in_channels,
+                      cnn_size_t out_channels,
+                      const connection_table& connection_table,
+                      padding pad_type = padding::valid, bool has_bias = true,
+                      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                      backend_t backend_type = core::default_engine(),
+                      backend_params b_params = backend_params())
+      : convolutional_layer(in_width, in_height, window_size, window_size,
+                            in_channels, out_channels, connection_table,
+                            pad_type, has_bias, w_stride, h_stride,
+                            backend_type, b_params) {}
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_width     [in] window_width(kernel) size of convolution
-    * @param window_height    [in] window_height(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    convolutional_layer(cnn_size_t              in_width,
-                        cnn_size_t              in_height,
-                        cnn_size_t              window_width,
-                        cnn_size_t              window_height,
-                        cnn_size_t              in_channels,
-                        cnn_size_t              out_channels,
-                        const connection_table& connection_table,
-                        padding                 pad_type = padding::valid,
-                        bool                    has_bias = true,
-                        cnn_size_t              w_stride = 1,
-                        cnn_size_t              h_stride = 1,
-                        backend_t      backend_type = core::default_engine(),
-                        backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            conv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_width, window_height,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride,
-                            connection_table);
-            init_backend(backend_type);
-            Base::set_backend_type(backend_type);
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_width     [in] window_width(kernel) size of convolution
+  * @param window_height    [in] window_height(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t window_width, cnn_size_t window_height,
+                      cnn_size_t in_channels, cnn_size_t out_channels,
+                      const connection_table& connection_table,
+                      padding pad_type = padding::valid, bool has_bias = true,
+                      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                      backend_t backend_type = core::default_engine(),
+                      backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                    window_height, out_channels, pad_type, has_bias, w_stride,
+                    h_stride, connection_table);
+    init_backend(backend_type);
+    Base::set_backend_type(backend_type);
+  }
+
+  // move constructor
+  convolutional_layer(convolutional_layer&& other)  // NOLINT
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        kernel_fwd_(std::move(other.kernel_fwd_)),
+        kernel_back_(std::move(other.kernel_back_)),
+        cws_(std::move(other.cws_)) {
+    init_backend(std::move(other.engine()));
+  }
+
+  ///< number of incoming connections for each output unit
+  size_t fan_in_size() const override {
+    return params_.weight.width_ * params_.weight.height_ * params_.in.depth_;
+  }
+
+  ///< number of outgoing connections for each input unit
+  size_t fan_out_size() const override {
+    return (params_.weight.width_ / params_.w_stride) *
+           (params_.weight.height_ / params_.h_stride) * params_.out.depth_;
+  }
+
+  /**
+   * @param in_data      input vectors of this layer (data, weight, bias)
+   * @param out_data     output vectors
+   **/
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    copy_and_pad_input(*in_data[0], cws_.prev_out_padded_);
+
+    std::vector<tensor_t*> in_data_;
+    in_data_.push_back(in_data_padded(in_data));
+
+    for (cnn_size_t i = 1; i < in_data.size(); ++i) {
+      in_data_.push_back(in_data[i]);
     }
 
-    // move constructor
-    convolutional_layer(convolutional_layer&& other)  // NOLINT
-            : Base(std::move(other))
-            , params_(std::move(other.params_))
-            , kernel_fwd_(std::move(other.kernel_fwd_))
-            , kernel_back_(std::move(other.kernel_back_))
-            , cws_(std::move(other.cws_)) {
-        init_backend(std::move(other.engine()));
+    // forward convolutional op context
+    auto ctx = OpKernelContext(in_data_, out_data);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
+
+    // launch convolutional kernel
+    kernel_fwd_->compute(ctx);
+
+    // activations
+    // TODO(edgar/nyanp): refactor and move activations outside
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
+
+  /**
+   * return delta of previous layer (delta=\frac{dE}{da}, a=wx in
+   *fully-connected layer)
+   * @param in_data      input vectors (same vectors as forward_propagation)
+   * @param out_data     output vectors (same vectors as forward_propagation)
+   * @param out_grad     gradient of output vectors (i-th vector correspond with
+   *out_data[i])
+   * @param in_grad      gradient of input vectors (i-th vector correspond with
+   *in_data[i])
+   **/
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    // activations
+    // TODO(edgar/nyanp): refactor and move activations outside
+    this->backward_activation(*out_grad[0], *out_data[0], *out_grad[1]);
+
+    std::vector<tensor_t*> in_data_;
+    in_data_.push_back(in_data_padded(in_data));
+    for (cnn_size_t i = 1; i < in_data.size(); ++i) {
+      in_data_.push_back(in_data[i]);
     }
 
-    ///< number of incoming connections for each output unit
-    size_t fan_in_size() const override {
-        return params_.weight.width_  *
-               params_.weight.height_ * params_.in.depth_;
+    std::vector<tensor_t*> in_grad_;
+    for (cnn_size_t i = 0; i < in_grad.size(); ++i) {
+      in_grad_.push_back(in_grad[i]);
     }
 
-    ///< number of outgoing connections for each input unit
-    size_t fan_out_size() const override  {
-        return (params_.weight.width_  / params_.w_stride) *
-               (params_.weight.height_ / params_.h_stride) *
-                params_.out.depth_;
+    if (params_.pad_type == padding::same) {
+      *in_grad_[0] = cws_.prev_delta_padded_;
     }
 
-    /**
-     * @param in_data      input vectors of this layer (data, weight, bias)
-     * @param out_data     output vectors
-     **/
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) override { 
-        copy_and_pad_input(*in_data[0], cws_.prev_out_padded_);
+    auto ctx = OpKernelContext(in_data_, out_data, out_grad, in_grad_);
+    ctx.setParams(&params_);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
 
-        std::vector<tensor_t*> in_data_;
-        in_data_.push_back(in_data_padded(in_data));
+    // launch convolutional kernel
+    kernel_back_->compute(ctx);
 
-        for (cnn_size_t i = 1; i < in_data.size(); ++i) {
-            in_data_.push_back(in_data[i]);
+    // unpad deltas
+    copy_and_unpad_delta(cws_.prev_delta_padded_, *in_grad[0]);
+  }
+
+  void set_sample_count(cnn_size_t sample_count) override {
+    Base::set_sample_count(sample_count);
+    cws_.prev_delta_padded_.resize(sample_count,
+                                   vec_t(params_.in_padded.size(), float_t(0)));
+  }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias) {
+      return {params_.in, params_.weight,
+              index3d<cnn_size_t>(1, 1, params_.out.depth_)};
+    } else {
+      return {params_.in, params_.weight};
+    }
+  }
+
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {params_.out, params_.out};
+  }
+
+  std::string layer_type() const override { return std::string("conv"); }
+
+  std::string kernel_file() const override {
+    return std::string(
+        "../tiny_cnn/core/kernels/cl_kernels/conv_layer_spatial.cl");
+  }
+
+  std::string kernel_header() const override {
+    std::stringstream ss;
+    ss << "#define MULTI\n";
+    ss << "#define KERNEL_H " << params_.weight.height_ << "\n";
+    ss << "#define KERNEL_W " << params_.weight.width_ << "\n";
+    ss << "#define CHANNELS " << params_.weight.depth_ << "\n";
+    ss << "#define STRIDE_H " << params_.h_stride << "\n";
+    ss << "#define STRIDE_W " << params_.w_stride << "\n";
+    ss << "#define APPLY_BIAS " << params_.has_bias << "\n";
+    ss << "#define OUTPUT_Z " << params_.out.depth_ << "\n";
+    // TODO(edgar): REVISE THIS
+    ss << "#define ZPAR " << params_.out.depth_ << "\n";
+    return ss.str();
+  }
+
+  image<> weight_to_image() const {
+    image<> img;
+    const cnn_size_t border_width = 1;
+    const auto pitch = params_.weight.width_ + border_width;
+    const auto width = params_.out.depth_ * pitch + border_width;
+    const auto height = params_.in.depth_ * pitch + border_width;
+    const image<>::intensity_t bg_color = 255;
+    const vec_t& W = *this->weights()[0];
+
+    img.resize(width, height);
+    img.fill(bg_color);
+
+    auto minmax = std::minmax_element(W.begin(), W.end());
+
+    for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
+      for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
+        if (!params_.tbl.is_connected(c, r)) continue;
+
+        const auto top = r * pitch + border_width;
+        const auto left = c * pitch + border_width;
+
+        cnn_size_t idx = 0;
+
+        for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
+          for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
+            idx = c * params_.in.depth_ + r;
+            idx = params_.weight.get_index(x, y, idx);
+            const float_t w = W[idx];
+
+            img.at(left + x, top + y) = static_cast<image<>::intensity_t>(
+                rescale(w, *minmax.first, *minmax.second, 0, 255));
+          }
         }
-
-        // forward convolutional op context
-        auto ctx = OpKernelContext(in_data_, out_data);
-             ctx.setParallelize(layer::parallelize());
-             ctx.setEngine(layer::engine());
-
-        // launch convolutional kernel
-        kernel_fwd_->compute(ctx);
-
-        // activations
-        // TODO(edgar/nyanp): refactor and move activations outside
-        this->forward_activation(*out_data[0], *out_data[1]);
+      }
     }
+    return img;
+  }
 
-    /**
-     * return delta of previous layer (delta=\frac{dE}{da}, a=wx in fully-connected layer)
-     * @param in_data      input vectors (same vectors as forward_propagation)
-     * @param out_data     output vectors (same vectors as forward_propagation)
-     * @param out_grad     gradient of output vectors (i-th vector correspond with out_data[i])
-     * @param in_grad      gradient of input vectors (i-th vector correspond with in_data[i])
-     **/
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        // activations
-        // TODO(edgar/nyanp): refactor and move activations outside
-        this->backward_activation(*out_grad[0], *out_data[0], *out_grad[1]);
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<convolutional_layer>& construct) {
+    size_t w_width, w_height, out_ch, w_stride, h_stride;
+    bool has_bias;
+    shape3d in;
+    padding pad_type;
+    connection_table tbl;
 
-        std::vector<tensor_t*> in_data_;
-        in_data_.push_back(in_data_padded(in_data));
-        for (cnn_size_t i = 1; i < in_data.size(); ++i) {
-            in_data_.push_back(in_data[i]);
-        }
+    ar(cereal::make_nvp("in_size", in),
+       cereal::make_nvp("window_width", w_width),
+       cereal::make_nvp("window_height", w_height),
+       cereal::make_nvp("out_channels", out_ch),
+       cereal::make_nvp("connection_table", tbl),
+       cereal::make_nvp("pad_type", pad_type),
+       cereal::make_nvp("has_bias", has_bias),
+       cereal::make_nvp("w_stride", w_stride),
+       cereal::make_nvp("h_stride", h_stride));
 
-        std::vector<tensor_t*> in_grad_;
-        for (cnn_size_t i = 0; i < in_grad.size(); ++i) {
-            in_grad_.push_back(in_grad[i]);
-        }
+    construct(in.width_, in.height_, w_width, w_height, in.depth_, out_ch, tbl,
+              pad_type, has_bias, w_stride, h_stride);
+  }
 
-        if (params_.pad_type == padding::same) {
-            *in_grad_[0] = cws_.prev_delta_padded_;
-        }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", params_.in),
+       cereal::make_nvp("window_width", params_.weight.width_),
+       cereal::make_nvp("window_height", params_.weight.height_),
+       cereal::make_nvp("out_channels", params_.out.depth_),
+       cereal::make_nvp("connection_table", params_.tbl),
+       cereal::make_nvp("pad_type", params_.pad_type),
+       cereal::make_nvp("has_bias", params_.has_bias),
+       cereal::make_nvp("w_stride", params_.w_stride),
+       cereal::make_nvp("h_stride", params_.h_stride));
+  }
 
-        auto ctx = OpKernelContext(in_data_, out_data, out_grad, in_grad_);
-             ctx.setParams(&params_);
-             ctx.setParallelize(layer::parallelize());
-             ctx.setEngine(layer::engine());
+ private:
+  tensor_t* in_data_padded(const std::vector<tensor_t*>& in) {
+    return (params_.pad_type == core::padding::valid) ? in[0]
+                                                      : &cws_.prev_out_padded_;
+  }
 
-        // launch convolutional kernel
-        kernel_back_->compute(ctx);
+  void conv_set_params(const shape3d& in, cnn_size_t w_width,
+                       cnn_size_t w_height, cnn_size_t outc, padding ptype,
+                       bool has_bias, cnn_size_t w_stride, cnn_size_t h_stride,
+                       const connection_table& tbl = connection_table()) {
+    params_.in = in;
+    params_.in_padded =
+        shape3d(in_length(in.width_, w_width, ptype),
+                in_length(in.height_, w_height, ptype), in.depth_);
+    params_.out =
+        shape3d(conv_out_length(in.width_, w_width, w_stride, ptype),
+                conv_out_length(in.height_, w_height, h_stride, ptype), outc);
+    params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
+    params_.has_bias = has_bias;
+    params_.pad_type = ptype;
+    params_.w_stride = w_stride;
+    params_.h_stride = h_stride;
+    params_.tbl = tbl;
 
-        // unpad deltas
-        copy_and_unpad_delta(cws_.prev_delta_padded_, *in_grad[0]);
+    // init padding buffer
+    if (params_.pad_type == padding::same) {
+      cws_.prev_delta_padded_.resize(
+          1, vec_t(params_.in_padded.size(), float_t(0)));
     }
+  }
 
-    void set_sample_count(cnn_size_t sample_count) override {
-        Base::set_sample_count(sample_count);
-        cws_.prev_delta_padded_.resize(
-            sample_count,
-            vec_t(params_.in_padded.size(), float_t(0)));
+  cnn_size_t in_length(cnn_size_t in_length, cnn_size_t window_size,
+                       padding pad_type) const {
+    return pad_type == padding::same ? (in_length + window_size - 1)
+                                     : in_length;
+  }
+
+  static cnn_size_t conv_out_length(cnn_size_t in_length,
+                                    cnn_size_t window_size, cnn_size_t stride,
+                                    padding pad_type) {
+    size_t output_length;
+
+    if (pad_type == padding::same) {
+      output_length = in_length;
+    } else if (pad_type == padding::valid) {
+      output_length = in_length - window_size + 1;
+    } else {
+      throw nn_error("Not recognized pad_type.");
     }
+    return (output_length + stride - 1) / stride;
+  }
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias) {
-            return { params_.in, params_.weight,
-                index3d<cnn_size_t>(1, 1, params_.out.depth_) };
-        }
-        else {
-            return { params_.in, params_.weight };
-        }
-    }
+  static cnn_size_t conv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                                 cnn_size_t window_size, cnn_size_t w_stride,
+                                 cnn_size_t h_stride, padding pad_type) {
+    return conv_out_length(in_width, window_size, w_stride, pad_type) *
+           conv_out_length(in_height, window_size, h_stride, pad_type);
+  }
 
-    std::vector<index3d<cnn_size_t>>
-    out_shape() const override { return { params_.out, params_.out }; }
+  cnn_size_t conv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                          cnn_size_t window_width, cnn_size_t window_height,
+                          cnn_size_t w_stride, cnn_size_t h_stride,
+                          padding pad_type) const {
+    return conv_out_length(in_width, window_width, w_stride, pad_type) *
+           conv_out_length(in_height, window_height, h_stride, pad_type);
+  }
 
-    std::string layer_type() const override {
-        return std::string("conv");
-    }
+  void createOp() override { init_backend(layer::engine()); }
 
-    std::string kernel_file() const override {
-        return std::string("../tiny_cnn/core/kernels/cl_kernels/conv_layer_spatial.cl");
-    }
-
-    std::string kernel_header() const override {
-        std::stringstream ss;
-        ss << "#define MULTI\n";
-        ss << "#define KERNEL_H " << params_.weight.height_ << "\n";
-        ss << "#define KERNEL_W " << params_.weight.width_  << "\n";
-        ss << "#define CHANNELS " << params_.weight.depth_  << "\n";
-        ss << "#define STRIDE_H " << params_.h_stride << "\n";
-        ss << "#define STRIDE_W " << params_.w_stride << "\n";
-        ss << "#define APPLY_BIAS " << params_.has_bias   << "\n";
-        ss << "#define OUTPUT_Z "   << params_.out.depth_ << "\n";
-        // TODO(edgar): REVISE THIS
-        ss << "#define ZPAR " << params_.out.depth_  << "\n";
-        return ss.str();
-    }
-
-    image<> weight_to_image() const {
-        image<> img;
-        const cnn_size_t border_width = 1;
-        const auto pitch = params_.weight.width_ + border_width;
-        const auto width = params_.out.depth_ * pitch + border_width;
-        const auto height = params_.in.depth_ * pitch + border_width;
-        const image<>::intensity_t bg_color = 255;
-        const vec_t& W = *this->weights()[0];
-
-        img.resize(width, height);
-        img.fill(bg_color);
-
-        auto minmax = std::minmax_element(W.begin(), W.end());
-
-        for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
-            for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
-                if (!params_.tbl.is_connected(c, r)) continue;
-
-                const auto top  = r * pitch + border_width;
-                const auto left = c * pitch + border_width;
-
-                cnn_size_t idx = 0;
-
-                for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
-                    for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
-                        idx = c * params_.in.depth_ + r;
-                        idx = params_.weight.get_index(x, y, idx);
-                        const float_t w = W[idx];
-
-                        img.at(left + x, top + y)
-                            = static_cast<image<>::intensity_t>(
-                                rescale(w, *minmax.first,
-                                        *minmax.second, 0, 255));
-                    }
-                }
-            }
-        }
-        return img;
-    }
-
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<convolutional_layer> & construct) {
-        size_t w_width, w_height, out_ch, w_stride, h_stride;
-        bool has_bias;
-        shape3d in;
-        padding pad_type;
-        connection_table tbl;
-
-        ar(cereal::make_nvp("in_size", in),
-            cereal::make_nvp("window_width", w_width),
-            cereal::make_nvp("window_height", w_height),
-            cereal::make_nvp("out_channels", out_ch),
-            cereal::make_nvp("connection_table", tbl),
-            cereal::make_nvp("pad_type", pad_type),
-            cereal::make_nvp("has_bias", has_bias),
-            cereal::make_nvp("w_stride", w_stride),
-            cereal::make_nvp("h_stride", h_stride)
-        );
-
-        construct(in.width_, in.height_, w_width, w_height, in.depth_, out_ch, tbl, pad_type, has_bias, w_stride, h_stride);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in),
-            cereal::make_nvp("window_width", params_.weight.width_),
-            cereal::make_nvp("window_height", params_.weight.height_),
-            cereal::make_nvp("out_channels", params_.out.depth_),
-            cereal::make_nvp("connection_table", params_.tbl),
-            cereal::make_nvp("pad_type", params_.pad_type),
-            cereal::make_nvp("has_bias", params_.has_bias),
-            cereal::make_nvp("w_stride", params_.w_stride),
-            cereal::make_nvp("h_stride", params_.h_stride)
-            );
-    }
-
-private:
-    tensor_t* in_data_padded(const std::vector<tensor_t*>& in) {
-        return (params_.pad_type == core::padding::valid) ? in[0] : &cws_.prev_out_padded_;
-    }
-
-    void conv_set_params(const shape3d& in,
-                         cnn_size_t     w_width,
-                         cnn_size_t     w_height,
-                         cnn_size_t     outc,
-                         padding        ptype,
-                         bool           has_bias,
-                         cnn_size_t     w_stride,
-                         cnn_size_t     h_stride,
-                         const connection_table& tbl = connection_table()) {
-        params_.in = in;
-        params_.in_padded = shape3d(in_length(in.width_, w_width, ptype),
-                                    in_length(in.height_, w_height, ptype),
-                                    in.depth_);
-        params_.out =
-            shape3d(conv_out_length(in.width_, w_width, w_stride, ptype),
-                    conv_out_length(in.height_, w_height, h_stride, ptype),
-                    outc);
-        params_.weight   = shape3d(w_width, w_height, in.depth_ * outc);
-        params_.has_bias = has_bias;
-        params_.pad_type = ptype;
-        params_.w_stride = w_stride;
-        params_.h_stride = h_stride;
-        params_.tbl      = tbl;
-
-        // init padding buffer
-        if (params_.pad_type == padding::same) {
-            cws_.prev_delta_padded_.resize(1, vec_t(params_.in_padded.size(), float_t(0)));
-        }
-    }
-
-    cnn_size_t in_length(cnn_size_t in_length,
-                         cnn_size_t window_size, padding pad_type) const {
-        return pad_type == padding::same ?
-               (in_length + window_size - 1) : in_length;
-    }
-
-    static cnn_size_t conv_out_length(cnn_size_t in_length,
-                                      cnn_size_t window_size,
-                                      cnn_size_t stride, padding pad_type) {
-
-        size_t output_length;
-
-        if (pad_type == padding::same) {
-            output_length = in_length;
-        } else if (pad_type == padding::valid) {
-            output_length = in_length - window_size + 1;
-        } else {
-            throw nn_error("Not recognized pad_type.");
-        }
-        return (output_length + stride - 1) / stride;
-    }
-
-    static cnn_size_t conv_out_dim(cnn_size_t in_width,
-                                   cnn_size_t in_height,
-                                   cnn_size_t window_size,
-                                   cnn_size_t w_stride,
-                                   cnn_size_t h_stride, padding pad_type) {
-        return conv_out_length(in_width, window_size, w_stride, pad_type) *
-               conv_out_length(in_height, window_size, h_stride, pad_type);
-    }
-
-    cnn_size_t conv_out_dim(cnn_size_t in_width,
-                            cnn_size_t in_height,
-                            cnn_size_t window_width,
-                            cnn_size_t window_height,
-                            cnn_size_t w_stride,
-                            cnn_size_t h_stride, padding pad_type) const {
-        return conv_out_length(in_width, window_width, w_stride, pad_type) *
-               conv_out_length(in_height, window_height, h_stride, pad_type);
-    }
-
-    void createOp() override {
-        init_backend(layer::engine());
-    }
-
-    void init_backend(const backend_t backend_type) {
-        core::OpKernelConstruction ctx =
+  void init_backend(const backend_t backend_type) {
+    core::OpKernelConstruction ctx =
         core::OpKernelConstruction(layer::device(), &params_);
 
-        if (backend_type == backend_t::tiny_dnn ||
-            backend_type == backend_t::nnpack ||
-            backend_type == backend_t::avx) {
-            
-            kernel_fwd_.reset(new Conv2dOp(ctx));
-            kernel_back_.reset(new Conv2dGradOp(ctx));
+    if (backend_type == backend_t::tiny_dnn ||
+        backend_type == backend_t::nnpack || backend_type == backend_t::avx) {
+      kernel_fwd_.reset(new Conv2dOp(ctx));
+      kernel_back_.reset(new Conv2dGradOp(ctx));
 
-            return;
-        }
-
-        else if (backend_type == backend_t::opencl) {
-            throw nn_error("Not implemented engine: " + to_string(backend_type));
-            /*kernel_fwd_.reset(new Conv2dOpenCLForwardOp(ctx));
-            kernel_back_.reset(new Conv2dOpenCLBackwardOp(ctx));
-            return;*/
-        }
-        else if (backend_type == backend_t::libdnn) {
-            if (layer::device() == nullptr) return;
-            kernel_fwd_.reset(new Conv2dLibDNNForwardOp(ctx));
-            kernel_back_.reset(new Conv2dLibDNNBackwardOp(ctx));
-            return;
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(backend_type));
-        }
-
+      return;
     }
+
+    else if (backend_type == backend_t::opencl) {
+      throw nn_error("Not implemented engine: " + to_string(backend_type));
+      /*kernel_fwd_.reset(new Conv2dOpenCLForwardOp(ctx));
+      kernel_back_.reset(new Conv2dOpenCLBackwardOp(ctx));
+      return;*/
+    } else if (backend_type == backend_t::libdnn) {
+      if (layer::device() == nullptr) return;
+      kernel_fwd_.reset(new Conv2dLibDNNForwardOp(ctx));
+      kernel_back_.reset(new Conv2dLibDNNBackwardOp(ctx));
+      return;
+    } else {
+      throw nn_error("Not supported engine: " + to_string(backend_type));
+    }
+  }
 
  private:
-    /* Applies padding to an input tensor given the convolution parameters
-     *
-     * @param in The input tensor
-     * @param out The output tensor with padding applied
-     */
-    void copy_and_pad_input(const tensor_t& in, tensor_t& out) {
-        if (params_.pad_type == core::padding::valid) {
-            return;
-        }
-
-        tensor_t buf(in.size());
-
-        for_i(true, buf.size(), [&](int sample) {
-            // alloc temporary buffer.
-            //buf[sample].resize(params_.in.depth_ *
-              //                 params_.in_padded.height_ *
-                //               params_.in_padded.width_);
-            buf[sample].resize(params_.in_padded.size());
-
-            // make padded version in order to avoid corner-case in fprop/bprop
-            for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                float_t* pimg = &buf[sample][params_.in_padded.get_index(
-                                             params_.weight.width_  / 2,
-                                             params_.weight.height_ / 2, c)];
-                const float_t* pin = &in[sample][params_.in.get_index(0, 0, c)];
-
-                for (cnn_size_t y = 0; y < params_.in.height_; y++) {
-                    std::copy(pin, pin + params_.in.width_, pimg);
-                    pin  += params_.in.width_;
-                    pimg += params_.in_padded.width_;
-                }
-            }
-        });
-
-        // shrink buffer to output
-        out = buf;
+  /* Applies padding to an input tensor given the convolution parameters
+   *
+   * @param in The input tensor
+   * @param out The output tensor with padding applied
+   */
+  void copy_and_pad_input(const tensor_t& in, tensor_t& out) {
+    if (params_.pad_type == core::padding::valid) {
+      return;
     }
 
-    /* Applies unpadding to an input tensor given the convolution parameters
-     *
-     * @param in The input tensor
-     * @param out The output tensor with unpadding applied
-     */
-    void copy_and_unpad_delta(const tensor_t& delta, tensor_t& delta_unpadded) {
-        if (params_.pad_type == core::padding::valid) {
-            return;
+    tensor_t buf(in.size());
+
+    for_i(true, buf.size(), [&](int sample) {
+      // alloc temporary buffer.
+      // buf[sample].resize(params_.in.depth_ *
+      //                 params_.in_padded.height_ *
+      //               params_.in_padded.width_);
+      buf[sample].resize(params_.in_padded.size());
+
+      // make padded version in order to avoid corner-case in fprop/bprop
+      for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+        float_t* pimg = &buf[sample][params_.in_padded.get_index(
+            params_.weight.width_ / 2, params_.weight.height_ / 2, c)];
+        const float_t* pin = &in[sample][params_.in.get_index(0, 0, c)];
+
+        for (cnn_size_t y = 0; y < params_.in.height_; y++) {
+          std::copy(pin, pin + params_.in.width_, pimg);
+          pin += params_.in.width_;
+          pimg += params_.in_padded.width_;
         }
+      }
+    });
 
-        tensor_t buf(delta.size());
+    // shrink buffer to output
+    out = buf;
+  }
 
-        for_i(true, buf.size(), [&](int sample) {
-            // alloc temporary buffer.
-            //buf[sample].resize(params_.in.depth_ *
-              //                 params_.in.height_ *
-                //               params_.in.width_);
-            buf[sample].resize(params_.in.size());
-
-            for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                const float_t *pin =
-                    &delta[sample][params_.in_padded.get_index(
-                                   params_.weight.width_  / 2,
-                                   params_.weight.height_ / 2, c)];
-                float_t *pdst = &buf[sample][params_.in.get_index(0, 0, c)];
-
-                for (cnn_size_t y = 0; y < params_.in.height_; y++) {
-                    std::copy(pin, pin + params_.in.width_, pdst);
-                    pdst += params_.in.width_;
-                    pin  += params_.in_padded.width_;
-                }
-            }
-        });
-
-        // shrink buffer to output
-        delta_unpadded = buf;
+  /* Applies unpadding to an input tensor given the convolution parameters
+   *
+   * @param in The input tensor
+   * @param out The output tensor with unpadding applied
+   */
+  void copy_and_unpad_delta(const tensor_t& delta, tensor_t& delta_unpadded) {
+    if (params_.pad_type == core::padding::valid) {
+      return;
     }
+
+    tensor_t buf(delta.size());
+
+    for_i(true, buf.size(), [&](int sample) {
+      // alloc temporary buffer.
+      // buf[sample].resize(params_.in.depth_ *
+      //                 params_.in.height_ *
+      //               params_.in.width_);
+      buf[sample].resize(params_.in.size());
+
+      for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+        const float_t* pin = &delta[sample][params_.in_padded.get_index(
+            params_.weight.width_ / 2, params_.weight.height_ / 2, c)];
+        float_t* pdst = &buf[sample][params_.in.get_index(0, 0, c)];
+
+        for (cnn_size_t y = 0; y < params_.in.height_; y++) {
+          std::copy(pin, pin + params_.in.width_, pdst);
+          pdst += params_.in.width_;
+          pin += params_.in_padded.width_;
+        }
+      }
+    });
+
+    // shrink buffer to output
+    delta_unpadded = buf;
+  }
 
  private:
-    /* The convolution parameters */
-    conv_params params_;
+  /* The convolution parameters */
+  conv_params params_;
 
-    /* Forward and backward ops */
-    std::shared_ptr<core::OpKernel> kernel_fwd_;
-    std::shared_ptr<core::OpKernel> kernel_back_;
+  /* Forward and backward ops */
+  std::shared_ptr<core::OpKernel> kernel_fwd_;
+  std::shared_ptr<core::OpKernel> kernel_back_;
 
-    /* Buffer to store padded data */
-    struct conv_layer_worker_specific_storage {
-        tensor_t prev_out_padded_;
-        tensor_t prev_delta_padded_;
-    } cws_;
+  /* Buffer to store padded data */
+  struct conv_layer_worker_specific_storage {
+    tensor_t prev_out_padded_;
+    tensor_t prev_delta_padded_;
+  } cws_;
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/layers/deconvolutional_layer.h
+++ b/tiny_dnn/layers/deconvolutional_layer.h
@@ -4,20 +4,20 @@
 
 #pragma once
 
+#include <algorithm>
 #include <deque>
 #include <string>
-#include <algorithm>
 
-#include "tiny_dnn/core/backend_tiny.h"
-#include "tiny_dnn/core/backend_nnp.h"
 #include "tiny_dnn/core/backend_dnn.h"
+#include "tiny_dnn/core/backend_nnp.h"
+#include "tiny_dnn/core/backend_tiny.h"
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/backend_avx.h"
 #endif
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 using namespace tiny_dnn::core;
 
@@ -28,454 +28,446 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class deconvolutional_layer : public feedforward_layer<Activation> {
-public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width     [in] input image width
-    * @param in_height    [in] input image height
-    * @param window_size  [in] window(kernel) size of convolution
-    * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels [in] output image channels
-    * @param padding      [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    deconvolutional_layer(cnn_size_t     in_width,
-                          cnn_size_t     in_height,
-                          cnn_size_t     window_size,
-                          cnn_size_t     in_channels,
-                          cnn_size_t     out_channels,
-                          padding        pad_type = padding::valid,
-                          bool           has_bias = true,
-                          cnn_size_t     w_stride = 1,
-                          cnn_size_t     h_stride = 1,
-                          backend_t      backend_type = backend_t::tiny_dnn,
-                          backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                              window_size, window_size,
-                              out_channels, pad_type, has_bias,
-                              w_stride, h_stride);
-            init_backend(backend_type);
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width     [in] input image width
+  * @param in_height    [in] input image height
+  * @param window_size  [in] window(kernel) size of convolution
+  * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels [in] output image channels
+  * @param padding      [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t window_size, cnn_size_t in_channels,
+                        cnn_size_t out_channels,
+                        padding pad_type = padding::valid, bool has_bias = true,
+                        cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                        backend_t backend_type = backend_t::tiny_dnn,
+                        backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                      window_size, out_channels, pad_type, has_bias, w_stride,
+                      h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width      [in] input image width
+  * @param in_height     [in] input image height
+  * @param window_width  [in] window_width(kernel) size of convolution
+  * @param window_height [in] window_height(kernel) size of convolution
+  * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels  [in] output image channels
+  * @param padding       [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_width + 1) * (in-height - window_height + 1) *
+  *out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t window_width, cnn_size_t window_height,
+                        cnn_size_t in_channels, cnn_size_t out_channels,
+                        padding pad_type = padding::valid, bool has_bias = true,
+                        cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                        backend_t backend_type = backend_t::tiny_dnn,
+                        backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                      window_height, out_channels, pad_type, has_bias, w_stride,
+                      h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_size      [in] window(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t window_size, cnn_size_t in_channels,
+                        cnn_size_t out_channels,
+                        const connection_table& connection_table,
+                        padding pad_type = padding::valid, bool has_bias = true,
+                        cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                        backend_t backend_type = backend_t::tiny_dnn,
+                        backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                      window_size, out_channels, pad_type, has_bias, w_stride,
+                      h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_width     [in] window_width(kernel) size of convolution
+  * @param window_height    [in] window_height(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                        cnn_size_t window_width, cnn_size_t window_height,
+                        cnn_size_t in_channels, cnn_size_t out_channels,
+                        const connection_table& connection_table,
+                        padding pad_type = padding::valid, bool has_bias = true,
+                        cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+                        backend_t backend_type = backend_t::tiny_dnn,
+                        backend_params b_params = backend_params())
+      : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                      window_height, out_channels, pad_type, has_bias, w_stride,
+                      h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  // move constructor
+  deconvolutional_layer(deconvolutional_layer&& other)
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        backend_type_(std::move(other.backend_type_)),
+        deconv_layer_worker_storage_(
+            std::move(other.deconv_layer_worker_storage_)) {
+    init_backend(std::move(Base::backend_type()));
+  }
+
+  ///< number of incoming connections for each output unit
+  virtual size_t fan_in_size() const override {
+    return params_.weight.width_ * params_.weight.height_ * params_.in.depth_;
+  }
+
+  ///< number of outgoing connections for each input unit
+  virtual size_t fan_out_size() const override {
+    return (params_.weight.width_ * params_.w_stride) *
+           (params_.weight.height_ * params_.h_stride) * params_.out.depth_;
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    // launch deconvolutional kernel
+    Base::backend_->deconv2d(in_data, out_data);
+
+    // activations
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
+
+  /**
+   * return delta of previous layer (delta=\frac{dE}{da}, a=wx in
+   *fully-connected layer)
+   * @param worker_index id of current worker-task
+   * @param in_data      input vectors (same vectors as forward_propagation)
+   * @param out_data     output vectors (same vectors as forward_propagation)
+   * @param out_grad     gradient of output vectors (i-th vector correspond with
+   *out_data[i])
+   * @param in_grad      gradient of input vectors (i-th vector correspond with
+   *in_data[i])
+   **/
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    Base::backend_->deconv2d(in_data, out_data, out_grad, in_grad);
+  }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias) {
+      return {params_.in, params_.weight,
+              index3d<cnn_size_t>(1, 1, params_.out.depth_)};
+    } else {
+      return {params_.in, params_.weight};
     }
+  }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width      [in] input image width
-    * @param in_height     [in] input image height
-    * @param window_width  [in] window_width(kernel) size of convolution
-    * @param window_height [in] window_height(kernel) size of convolution
-    * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels  [in] output image channels
-    * @param padding       [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_width + 1) * (in-height - window_height + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    deconvolutional_layer(cnn_size_t     in_width,
-                          cnn_size_t     in_height,
-                          cnn_size_t     window_width,
-                          cnn_size_t     window_height,
-                          cnn_size_t     in_channels,
-                          cnn_size_t     out_channels,
-                          padding        pad_type = padding::valid,
-                          bool           has_bias = true,
-                          cnn_size_t     w_stride = 1,
-                          cnn_size_t     h_stride = 1,
-                          backend_t      backend_type = backend_t::tiny_dnn,
-                          backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                              window_width, window_height,
-                              out_channels, pad_type, has_bias,
-                              w_stride, h_stride);
-            init_backend(backend_type);
-    }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {params_.out_unpadded, params_.out_unpadded};
+  }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_size      [in] window(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    deconvolutional_layer(cnn_size_t              in_width,
-                          cnn_size_t              in_height,
-                          cnn_size_t              window_size,
-                          cnn_size_t              in_channels,
-                          cnn_size_t              out_channels,
-                          const connection_table& connection_table,
-                          padding                 pad_type = padding::valid,
-                          bool                    has_bias = true,
-                          cnn_size_t              w_stride = 1,
-                          cnn_size_t              h_stride = 1,
-                          backend_t               backend_type = backend_t::tiny_dnn,
-                          backend_params          b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                              window_size, window_size,
-                              out_channels, pad_type, has_bias,
-                              w_stride, h_stride,
-                              connection_table);
-            init_backend(backend_type);
-    }
+  std::string layer_type() const override { return "deconv"; }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_width     [in] window_width(kernel) size of convolution
-    * @param window_height    [in] window_height(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    deconvolutional_layer(cnn_size_t              in_width,
-                          cnn_size_t              in_height,
-                          cnn_size_t              window_width,
-                          cnn_size_t              window_height,
-                          cnn_size_t              in_channels,
-                          cnn_size_t              out_channels,
-                          const connection_table& connection_table,
-                          padding                 pad_type = padding::valid,
-                          bool                    has_bias = true,
-                          cnn_size_t              w_stride = 1,
-                          cnn_size_t              h_stride = 1,
-                          backend_t               backend_type = backend_t::tiny_dnn,
-                          backend_params          b_params = backend_params())
-        : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                              window_width, window_height,
-                              out_channels, pad_type, has_bias,
-                              w_stride, h_stride,
-                              connection_table);
-            init_backend(backend_type);
-    }
+  image<> weightto_image() const {
+    image<> img;
+    const cnn_size_t border_width = 1;
+    const auto pitch = params_.weight.width_ + border_width;
+    const auto width = params_.out.depth_ * pitch + border_width;
+    const auto height = params_.in.depth_ * pitch + border_width;
+    const image<>::intensity_t bg_color = 255;
+    const vec_t& W = *this->get_weights()[0];
 
-    // move constructor
-    deconvolutional_layer(deconvolutional_layer&& other)
-        : Base(std::move(other))
-        , params_(std::move(other.params_))
-        , backend_type_(std::move(other.backend_type_))
-        , deconv_layer_worker_storage_(std::move(other.deconv_layer_worker_storage_)) {
-            init_backend(std::move(Base::backend_type()));
-    }
+    img.resize(width, height);
+    img.fill(bg_color);
 
-    ///< number of incoming connections for each output unit
-    virtual size_t fan_in_size() const override {
-        return  params_.weight.width_ *
-                params_.weight.height_ *
-                params_.in.depth_;
-    }
+    auto minmax = std::minmax_element(W.begin(), W.end());
 
-    ///< number of outgoing connections for each input unit
-    virtual size_t fan_out_size() const override {
-        return  (params_.weight.width_ * params_.w_stride) *
-                (params_.weight.height_ * params_.h_stride) *
-                params_.out.depth_;
-    }
+    for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
+      for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
+        if (!params_.tbl.is_connected(c, r)) continue;
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) override {
-        // launch deconvolutional kernel
-        Base::backend_->deconv2d(in_data, out_data);
+        const auto top = r * pitch + border_width;
+        const auto left = c * pitch + border_width;
 
-        // activations
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
+        cnn_size_t idx = 0;
 
-    /**
-     * return delta of previous layer (delta=\frac{dE}{da}, a=wx in fully-connected layer)
-     * @param worker_index id of current worker-task
-     * @param in_data      input vectors (same vectors as forward_propagation)
-     * @param out_data     output vectors (same vectors as forward_propagation)
-     * @param out_grad     gradient of output vectors (i-th vector correspond with out_data[i])
-     * @param in_grad      gradient of input vectors (i-th vector correspond with in_data[i])
-     **/
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        Base::backend_->deconv2d(in_data, out_data, out_grad, in_grad);
-    }
+        for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
+          for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
+            idx = params_.weight.get_index(x, y, c * params_.in.depth_ + r);
+            const float_t w = W[idx];
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias) {
-            return { params_.in, params_.weight,
-                     index3d<cnn_size_t>(1, 1, params_.out.depth_) };
-        } else {
-            return { params_.in, params_.weight };
+            img.at(left + x, top + y) = static_cast<image<>::intensity_t>(
+                rescale(w, *minmax.first, *minmax.second, 0, 255));
+          }
         }
+      }
     }
+    return img;
+  }
 
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return {params_.out_unpadded, params_.out_unpadded};
-    }
+ private:
+  void init_backend(const backend_t backend_type) {
+    std::shared_ptr<core::backend> backend = nullptr;
 
-    std::string layer_type() const override { return "deconv"; }
-
-    image<> weightto_image() const {
-        image<> img;
-        const cnn_size_t border_width = 1;
-        const auto pitch = params_.weight.width_ + border_width;
-        const auto width = params_.out.depth_ * pitch + border_width;
-        const auto height = params_.in.depth_ * pitch + border_width;
-        const image<>::intensity_t bg_color = 255;
-        const vec_t& W = *this->get_weights()[0];
-
-        img.resize(width, height);
-        img.fill(bg_color);
-
-        auto minmax = std::minmax_element(W.begin(), W.end());
-
-        for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
-            for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
-                if (!params_.tbl.is_connected(c, r)) continue;
-
-                const auto top = r * pitch + border_width;
-                const auto left = c * pitch + border_width;
-
-                cnn_size_t idx = 0;
-
-                for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
-                    for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
-                        idx = params_.weight.get_index(x, y, c * params_.in.depth_ + r);
-                        const float_t w = W[idx];
-
-                        img.at(left + x, top + y)
-                            = static_cast<image<>::intensity_t>(
-                                rescale(w, *minmax.first,
-                                        *minmax.second, 0, 255));
-                    }
-                }
-            }
-        }
-        return img;
-    }
-
-private:
-    void init_backend(const backend_t backend_type) {
-        std::shared_ptr<core::backend> backend = nullptr;
-
-        // allocate new backend
-        if (backend_type == backend_t::tiny_dnn) {
-            backend = std::make_shared<core::tiny_backend>(&params_,
-                    [this](const tensor_t& in) {
-                        return copy_and_unpad_output(in);
-                    },
-                    [this](const tensor_t& delta, tensor_t& dst) {
-                        return copy_and_pad_delta(delta, dst);
-                    },
-                    [this](const tensor_t& p_delta,
-                           const tensor_t& out, tensor_t& c_delta) {
-                        return Base::backward_activation(p_delta, out, c_delta);
-                    },
-                    &deconv_layer_worker_storage_);
-        } else if (backend_type == backend_t::nnpack) {
-            backend = std::make_shared<core::nnp_backend>();
-        } else if (backend_type == backend_t::libdnn) {
-            backend = std::make_shared<core::dnn_backend>();
+    // allocate new backend
+    if (backend_type == backend_t::tiny_dnn) {
+      backend = std::make_shared<core::tiny_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_unpad_output(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_pad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &deconv_layer_worker_storage_);
+    } else if (backend_type == backend_t::nnpack) {
+      backend = std::make_shared<core::nnp_backend>();
+    } else if (backend_type == backend_t::libdnn) {
+      backend = std::make_shared<core::dnn_backend>();
 #ifdef CNN_USE_AVX
-        } else if (backend_type == backend_t::avx) {
-            backend = std::make_shared<core::avx_backend>(&params_,
-                    [this](const tensor_t& in) {
-                        return copy_and_unpad_output(in);
-                    },
-                    [this](const tensor_t& delta, tensor_t& dst) {
-                        return copy_and_pad_delta(delta, dst);
-                    },
-                    [this](const tensor_t& p_delta,
-                           const tensor_t& out, tensor_t& c_delta) {
-                        return Base::backward_activation(p_delta, out, c_delta);
-                    },
-                    &deconv_layer_worker_storage_);
+    } else if (backend_type == backend_t::avx) {
+      backend = std::make_shared<core::avx_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_unpad_output(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_pad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &deconv_layer_worker_storage_);
 #endif
-        } else {
-            throw nn_error("Not supported backend type.");
-        }
-
-        if (backend) {
-            Base::set_backend(backend);
-            Base::backend_->set_layer(this);
-        } else {
-            throw nn_error("Could not allocate the backend.");
-        }
+    } else {
+      throw nn_error("Not supported backend type.");
     }
 
-    void deconv_set_params(const shape3d& in,
-                         cnn_size_t     w_width,
-                         cnn_size_t     w_height,
-                         cnn_size_t     outc,
-                         padding        ptype,
-                         bool           has_bias,
-                         cnn_size_t     w_stride,
-                         cnn_size_t     h_stride,
+    if (backend) {
+      Base::set_backend(backend);
+      Base::backend_->set_layer(this);
+    } else {
+      throw nn_error("Could not allocate the backend.");
+    }
+  }
+
+  void deconv_set_params(const shape3d& in, cnn_size_t w_width,
+                         cnn_size_t w_height, cnn_size_t outc, padding ptype,
+                         bool has_bias, cnn_size_t w_stride,
+                         cnn_size_t h_stride,
                          const connection_table& tbl = connection_table()) {
-        params_.in = in;
-        params_.out =
-              shape3d(deconv_out_length(in.width_, w_width, w_stride),
-                      deconv_out_length(in.height_, w_height, h_stride),
-                      outc);
-        params_.out_unpadded =
-              shape3d(deconv_out_unpadded_length(in.width_, w_width, w_stride, ptype),
-                      deconv_out_unpadded_length(in.height_, w_height, h_stride, ptype),
-                      outc);
-        params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
-        params_.has_bias = has_bias;
-        params_.pad_type = ptype;
-        params_.w_stride = w_stride;
-        params_.h_stride = h_stride;
-        params_.tbl      = tbl;
+    params_.in = in;
+    params_.out =
+        shape3d(deconv_out_length(in.width_, w_width, w_stride),
+                deconv_out_length(in.height_, w_height, h_stride), outc);
+    params_.out_unpadded = shape3d(
+        deconv_out_unpadded_length(in.width_, w_width, w_stride, ptype),
+        deconv_out_unpadded_length(in.height_, w_height, h_stride, ptype),
+        outc);
+    params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
+    params_.has_bias = has_bias;
+    params_.pad_type = ptype;
+    params_.w_stride = w_stride;
+    params_.h_stride = h_stride;
+    params_.tbl = tbl;
+  }
+
+  void init_workers(cnn_size_t sample_count) {
+    deconv_layer_worker_specific_storage& dws = deconv_layer_worker_storage_;
+
+    if (params_.pad_type == padding::same) {
+      dws.curr_out_buf_.resize(sample_count,
+                               vec_t(params_.out_unpadded.size(), float_t(0)));
+      dws.curr_delta_padded.resize(sample_count,
+                                   vec_t(params_.out.size(), float_t(0)));
+    } else {
+      dws.curr_out_buf_.clear();
     }
+  }
 
-    void init_workers(cnn_size_t sample_count) {
-        deconv_layer_worker_specific_storage& dws = deconv_layer_worker_storage_;
+  cnn_size_t in_length(cnn_size_t in_length, cnn_size_t window_size,
+                       padding pad_type) const {
+    return in_length;
+  }
 
-        if (params_.pad_type == padding::same) {
-            dws.curr_out_buf_.resize(sample_count, vec_t(params_.out_unpadded.size(), float_t(0)));
-            dws.curr_delta_padded.resize(sample_count, vec_t(params_.out.size(), float_t(0)));
+  static cnn_size_t deconv_out_length(cnn_size_t in_length,
+                                      cnn_size_t window_size,
+                                      cnn_size_t stride) {
+    return (cnn_size_t)ceil((float_t)(in_length)*stride + window_size - 1);
+  }
+
+  static cnn_size_t deconv_out_unpadded_length(cnn_size_t in_length,
+                                               cnn_size_t window_size,
+                                               cnn_size_t stride,
+                                               padding pad_type) {
+    return pad_type == padding::same
+               ? (cnn_size_t)ceil((float_t)in_length * stride)
+               : (cnn_size_t)ceil((float_t)(in_length)*stride + window_size -
+                                  1);
+  }
+
+  static cnn_size_t deconv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                                   cnn_size_t window_size, cnn_size_t w_stride,
+                                   cnn_size_t h_stride, padding pad_type) {
+    return deconv_out_unpadded_length(in_width, window_size, w_stride,
+                                      pad_type) *
+           deconv_out_unpadded_length(in_height, window_size, h_stride,
+                                      pad_type);
+  }
+
+  cnn_size_t deconv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                            cnn_size_t window_width, cnn_size_t window_height,
+                            cnn_size_t w_stride, cnn_size_t h_stride,
+                            padding pad_type) const {
+    return deconv_out_unpadded_length(in_width, window_width, w_stride,
+                                      pad_type) *
+           deconv_out_unpadded_length(in_height, window_height, h_stride,
+                                      pad_type);
+  }
+
+  void copy_and_pad_delta(const tensor_t& delta, tensor_t& delta_padded) {
+    if (params_.pad_type == padding::valid) {
+      delta_padded = delta;
+    } else {
+      for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
+        vec_t& dst = delta_padded[sample];
+        const vec_t& src = delta[sample];
+
+        for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+          float_t* pdst = &dst[params_.in.get_index(0, 0, c)];
+          const float_t* pin = &src[params_.in.get_index(0, 0, c)];
+
+          for (cnn_size_t y = 0; y < params_.in.height_;
+               y++, pdst += params_.in.width_, pin += params_.in.width_) {
+            std::copy(pin, pin + params_.in.width_, pdst);
+          }
         }
-        else {
-            dws.curr_out_buf_.clear();
+      }
+    }
+  }
+
+  void copy_and_unpad_output(const tensor_t& out) {
+    deconv_layer_worker_specific_storage& dws = deconv_layer_worker_storage_;
+
+    dws.curr_out_buf_ =
+        tensor_t(out.size(), vec_t(params_.out_unpadded.width_ *
+                                       params_.out_unpadded.height_ *
+                                       params_.out_unpadded.depth_,
+                                   0));
+    tensor_t* dst_tensor = &dws.curr_out_buf_;
+
+    if (params_.pad_type == padding::valid) {
+      dws.curr_out_unpadded_ = &out;
+    } else {
+      // make unpadded version in order to restore scale in fprop/bprop
+      for (cnn_size_t sample = 0; sample < out.size(); sample++) {
+        cnn_size_t idx = 0;
+        vec_t& dst = (*dst_tensor)[sample];
+        size_t wieght_w_half =
+            static_cast<size_t>(floor(params_.weight.width_ / 2));
+        size_t wieght_h_half =
+            static_cast<size_t>(floor(params_.weight.height_ / 2));
+
+        for (cnn_size_t c = 0; c < params_.out_unpadded.depth_; c++) {
+          float_t* pimg = &dst[params_.out_unpadded.get_index(0, 0, c)];
+          idx = params_.out.get_index(wieght_w_half, wieght_h_half, c);
+          const float_t* pout = &out[sample][idx];
+
+          for (cnn_size_t y = wieght_h_half;
+               y < params_.out_unpadded.height_ + wieght_h_half;
+               y++, pout += params_.out.width_,
+                          pimg += params_.out_unpadded.width_) {
+            std::copy(pout, pout + params_.out_unpadded.width_, pimg);
+          }
         }
+      }
 
+      dws.curr_out_unpadded_ = &dws.curr_out_buf_;
     }
+  }
 
-    cnn_size_t in_length(cnn_size_t in_length,
-                        cnn_size_t window_size, padding pad_type) const {
-        return in_length;
-    }
+  /* The convolution parameters */
+  deconv_params params_;
 
-    static cnn_size_t deconv_out_length(cnn_size_t in_length,
-                                        cnn_size_t window_size,
-                                        cnn_size_t stride) {
-        return (cnn_size_t)ceil((float_t)(in_length) * stride + window_size - 1);
-    }
+  /* The type of backend */
+  backend_t backend_type_;
 
-    static cnn_size_t deconv_out_unpadded_length(cnn_size_t in_length,
-                                                 cnn_size_t window_size,
-                                                 cnn_size_t stride, padding pad_type) {
-        return pad_type == padding::same ?
-                (cnn_size_t)ceil((float_t)in_length * stride) :
-                (cnn_size_t)ceil((float_t)(in_length) * stride + window_size - 1);
-    }
-
-    static cnn_size_t deconv_out_dim(cnn_size_t in_width,
-                                     cnn_size_t in_height,
-                                     cnn_size_t window_size,
-                                     cnn_size_t w_stride,
-                                     cnn_size_t h_stride, padding pad_type) {
-        return deconv_out_unpadded_length(in_width, window_size, w_stride, pad_type) *
-                deconv_out_unpadded_length(in_height, window_size, h_stride, pad_type);
-    }
-
-    cnn_size_t deconv_out_dim(cnn_size_t in_width,
-                              cnn_size_t in_height,
-                              cnn_size_t window_width,
-                              cnn_size_t window_height,
-                              cnn_size_t w_stride,
-                              cnn_size_t h_stride, padding pad_type) const {
-        return deconv_out_unpadded_length(in_width, window_width, w_stride, pad_type) *
-                deconv_out_unpadded_length(in_height, window_height, h_stride, pad_type);
-    }
-
-    void copy_and_pad_delta(const tensor_t& delta, tensor_t& delta_padded) {
-        if (params_.pad_type == padding::valid) {
-            delta_padded = delta;
-        }
-        else {
-            for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
-                vec_t& dst = delta_padded[sample];
-                const vec_t& src = delta[sample];
-
-                for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                    float_t *pdst = &dst[params_.in.get_index(0, 0, c)];
-                    const float_t *pin = &src[params_.in.get_index(0, 0, c)];
-
-                    for (cnn_size_t y = 0; y < params_.in.height_; y++, pdst +=
-                        params_.in.width_, pin += params_.in.width_) {
-                        std::copy(pin, pin + params_.in.width_, pdst);
-                    }
-                }
-            }
-        }
-    }
-
-    void copy_and_unpad_output(const tensor_t& out) {
-        deconv_layer_worker_specific_storage& dws =
-            deconv_layer_worker_storage_;
-
-        dws.curr_out_buf_ = tensor_t(out.size(), vec_t(params_.out_unpadded.width_*
-                                     params_.out_unpadded.height_*
-                                     params_.out_unpadded.depth_,0));
-        tensor_t* dst_tensor = &dws.curr_out_buf_;
-
-        if (params_.pad_type == padding::valid) {
-            dws.curr_out_unpadded_ = &out;
-        } else {
-            // make unpadded version in order to restore scale in fprop/bprop
-            for (cnn_size_t sample = 0; sample < out.size(); sample++) {
-                cnn_size_t idx = 0;
-                vec_t& dst = (*dst_tensor)[sample];
-                size_t wieght_w_half = static_cast<size_t>(floor(params_.weight.width_ / 2));
-                size_t wieght_h_half = static_cast<size_t>(floor(params_.weight.height_ / 2));
-
-                for (cnn_size_t c = 0; c < params_.out_unpadded.depth_; c++) {
-                    float_t *pimg = &dst[params_.out_unpadded.get_index(0, 0, c)];
-                    idx = params_.out.get_index(wieght_w_half, wieght_h_half, c);
-                    const float_t *pout = &out[sample][idx];
-
-                    for (cnn_size_t y = wieght_h_half;
-                        y < params_.out_unpadded.height_ + wieght_h_half;
-                        y++,
-                        pout += params_.out.width_,
-                        pimg += params_.out_unpadded.width_) {
-                        std::copy(pout,
-                            pout + params_.out_unpadded.width_,
-                            pimg);
-                    }
-                }
-            }
-
-            dws.curr_out_unpadded_ = &dws.curr_out_buf_;
-        }
-    }
-
-    /* The convolution parameters */
-    deconv_params params_;
-
-    /* The type of backend */
-    backend_t backend_type_;
-
-    deconv_layer_worker_specific_storage deconv_layer_worker_storage_;
+  deconv_layer_worker_specific_storage deconv_layer_worker_storage_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/deconvolutional_layer.h
+++ b/tiny_dnn/layers/deconvolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <deque>

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/layers/layer.h"
 #include <algorithm>
+#include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
@@ -13,157 +13,151 @@ namespace tiny_dnn {
  * applies dropout to the input
  **/
 class dropout_layer : public layer {
-public:
-    typedef activation::identity Activation;
-    typedef layer Base;
+ public:
+  typedef activation::identity Activation;
+  typedef layer Base;
 
-    /**
-     * @param in_dim       [in] number of elements of the input
-     * @param dropout_rate [in] (0-1) fraction of the input units to be dropped
-     * @param phase        [in] initial state of the dropout
-     **/
-    dropout_layer(cnn_size_t in_dim, float_t dropout_rate, net_phase phase = net_phase::train)
-        : Base({vector_type::data}, {vector_type::data}),
-          phase_(phase),
-          dropout_rate_(dropout_rate),
-          scale_(float_t(1) / (float_t(1) - dropout_rate_)),
-          in_size_(in_dim)
-    {
-		mask_.resize(1, std::vector<uint8_t>(in_dim));
-        clear_mask();
-    }
+  /**
+   * @param in_dim       [in] number of elements of the input
+   * @param dropout_rate [in] (0-1) fraction of the input units to be dropped
+   * @param phase        [in] initial state of the dropout
+   **/
+  dropout_layer(cnn_size_t in_dim, float_t dropout_rate,
+                net_phase phase = net_phase::train)
+      : Base({vector_type::data}, {vector_type::data}),
+        phase_(phase),
+        dropout_rate_(dropout_rate),
+        scale_(float_t(1) / (float_t(1) - dropout_rate_)),
+        in_size_(in_dim) {
+    mask_.resize(1, std::vector<uint8_t>(in_dim));
+    clear_mask();
+  }
 
-    dropout_layer(const dropout_layer& obj) = default;
-    virtual ~dropout_layer(){}
+  dropout_layer(const dropout_layer& obj) = default;
+  virtual ~dropout_layer() {}
 
 #ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    dropout_layer(dropout_layer&& obj) = default;
-    dropout_layer& operator=(const dropout_layer& obj) = default;
-    dropout_layer& operator=(dropout_layer&& obj) = default;
+  dropout_layer(dropout_layer&& obj) = default;
+  dropout_layer& operator=(const dropout_layer& obj) = default;
+  dropout_layer& operator=(dropout_layer&& obj) = default;
 #endif
 
-    void set_dropout_rate(float_t rate)
-    {
-        dropout_rate_ = rate;
-        scale_ = float_t(1) / (float_t(1) - dropout_rate_);
+  void set_dropout_rate(float_t rate) {
+    dropout_rate_ = rate;
+    scale_ = float_t(1) / (float_t(1) - dropout_rate_);
+  }
+
+  float_t dropout_rate() const { return dropout_rate_; }
+
+  ///< number of incoming connections for each output unit
+  size_t fan_in_size() const override { return 1; }
+
+  ///< number of outgoing connections for each input unit
+  size_t fan_out_size() const override { return 1; }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    return {index3d<cnn_size_t>(in_size_, 1, 1)};
+  }
+
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {index3d<cnn_size_t>(in_size_, 1, 1)};
+  }
+
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    tensor_t& prev_delta = *in_grad[0];
+    const tensor_t& curr_delta = *out_grad[0];
+
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+
+    for (cnn_size_t sample = 0, sample_count = prev_delta.size();
+         sample < sample_count; ++sample) {
+      for (size_t i = 0; i < curr_delta.size(); i++) {
+        prev_delta[sample][i] = mask_[sample][i] * curr_delta[sample][i];
+      }
+    }
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    tensor_t& out = *out_data[0];
+
+    const cnn_size_t sample_count = in.size();
+
+    if (mask_.size() < sample_count) {
+      mask_.resize(sample_count, mask_[0]);
     }
 
-    float_t dropout_rate() const {
-        return dropout_rate_;
+    for (size_t sample = 0, sample_count = in.size(); sample < sample_count;
+         ++sample) {
+      std::vector<uint8_t>& mask = mask_[sample];
+
+      const vec_t& in_vec = in[sample];
+      vec_t& out_vec = out[sample];
+
+      if (phase_ == net_phase::train) {
+        for (size_t i = 0; i < in_vec.size(); i++)
+          mask[i] = bernoulli(dropout_rate_);
+
+        for (size_t i = 0; i < in_vec.size(); i++)
+          out_vec[i] = mask[i] * scale_ * in_vec[i];
+      } else {
+        for (size_t i = 0, end = in_vec.size(); i < end; i++)
+          out_vec[i] = in_vec[i];
+      }
     }
+  }
 
-    ///< number of incoming connections for each output unit
-    size_t fan_in_size() const override
-    {
-        return 1;
+  /**
+   * set dropout-context (training-phase or test-phase)
+   **/
+  void set_context(net_phase ctx) override { phase_ = ctx; }
+
+  std::string layer_type() const override { return "dropout"; }
+
+  // currently used by tests only
+  const std::vector<uint8_t>& get_mask(cnn_size_t sample_index) const {
+    return mask_[sample_index];
+  }
+
+  void clear_mask() {
+    for (cnn_size_t sample = 0, sample_count = mask_.size();
+         sample < sample_count; ++sample) {
+      std::fill(mask_[sample].begin(), mask_[sample].end(), 0);
     }
+  }
 
-    ///< number of outgoing connections for each input unit
-    size_t fan_out_size() const override
-    {
-        return 1;
-    }
+  template <class Archive>
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<dropout_layer>& construct) {
+    net_phase phase;
+    float_t dropout_rate;
+    cnn_size_t in_size;
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        return{ index3d<cnn_size_t>(in_size_, 1, 1) };
-    }
+    ar(cereal::make_nvp("in_size", in_size),
+       cereal::make_nvp("dropout_rate", dropout_rate),
+       cereal::make_nvp("phase", phase));
+    construct(in_size, dropout_rate, phase);
+  }
 
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return{ index3d<cnn_size_t>(in_size_, 1, 1) };
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", in_size_),
+       cereal::make_nvp("dropout_rate", dropout_rate_),
+       cereal::make_nvp("phase", phase_));
+  }
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        tensor_t&       prev_delta = *in_grad[0];
-        const tensor_t& curr_delta = *out_grad[0];
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-
-        for (cnn_size_t sample = 0, sample_count = prev_delta.size(); sample < sample_count; ++sample) {
-            for (size_t i = 0; i < curr_delta.size(); i++) {
-                prev_delta[sample][i] = mask_[sample][i] * curr_delta[sample][i];
-            }
-        }
-    }
-
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        const tensor_t& in  = *in_data[0];
-        tensor_t&       out = *out_data[0];
-
-        const cnn_size_t sample_count = in.size();
-
-        if (mask_.size() < sample_count) {
-            mask_.resize(sample_count, mask_[0]);
-        }
-
-        for (size_t sample = 0, sample_count = in.size(); sample < sample_count; ++sample) {
-
-            std::vector<uint8_t>& mask = mask_[sample];
-
-            const vec_t& in_vec = in[sample];
-            vec_t& out_vec = out[sample];
-
-            if (phase_ == net_phase::train) {
-                for (size_t i = 0; i < in_vec.size(); i++)
-                    mask[i] = bernoulli(dropout_rate_);
-
-                for (size_t i = 0; i < in_vec.size(); i++)
-                    out_vec[i] = mask[i] * scale_ * in_vec[i];
-            }
-            else {
-                for (size_t i = 0, end = in_vec.size(); i < end; i++)
-                    out_vec[i] = in_vec[i];
-            }
-        }
-    }
-
-    /**
-     * set dropout-context (training-phase or test-phase)
-     **/
-    void set_context(net_phase ctx) override
-    {
-        phase_ = ctx;
-    }
-
-    std::string layer_type() const override { return "dropout"; }
-
-    // currently used by tests only
-    const std::vector<uint8_t>& get_mask(cnn_size_t sample_index) const {
-        return mask_[sample_index];
-    }
-
-    void clear_mask() {
-		for (cnn_size_t sample = 0, sample_count = mask_.size(); sample < sample_count; ++sample) {
-			std::fill(mask_[sample].begin(), mask_[sample].end(), 0);
-		}
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<dropout_layer> & construct) {
-        net_phase phase;
-        float_t dropout_rate;
-        cnn_size_t in_size;
-
-        ar(cereal::make_nvp("in_size", in_size), cereal::make_nvp("dropout_rate", dropout_rate), cereal::make_nvp("phase", phase));
-        construct(in_size, dropout_rate, phase);
-    }
-    
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_size_), cereal::make_nvp("dropout_rate", dropout_rate_), cereal::make_nvp("phase", phase_));
-    }
-
-private:
-    net_phase phase_;
-    float_t dropout_rate_;
-    float_t scale_;
-    cnn_size_t in_size_;
-	std::vector<std::vector<uint8_t>> mask_;
+ private:
+  net_phase phase_;
+  float_t dropout_rate_;
+  float_t scale_;
+  cnn_size_t in_size_;
+  std::vector<std::vector<uint8_t>> mask_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/layers/feedforward_layer.h
+++ b/tiny_dnn/layers/feedforward_layer.h
@@ -3,63 +3,64 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/layers/layer.h"
 
 namespace tiny_dnn {
 
 /**
  * single-input, single-output network with activation function
  **/
-template<typename Activation>
+template <typename Activation>
 class feedforward_layer : public layer {
-public:
-    explicit feedforward_layer(const std::vector<vector_type>& in_data_type)
-        : layer(in_data_type, std_output_order(true)) {}
-    activation::function& activation_function() { return h_; }
-    std::pair<float_t, float_t> out_value_range() const override { return h_.scale(); }
+ public:
+  explicit feedforward_layer(const std::vector<vector_type>& in_data_type)
+      : layer(in_data_type, std_output_order(true)) {}
+  activation::function& activation_function() { return h_; }
+  std::pair<float_t, float_t> out_value_range() const override {
+    return h_.scale();
+  }
 
-public:
-    void forward_activation(tensor_t& a_tensor, tensor_t& out_tensor) {
-        cnn_size_t out_dim = out_shape()[0].size();
+ public:
+  void forward_activation(tensor_t& a_tensor, tensor_t& out_tensor) {
+    cnn_size_t out_dim = out_shape()[0].size();
 
-        for_i(a_tensor.size(), [&](int sample) {
-            vec_t& out = a_tensor[sample];
-            vec_t& a   = out_tensor[sample];
-            out.resize(out_dim);
-            a.resize(out_dim);
+    for_i(a_tensor.size(), [&](int sample) {
+      vec_t& out = a_tensor[sample];
+      vec_t& a = out_tensor[sample];
+      out.resize(out_dim);
+      a.resize(out_dim);
 
-            for (cnn_size_t i = 0; i < out_dim; i++) {
-                out[i] = this->h_.f(a, i);
-            }
-        });
-    }
+      for (cnn_size_t i = 0; i < out_dim; i++) {
+        out[i] = this->h_.f(a, i);
+      }
+    });
+  }
 
-    void backward_activation(const tensor_t& prev_delta, const tensor_t& this_out, tensor_t& curr_delta) {
+  void backward_activation(const tensor_t& prev_delta, const tensor_t& this_out,
+                           tensor_t& curr_delta) {
+    // @todo consider parallelism
+    for_i(this_out.size(), [&](cnn_size_t sample) {
+      const vec_t& out_vec = this_out[sample];
+      const vec_t& prev_delta_vec = prev_delta[sample];
+      vec_t& curr_delta_vec = curr_delta[sample];
 
-        // @todo consider parallelism
-        for_i(this_out.size(), [&](cnn_size_t sample) {
-            const vec_t& out_vec = this_out[sample];
-            const vec_t& prev_delta_vec = prev_delta[sample];
-            vec_t& curr_delta_vec = curr_delta[sample];
+      const cnn_size_t len = prev_delta_vec.size();
 
-            const cnn_size_t len = prev_delta_vec.size();
-            
-            if (h_.one_hot()) {
-                for (cnn_size_t c = 0; c < len; c++) {
-                    curr_delta_vec[c] = prev_delta_vec[c] * h_.df(out_vec[c]);
-                }
-            }
-            else {
-                for (cnn_size_t c = 0; c < len; c++) {
-                    vec_t df = h_.df(out_vec, c);
-                    curr_delta_vec[c] = vectorize::dot(&prev_delta_vec[0], &df[0], len);
-                }
-            }
-        });
-    }
+      if (h_.one_hot()) {
+        for (cnn_size_t c = 0; c < len; c++) {
+          curr_delta_vec[c] = prev_delta_vec[c] * h_.df(out_vec[c]);
+        }
+      } else {
+        for (cnn_size_t c = 0; c < len; c++) {
+          vec_t df = h_.df(out_vec, c);
+          curr_delta_vec[c] = vectorize::dot(&prev_delta_vec[0], &df[0], len);
+        }
+      }
+    });
+  }
 
-    Activation h_;
+  Activation h_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/feedforward_layer.h
+++ b/tiny_dnn/layers/feedforward_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/activations/activation_function.h"

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -5,156 +5,145 @@
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 
-#include "tiny_dnn/core/kernels/fully_connected_op.h"
 #include "tiny_dnn/core/kernels/fully_connected_grad_op.h"
+#include "tiny_dnn/core/kernels/fully_connected_op.h"
 
 namespace tiny_dnn {
 
 /**
  * compute fully-connected(matmul) operation
  **/
-template<typename Activation>
+template <typename Activation>
 class fully_connected_layer : public feedforward_layer<Activation> {
-public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-     * @param in_dim [in] number of elements of the input
-     * @param out_dim [in] number of elements of the output
-     * @param has_bias [in] whether to include additional bias to the layer
-     **/
-    fully_connected_layer(cnn_size_t     in_dim,
-                          cnn_size_t     out_dim,
-                          bool           has_bias = true,
-                          backend_t      backend_type = core::default_engine())
-            : Base(std_input_order(has_bias)) {
-        set_params(in_dim, out_dim, has_bias);
-        init_backend(backend_type);
-        Base::set_backend_type(backend_type);
+  /**
+   * @param in_dim [in] number of elements of the input
+   * @param out_dim [in] number of elements of the output
+   * @param has_bias [in] whether to include additional bias to the layer
+   **/
+  fully_connected_layer(cnn_size_t in_dim, cnn_size_t out_dim,
+                        bool has_bias = true,
+                        backend_t backend_type = core::default_engine())
+      : Base(std_input_order(has_bias)) {
+    set_params(in_dim, out_dim, has_bias);
+    init_backend(backend_type);
+    Base::set_backend_type(backend_type);
+  }
+
+  // move constructor
+  fully_connected_layer(fully_connected_layer&& other)
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        kernel_fwd_(std::move(other.kernel_fwd_)),
+        kernel_back_(std::move(other.kernel_back_)) {
+    init_backend(std::move(other.engine()));
+  }
+
+  size_t fan_in_size() const override { return params_.in_size_; }
+
+  size_t fan_out_size() const override { return params_.out_size_; }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias_) {
+      return {index3d<cnn_size_t>(params_.in_size_, 1, 1),
+              index3d<cnn_size_t>(params_.in_size_, params_.out_size_, 1),
+              index3d<cnn_size_t>(params_.out_size_, 1, 1)};
+    } else {
+      return {index3d<cnn_size_t>(params_.in_size_, 1, 1),
+              index3d<cnn_size_t>(params_.in_size_, params_.out_size_, 1)};
     }
+  }
 
-    // move constructor
-    fully_connected_layer(fully_connected_layer&& other)
-            : Base(std::move(other))
-            , params_(std::move(other.params_))
-            , kernel_fwd_(std::move(other.kernel_fwd_))
-            , kernel_back_(std::move(other.kernel_back_)) {
-        init_backend(std::move(other.engine()));
-    }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {index3d<cnn_size_t>(params_.out_size_, 1, 1),
+            index3d<cnn_size_t>(params_.out_size_, 1, 1)};
+  }
 
-    size_t fan_in_size() const override {
-        return params_.in_size_;
-    }
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    // forward convolutional op context
+    auto ctx = OpKernelContext(in_data, out_data);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
 
-    size_t fan_out_size() const override {
-        return params_.out_size_;
-    }
+    // launch convolutional kernel
+    kernel_fwd_->compute(ctx);
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias_) {
-            return { index3d<cnn_size_t>(params_.in_size_, 1, 1),
-                     index3d<cnn_size_t>(params_.in_size_,
-                                         params_.out_size_, 1),
-                     index3d<cnn_size_t>(params_.out_size_, 1, 1) };
-        } else {
-            return { index3d<cnn_size_t>(params_.in_size_, 1, 1),
-                     index3d<cnn_size_t>(params_.in_size_,
-                                         params_.out_size_, 1) };
-        }
-    }
+    // activations
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
 
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return { index3d<cnn_size_t>(params_.out_size_, 1, 1),
-                 index3d<cnn_size_t>(params_.out_size_, 1, 1) };
-    }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    // activations
+    // TODO(edgar/nyanp): refactor and move activations outside
+    this->backward_activation(*out_grad[0], *out_data[0], *out_grad[1]);
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) override {
-        // forward convolutional op context
-        auto ctx = OpKernelContext(in_data, out_data);
-             ctx.setParallelize(layer::parallelize());
-             ctx.setEngine(layer::engine());
+    // backward convolutional op context
+    auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
 
-        // launch convolutional kernel
-        kernel_fwd_->compute(ctx);
+    // launch convolutional kernel
+    kernel_back_->compute(ctx);
+  }
 
-        // activations
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
+  std::string layer_type() const override { return "fully-connected"; }
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        // activations
-        // TODO(edgar/nyanp): refactor and move activations outside
-        this->backward_activation(*out_grad[0], *out_data[0], *out_grad[1]);
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<fully_connected_layer>& construct) {
+    size_t in_dim, out_dim;
+    bool has_bias;
 
-        // backward convolutional op context
-        auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
-             ctx.setParallelize(layer::parallelize());
-             ctx.setEngine(layer::engine());
+    ar(cereal::make_nvp("in_size", in_dim),
+       cereal::make_nvp("out_size", out_dim),
+       cereal::make_nvp("has_bias", has_bias));
+    construct(in_dim, out_dim, has_bias);
+  }
 
-        // launch convolutional kernel
-        kernel_back_->compute(ctx);
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", params_.in_size_),
+       cereal::make_nvp("out_size", params_.out_size_),
+       cereal::make_nvp("has_bias", params_.has_bias_));
+  }
 
-    std::string layer_type() const override { return "fully-connected"; }
+ protected:
+  void set_params(const cnn_size_t in_size, const cnn_size_t out_size,
+                  bool has_bias) {
+    params_.in_size_ = in_size;
+    params_.out_size_ = out_size;
+    params_.has_bias_ = has_bias;
+  }
 
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<fully_connected_layer> & construct) {
-        size_t in_dim, out_dim;
-        bool has_bias;
-
-        ar(cereal::make_nvp("in_size", in_dim),
-           cereal::make_nvp("out_size", out_dim),
-           cereal::make_nvp("has_bias", has_bias));
-        construct(in_dim, out_dim, has_bias);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in_size_),
-           cereal::make_nvp("out_size", params_.out_size_),
-           cereal::make_nvp("has_bias", params_.has_bias_));
-    }
-
-protected:
-
-    void set_params(const cnn_size_t in_size,
-                    const cnn_size_t out_size,
-                    bool             has_bias) {
-        params_.in_size_  = in_size;
-        params_.out_size_ = out_size;
-        params_.has_bias_ = has_bias;
-    }
-
-    void init_backend(backend_t backend_type) {
-        core::OpKernelConstruction ctx =
+  void init_backend(backend_t backend_type) {
+    core::OpKernelConstruction ctx =
         core::OpKernelConstruction(layer::device(), &params_);
 
-        if (backend_type == backend_t::tiny_dnn ||
-            backend_type == backend_t::avx) {
+    if (backend_type == backend_t::tiny_dnn || backend_type == backend_t::avx) {
+      kernel_fwd_.reset(new FullyConnectedOp(ctx));
+      kernel_back_.reset(new FullyConnectedGradOp(ctx));
 
-            kernel_fwd_.reset(new FullyConnectedOp(ctx));
-            kernel_back_.reset(new FullyConnectedGradOp(ctx));
-
-            return;
-        }
-        else {
-            throw nn_error("Not supported engine: " + to_string(backend_type));
-        }
+      return;
+    } else {
+      throw nn_error("Not supported engine: " + to_string(backend_type));
     }
+  }
 
  private:
-    /* The layer parameters */
-    fully_params params_;
+  /* The layer parameters */
+  fully_params params_;
 
-    /* Forward and backward ops */
-    std::shared_ptr<core::OpKernel> kernel_fwd_;
-    std::shared_ptr<core::OpKernel> kernel_back_;
+  /* Forward and backward ops */
+  std::shared_ptr<core::OpKernel> kernel_fwd_;
+  std::shared_ptr<core::OpKernel> kernel_back_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/input_layer.h
+++ b/tiny_dnn/layers/input_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 

--- a/tiny_dnn/layers/input_layer.h
+++ b/tiny_dnn/layers/input_layer.h
@@ -8,37 +8,36 @@
 namespace tiny_dnn {
 
 class input_layer : public layer {
-public:
-    explicit input_layer(const shape3d& shape)
-    : layer({vector_type::data}, {vector_type::data}), shape_(shape) {}
+ public:
+  explicit input_layer(const shape3d& shape)
+      : layer({vector_type::data}, {vector_type::data}), shape_(shape) {}
 
-    explicit input_layer(cnn_size_t in_dim)
-    : layer({ vector_type::data }, { vector_type::data }), shape_(shape3d(in_dim,1,1)) {}
+  explicit input_layer(cnn_size_t in_dim)
+      : layer({vector_type::data}, {vector_type::data}),
+        shape_(shape3d(in_dim, 1, 1)) {}
 
-    std::vector<shape3d> in_shape() const override { return { shape_ }; }
-    std::vector<shape3d> out_shape() const override { return { shape_ }; }
-    std::string layer_type() const override { return "input"; }
+  std::vector<shape3d> in_shape() const override { return {shape_}; }
+  std::vector<shape3d> out_shape() const override { return {shape_}; }
+  std::string layer_type() const override { return "input"; }
 
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    *out_data[0] = *in_data[0];
+  }
 
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    // do nothing
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(out_grad);
+    CNN_UNREFERENCED_PARAMETER(in_grad);
+  }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        *out_data[0] = *in_data[0];
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        // do nothing
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-    }
-
-private:
-    shape3d shape_;
+ private:
+  shape3d shape_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <sstream>
 #include <iomanip>

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -3,27 +3,27 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <sstream>
+#include <algorithm>
 #include <iomanip>
 #include <memory>
 #include <numeric>
-#include <algorithm>
-#include <vector>
+#include <queue>
+#include <sstream>
 #include <string>
 #include <utility>
-#include <queue>
+#include <vector>
 
-#include "tiny_dnn/node.h"
 #include "tiny_dnn/core/backend.h"
 #include "tiny_dnn/core/framework/device.fwd.h"
+#include "tiny_dnn/node.h"
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/product.h"
 #include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/product.h"
+#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/util/weight_init.h"
 
-#include "tiny_dnn/optimizers/optimizer.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/optimizers/optimizer.h"
 
 namespace tiny_dnn {
 
@@ -39,729 +39,705 @@ namespace tiny_dnn {
  **/
 class layer : public node {
  public:
-    friend void connection_mismatch(const layer& from,
-                                    const layer& to);
+  friend void connection_mismatch(const layer& from, const layer& to);
 
-    virtual ~layer() = default;
+  virtual ~layer() = default;
 
-    /**
-     * construct N-input, M-output layer
-     * @param in_type[N] type of input vector (data, weight, bias...)
-     * @param out_type[M] type of output vector
-     **/
-    layer(const std::vector<vector_type>& in_type,
-          const std::vector<vector_type>& out_type)
-            : node(in_type.size(), out_type.size()),
-              initialized_(false),
-              parallelize_(true),
-              in_channels_(in_type.size()),
-              out_channels_(out_type.size()),
-              in_type_(in_type),
-              out_type_(out_type) {
-        weight_init_ = std::make_shared<weight_init::xavier>();
-        bias_init_ = std::make_shared<weight_init::constant>();
-        trainable_ = true;
-    }
+  /**
+   * construct N-input, M-output layer
+   * @param in_type[N] type of input vector (data, weight, bias...)
+   * @param out_type[M] type of output vector
+   **/
+  layer(const std::vector<vector_type>& in_type,
+        const std::vector<vector_type>& out_type)
+      : node(in_type.size(), out_type.size()),
+        initialized_(false),
+        parallelize_(true),
+        in_channels_(in_type.size()),
+        out_channels_(out_type.size()),
+        in_type_(in_type),
+        out_type_(out_type) {
+    weight_init_ = std::make_shared<weight_init::xavier>();
+    bias_init_ = std::make_shared<weight_init::constant>();
+    trainable_ = true;
+  }
 
-    layer(const layer&) = default;
-    layer &operator =(const layer&) = default;
+  layer(const layer&) = default;
+  layer& operator=(const layer&) = default;
 
 #ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    layer(layer&&) = default;
-    layer &operator = (layer&&) = default;
+  layer(layer&&) = default;
+  layer& operator=(layer&&) = default;
 #endif
 
-    void set_parallelize(bool parallelize) {
-        parallelize_ = parallelize;
+  void set_parallelize(bool parallelize) { parallelize_ = parallelize; }
+
+  void set_backend(std::shared_ptr<core::backend> backend) {
+    backend_ = backend;
+  }
+
+  void set_backend_type(core::backend_t backend_type) {
+    backend_type_ = backend_type;
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  // getter
+
+  bool parallelize() const { return parallelize_; }
+
+  // TODO(edgar): Deprecated: use the below method
+  core::backend_t backend_type() const { return backend_->type(); }
+
+  core::backend_t engine() const { return backend_type_; }
+
+  virtual std::string kernel_file() const {
+    return std::string("empty_kernel_str");
+  }
+
+  virtual std::string kernel_header() const { return std::string(); }
+
+  virtual void createOp() {}
+
+  void setDevice(const Device& device) {
+    device_ptr_ = const_cast<Device*>(&device);
+  }
+
+  Device* device() const { return device_ptr_; }
+
+  std::shared_ptr<core::backend> backend() { return backend_; }
+
+  ///< number of incoming edges in this layer
+  cnn_size_t in_channels() const { return in_channels_; }
+
+  ///< number of outgoing edges in this layer
+  cnn_size_t out_channels() const { return out_channels_; }
+
+  cnn_size_t in_data_size() const {
+    return sumif(in_shape(),
+                 [&](cnn_size_t i) {  // NOLINT
+                   return in_type_[i] == vector_type::data;
+                 },
+                 [](const shape3d& s) { return s.size(); });
+  }
+
+  cnn_size_t out_data_size() const {
+    return sumif(out_shape(),
+                 [&](cnn_size_t i) {  // NOLINT
+                   return out_type_[i] == vector_type::data;
+                 },
+                 [](const shape3d& s) { return s.size(); });
+  }
+
+  std::vector<shape3d> in_data_shape() {
+    return filter(in_shape(), [&](size_t i) {  // NOLINT
+      return in_type_[i] == vector_type::data;
+    });
+  }
+
+  std::vector<shape3d> out_data_shape() {
+    return filter(out_shape(), [&](size_t i) {  // NOLINT
+      return out_type_[i] == vector_type::data;
+    });
+  }
+
+  ///! @deprecated use in_data_size() instead
+  cnn_size_t in_size() const { return in_data_size(); }
+
+  ///! @deprecated use out_data_size() instead
+  cnn_size_t out_size() const { return out_data_size(); }
+
+  std::vector<const vec_t*> weights() const {
+    std::vector<const vec_t*> v;
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      if (is_trainable_weight(in_type_[i])) {
+        v.push_back(get_weight_data(i));
+      }
+    }
+    return v;
+  }
+
+  std::vector<vec_t*> weights() {
+    std::vector<vec_t*> v;
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      if (is_trainable_weight(in_type_[i])) {
+        v.push_back(get_weight_data(i));
+      }
+    }
+    return v;
+  }
+
+  std::vector<tensor_t*> weights_grads() {
+    std::vector<tensor_t*> v;
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      if (is_trainable_weight(in_type_[i])) {
+        v.push_back(ith_in_node(i)->get_gradient());
+      }
+    }
+    return v;
+  }
+
+  std::vector<edgeptr_t> inputs() {
+    std::vector<edgeptr_t> nodes;
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      nodes.push_back(ith_in_node(i));
+    }
+    return nodes;
+  }
+
+  std::vector<edgeptr_t> outputs() {
+    std::vector<edgeptr_t> nodes;
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      nodes.push_back(ith_out_node(i));
+    }
+    return nodes;
+  }
+
+  std::vector<edgeptr_t> outputs() const {
+    std::vector<edgeptr_t> nodes;
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      nodes.push_back(const_cast<layerptr_t>(this)->ith_out_node(i));
+    }
+    return nodes;
+  }
+
+  void set_out_grads(const std::vector<tensor_t>& grad) {
+    cnn_size_t j = 0;
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      if (out_type_[i] != vector_type::data) continue;
+      assert(j < grad.size());
+      *ith_out_node(i)->get_gradient() = grad[j++];
+    }
+  }
+
+  void set_in_data(const std::vector<tensor_t>& data) {
+    cnn_size_t j = 0;
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      if (in_type_[i] != vector_type::data) continue;
+      assert(j < data.size());
+      *ith_in_node(i)->get_data() = data[j++];
+    }
+  }
+
+  std::vector<tensor_t> output() const {
+    std::vector<tensor_t> out;
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      if (out_type_[i] == vector_type::data) {
+        out.push_back(
+            *(const_cast<layerptr_t>(this))->ith_out_node(i)->get_data());
+      }
+    }
+    return out;
+  }
+
+  std::vector<vector_type> in_types() const { return in_type_; }
+
+  std::vector<vector_type> out_types() const { return out_type_; }
+
+  void set_trainable(bool trainable) { trainable_ = trainable; }
+
+  bool trainable() const { return trainable_; }
+
+  /**
+   * return output value range
+   * used only for calculating target value from label-id in final(output) layer
+   * override properly if the layer is intended to be used as output layer
+   **/
+  virtual std::pair<float_t, float_t> out_value_range() const {
+    return {float_t(0.0), float_t(1.0)};
+  }
+
+  /**
+   * array of input shapes (width x height x depth)
+   **/
+  virtual std::vector<shape3d> in_shape() const = 0;
+
+  /**
+   * array of output shapes (width x height x depth)
+   **/
+  virtual std::vector<shape3d> out_shape() const = 0;
+
+  /**
+   * name of layer, should be unique for each concrete class
+   **/
+  virtual std::string layer_type() const = 0;
+
+  /**
+   * number of incoming connections for each output unit
+   * used only for weight/bias initialization methods which require fan-in size
+   *(e.g. xavier)
+   * override if the layer has trainable weights, and scale of initialization is
+   *important
+   **/
+  virtual size_t fan_in_size() const { return in_shape()[0].width_; }
+
+  /**
+   * number of outgoing connections for each input unit
+   * used only for weight/bias initialization methods which require fan-out size
+   *(e.g. xavier)
+   * override if the layer has trainable weights, and scale of initialization is
+   *important
+   **/
+  virtual size_t fan_out_size() const { return out_shape()[0].width_; }
+
+  /////////////////////////////////////////////////////////////////////////
+  // setter
+  template <typename WeightInit>
+  layer& weight_init(const WeightInit& f) {
+    weight_init_ = std::make_shared<WeightInit>(f);
+    return *this;
+  }
+
+  template <typename BiasInit>
+  layer& bias_init(const BiasInit& f) {
+    bias_init_ = std::make_shared<BiasInit>(f);
+    return *this;
+  }
+
+  template <typename WeightInit>
+  layer& weight_init(std::shared_ptr<WeightInit> f) {
+    weight_init_ = f;
+    return *this;
+  }
+
+  template <typename BiasInit>
+  layer& bias_init(std::shared_ptr<BiasInit> f) {
+    bias_init_ = f;
+    return *this;
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  // save/load
+  template <typename Archive>
+  void serialize(Archive& ar) {
+    auto all_weights = weights();
+    for (auto weight : all_weights) {
+      ar(*weight);
+    }
+    initialized_ = true;
+  }
+
+  virtual void save(std::ostream& os) const {  // NOLINT
+    /*if (is_exploded()) {
+        throw nn_error("failed to save weights because of infinite weight");
+    }*/
+    auto all_weights = weights();
+    for (auto& weight : all_weights) {
+      for (auto w : *weight) os << w << " ";
+    }
+  }
+
+  virtual void load(std::istream& is) {  // NOLINT
+    auto all_weights = weights();
+    for (auto& weight : all_weights) {
+      for (auto& w : *weight) is >> w;
+    }
+    initialized_ = true;
+  }
+
+  virtual void load(const std::vector<float_t>& src, int& idx) {  // NOLINT
+    auto all_weights = weights();
+    for (auto& weight : all_weights) {
+      for (auto& w : *weight) w = src[idx++];
+    }
+    initialized_ = true;
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  // visualize
+
+  ///< visualize latest output of this layer
+  ///< default implementation interpret output as 1d-vector,
+  ///< so "visual" layer(like convolutional layer) should override this for
+  ///better visualization.
+  virtual image<> output_to_image(size_t channel = 0) const {
+    const vec_t* output = &(*(outputs()[channel]->get_data()))[0];
+    return vec2image<unsigned char>(*output, out_shape()[channel]);
+  }
+
+  /////////////////////////////////////////////////////////////////////////
+  // fprop/bprop
+
+  /**
+   * @param in_data      input vectors of this layer (data, weight, bias)
+   * @param out_data     output vectors
+   **/
+  virtual void forward_propagation(const std::vector<tensor_t*>& in_data,
+                                   std::vector<tensor_t*>& out_data) = 0;
+
+  /**
+   * return delta of previous layer (delta=\frac{dE}{da}, a=wx in
+   *fully-connected layer)
+   * @param in_data      input vectors (same vectors as forward_propagation)
+   * @param out_data     output vectors (same vectors as forward_propagation)
+   * @param out_grad     gradient of output vectors (i-th vector correspond with
+   *out_data[i])
+   * @param in_grad      gradient of input vectors (i-th vector correspond with
+   *in_data[i])
+   **/
+  virtual void back_propagation(const std::vector<tensor_t*>& in_data,
+                                const std::vector<tensor_t*>& out_data,
+                                std::vector<tensor_t*>& out_grad,
+                                std::vector<tensor_t*>& in_grad) = 0;
+
+  /**
+   * return delta2 of previous layer (delta2=\frac{d^2E}{da^2}, diagonal of
+   *hessian matrix)
+   * it is never called if optimizer is hessian-free
+   **/
+  // virtual void back_propagation_2nd(const std::vector<vec_t>& delta_in) = 0;
+
+  // called afrer updating weight
+  virtual void post_update() {}
+
+  /**
+  * notify changing context (train <=> test)
+  **/
+  virtual void set_context(net_phase ctx) { CNN_UNREFERENCED_PARAMETER(ctx); }
+
+  std::vector<tensor_t> forward(
+      const std::vector<tensor_t>& input) {  // for test
+    setup(false);
+    set_in_data(input);
+    forward();
+    return output();
+  }
+
+  std::vector<tensor_t> backward(
+      const std::vector<tensor_t>& out_grads) {  // for test
+    setup(false);
+    set_out_grads(out_grads);
+    backward();
+    return map_<tensor_t>(inputs(),
+                          [](edgeptr_t e) { return *e->get_gradient(); });
+  }
+
+  void forward() {
+    std::vector<tensor_t*> in_data, out_data;
+
+    // organize input/output vectors from storage
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      in_data.push_back(ith_in_node(i)->get_data());
     }
 
-    void set_backend(std::shared_ptr<core::backend> backend) {
-        backend_ = backend;
+    // resize outs and stuff to have room for every input sample in the batch
+    set_sample_count(in_data[0]->size());
+
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      out_data.push_back(ith_out_node(i)->get_data());
+      ith_out_node(i)->clear_grads();
     }
 
-    void set_backend_type(core::backend_t backend_type) {
-        backend_type_ = backend_type;
+    forward_propagation(in_data, out_data);
+  }
+
+  void backward() {
+    std::vector<tensor_t*> in_data, out_data, in_grad, out_grad;
+
+    // organize input/output vectors from storage
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      in_data.push_back(ith_in_node(i)->get_data());
+    }
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      out_data.push_back(ith_out_node(i)->get_data());
+    }
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      in_grad.push_back(ith_in_node(i)->get_gradient());
+    }
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      out_grad.push_back(ith_out_node(i)->get_gradient());
+    }
+    back_propagation(in_data, out_data, out_grad, in_grad);
+  }
+
+  // allocate & reset weight
+  void setup(bool reset_weight) {
+    if (in_shape().size() != in_channels_ ||
+        out_shape().size() != out_channels_) {
+      throw nn_error("Connection mismatch at setup layer");
     }
 
-    /////////////////////////////////////////////////////////////////////////
-    // getter
-
-    bool parallelize() const { return parallelize_; }
-
-    // TODO(edgar): Deprecated: use the below method 
-    core::backend_t backend_type() const {
-        return backend_->type();
+    for (size_t i = 0; i < out_channels_; i++) {
+      if (!next_[i]) {
+        next_[i] = std::make_shared<edge>(this, out_shape()[i], out_type_[i]);
+      }
     }
 
-    core::backend_t engine() const {
-        return backend_type_;
+    if (reset_weight || !initialized_) {
+      init_weight();
+    }
+  }
+
+  void init_weight() {
+    if (!trainable_) {
+      initialized_ = true;
+      return;
     }
 
-    virtual std::string kernel_file() const {
-        return std::string("empty_kernel_str");
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      switch (in_type_[i]) {
+        case vector_type::weight:
+          weight_init_->fill(get_weight_data(i), fan_in_size(), fan_out_size());
+          break;
+        case vector_type::bias:
+          bias_init_->fill(get_weight_data(i), fan_in_size(), fan_out_size());
+          break;
+        default:
+          break;
+      }
+    }
+    initialized_ = true;
+  }
+
+  void clear_grads() {
+    for (size_t i = 0; i < in_type_.size(); i++) {
+      ith_in_node(i)->clear_grads();
+    }
+  }
+
+  void update_weight(optimizer* o, cnn_size_t batch_size) {
+    float_t rcp_batch_size = float_t(1) / float_t(batch_size);
+    for (size_t i = 0; i < in_type_.size(); i++) {
+      if (trainable() && is_trainable_weight(in_type_[i])) {
+        vec_t diff;
+        vec_t& target = *get_weight_data(i);
+
+        ith_in_node(i)->merge_grads(&diff);
+        std::transform(diff.begin(), diff.end(), diff.begin(),
+                       [&](float_t x) {  // NOLINT
+                         return x * rcp_batch_size;
+                       });
+        o->update(diff, target);
+      }
+    }
+    clear_grads();
+    post_update();
+  }
+
+  bool has_same_weights(const layer& rhs, float_t eps) const {
+    auto w1 = weights();
+    auto w2 = rhs.weights();
+    if (w1.size() != w2.size()) return false;
+
+    for (size_t i = 0; i < w1.size(); i++) {
+      if (w1[i]->size() != w2[i]->size()) return false;
+
+      for (size_t j = 0; j < w1[i]->size(); j++) {
+        if (std::abs(w1[i]->at(j) - w2[i]->at(j)) > eps) return false;
+      }
+    }
+    return true;
+  }
+
+  virtual void set_sample_count(cnn_size_t sample_count) {
+    // increase the size if necessary - but do not decrease
+    auto resize = [sample_count](tensor_t* tensor) {
+      tensor->resize(sample_count, (*tensor)[0]);
+    };
+
+    for (cnn_size_t i = 0; i < in_channels_; i++) {
+      if (!is_trainable_weight(in_type_[i])) {
+        resize(ith_in_node(i)->get_data());
+      }
+      resize(ith_in_node(i)->get_gradient());
     }
 
-    virtual std::string kernel_header() const {
-        return std::string();
+    for (cnn_size_t i = 0; i < out_channels_; i++) {
+      if (!is_trainable_weight(out_type_[i])) {
+        resize(ith_out_node(i)->get_data());
+      }
+      resize(ith_out_node(i)->get_gradient());
     }
-
-    virtual void createOp() {
-    }
-
-    void setDevice(const Device& device) {
-        device_ptr_ = const_cast<Device*>(&device);
-    }
-
-    Device* device() const {
-        return device_ptr_;
-    }
-
-    std::shared_ptr<core::backend> backend() { return backend_; }
-
-    ///< number of incoming edges in this layer
-    cnn_size_t in_channels() const { return in_channels_; }
-
-    ///< number of outgoing edges in this layer
-    cnn_size_t out_channels() const { return out_channels_; }
-
-    cnn_size_t in_data_size() const {
-        return sumif(in_shape(), [&](cnn_size_t i) { // NOLINT
-            return in_type_[i] == vector_type::data; }, [](const shape3d& s) {
-                return s.size(); });
-    }
-
-    cnn_size_t out_data_size() const {
-        return sumif(out_shape(), [&](cnn_size_t i) { // NOLINT
-            return out_type_[i] == vector_type::data; }, [](const shape3d& s) {
-                return s.size(); });
-    }
-
-    std::vector<shape3d> in_data_shape() {
-        return filter(in_shape(), [&](size_t i) { // NOLINT
-            return in_type_[i] == vector_type::data;
-        });
-    }
-
-    std::vector<shape3d> out_data_shape() {
-        return filter(out_shape(), [&](size_t i) { // NOLINT
-            return out_type_[i] == vector_type::data;
-        });
-    }
-
-    ///! @deprecated use in_data_size() instead
-    cnn_size_t in_size() const {
-        return in_data_size();
-    }
-
-    ///! @deprecated use out_data_size() instead
-    cnn_size_t out_size() const {
-        return out_data_size();
-    }
-
-    std::vector<const vec_t*> weights() const {
-        std::vector<const vec_t*> v;
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            if (is_trainable_weight(in_type_[i])) {
-                v.push_back(get_weight_data(i));
-            }
-        }
-        return v;
-    }
-
-    std::vector<vec_t*> weights() {
-        std::vector<vec_t*> v;
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            if (is_trainable_weight(in_type_[i])) {
-                v.push_back(get_weight_data(i));
-            }
-        }
-        return v;
-    }
-
-    std::vector<tensor_t*> weights_grads() {
-        std::vector<tensor_t*> v;
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            if (is_trainable_weight(in_type_[i])) {
-                v.push_back(ith_in_node(i)->get_gradient());
-            }
-        }
-        return v;
-    }
-
-    std::vector<edgeptr_t> inputs() {
-        std::vector<edgeptr_t> nodes;
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            nodes.push_back(ith_in_node(i));
-        }
-        return nodes;
-    }
-
-    std::vector<edgeptr_t> outputs() {
-        std::vector<edgeptr_t> nodes;
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            nodes.push_back(ith_out_node(i));
-        }
-        return nodes;
-    }
-
-    std::vector<edgeptr_t> outputs() const {
-        std::vector<edgeptr_t> nodes;
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            nodes.push_back(const_cast<layerptr_t>(this)
-                    ->ith_out_node(i));
-        }
-        return nodes;
-    }
-
-    void set_out_grads(const std::vector<tensor_t>& grad) {
-        cnn_size_t j = 0;
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            if (out_type_[i] != vector_type::data) continue;
-            assert(j < grad.size());
-            *ith_out_node(i)->get_gradient() = grad[j++];
-        }
-    }
-
-    void set_in_data(const std::vector<tensor_t>& data) {
-        cnn_size_t j = 0;
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            if (in_type_[i] != vector_type::data) continue;
-            assert(j < data.size());
-            *ith_in_node(i)->get_data() = data[j++];
-        }
-    }
-
-    std::vector<tensor_t> output() const {
-        std::vector<tensor_t> out;
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            if (out_type_[i] == vector_type::data) {
-                out.push_back(*(const_cast<layerptr_t>(this))
-                    ->ith_out_node(i)->get_data());
-            }
-        }
-        return out;
-    }
-
-    std::vector<vector_type> in_types() const { return in_type_; }
-
-    std::vector<vector_type> out_types() const { return out_type_; }
-
-    void set_trainable(bool trainable) { trainable_ = trainable; }
-
-    bool trainable() const { return trainable_; }
-
-    /**
-     * return output value range
-     * used only for calculating target value from label-id in final(output) layer
-     * override properly if the layer is intended to be used as output layer
-     **/
-    virtual std::pair<float_t, float_t> out_value_range() const {
-        return { float_t(0.0), float_t(1.0) };
-    }
-
-    /**
-     * array of input shapes (width x height x depth)
-     **/
-    virtual std::vector<shape3d> in_shape() const = 0;
-
-    /**
-     * array of output shapes (width x height x depth)
-     **/
-    virtual std::vector<shape3d> out_shape() const = 0;
-
-    /**
-     * name of layer, should be unique for each concrete class
-     **/
-    virtual std::string layer_type() const = 0;
-
-    /**
-     * number of incoming connections for each output unit
-     * used only for weight/bias initialization methods which require fan-in size (e.g. xavier)
-     * override if the layer has trainable weights, and scale of initialization is important
-     **/
-    virtual size_t fan_in_size() const {
-        return in_shape()[0].width_;
-    }
-
-    /**
-     * number of outgoing connections for each input unit
-     * used only for weight/bias initialization methods which require fan-out size (e.g. xavier)
-     * override if the layer has trainable weights, and scale of initialization is important
-     **/
-    virtual size_t fan_out_size() const {
-        return out_shape()[0].width_;
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // setter
-    template <typename WeightInit>
-    layer& weight_init(const WeightInit& f) {
-        weight_init_ = std::make_shared<WeightInit>(f);
-        return *this;
-    }
-
-    template <typename BiasInit>
-    layer& bias_init(const BiasInit& f) {
-        bias_init_ = std::make_shared<BiasInit>(f);
-        return *this;
-    }
-
-    template <typename WeightInit>
-    layer& weight_init(std::shared_ptr<WeightInit> f) {
-        weight_init_ = f;
-        return *this;
-    }
-
-    template <typename BiasInit>
-    layer& bias_init(std::shared_ptr<BiasInit> f) {
-        bias_init_ = f;
-        return *this;
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // save/load
-    template <typename Archive>
-    void serialize(Archive & ar) {
-        auto all_weights = weights();
-        for (auto weight : all_weights) {
-            ar(*weight);
-        }
-        initialized_ = true;
-    }
-
-    virtual void save(std::ostream& os) const { // NOLINT
-        /*if (is_exploded()) {
-            throw nn_error("failed to save weights because of infinite weight");
-        }*/
-        auto all_weights = weights();
-        for (auto& weight : all_weights) {
-            for (auto w : *weight) os << w <<  " ";
-        }
-    }
-
-    virtual void load(std::istream& is) { // NOLINT
-        auto all_weights = weights();
-        for (auto& weight : all_weights) {
-            for (auto& w : *weight) is >> w;
-        }
-        initialized_ = true;
-    }
-
-    virtual void load(const std::vector<float_t>& src, int& idx) { // NOLINT
-        auto all_weights = weights();
-        for (auto& weight : all_weights) {
-            for (auto& w : *weight) w = src[idx++];
-        }
-        initialized_ = true;
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // visualize
-
-    ///< visualize latest output of this layer
-    ///< default implementation interpret output as 1d-vector,
-    ///< so "visual" layer(like convolutional layer) should override this for better visualization.
-    virtual image<> output_to_image(size_t channel = 0) const {
-        const vec_t* output = &(*(outputs()[channel]->get_data()))[0];
-        return vec2image<unsigned char>(*output, out_shape()[channel]);
-    }
-
-    /////////////////////////////////////////////////////////////////////////
-    // fprop/bprop
-
-    /**
-     * @param in_data      input vectors of this layer (data, weight, bias)
-     * @param out_data     output vectors
-     **/
-    virtual void forward_propagation(const std::vector<tensor_t*>& in_data,
-                                     std::vector<tensor_t*>& out_data) = 0;
-
-    /**
-     * return delta of previous layer (delta=\frac{dE}{da}, a=wx in fully-connected layer)
-     * @param in_data      input vectors (same vectors as forward_propagation)
-     * @param out_data     output vectors (same vectors as forward_propagation)
-     * @param out_grad     gradient of output vectors (i-th vector correspond with out_data[i])
-     * @param in_grad      gradient of input vectors (i-th vector correspond with in_data[i])
-     **/
-    virtual void back_propagation(const std::vector<tensor_t*>& in_data,
-                                  const std::vector<tensor_t*>& out_data,
-                                  std::vector<tensor_t*>&       out_grad,
-                                  std::vector<tensor_t*>&       in_grad) = 0;
-
-    /**
-     * return delta2 of previous layer (delta2=\frac{d^2E}{da^2}, diagonal of hessian matrix)
-     * it is never called if optimizer is hessian-free
-     **/
-    //virtual void back_propagation_2nd(const std::vector<vec_t>& delta_in) = 0;
-
-    // called afrer updating weight
-    virtual void post_update() {}
-
-    /**
-    * notify changing context (train <=> test)
-    **/
-    virtual void set_context(net_phase ctx) {
-        CNN_UNREFERENCED_PARAMETER(ctx);
-    }
-
-    std::vector<tensor_t> forward(const std::vector<tensor_t>& input) {   // for test
-        setup(false);
-        set_in_data(input);
-        forward();
-        return output();
-    }
-
-    std::vector<tensor_t> backward(const std::vector<tensor_t>& out_grads) {   // for test
-        setup(false);
-        set_out_grads(out_grads);
-        backward();
-        return map_<tensor_t>(inputs(), [](edgeptr_t e) {
-            return *e->get_gradient();
-        });
-    }
-
-    void forward() {
-        std::vector<tensor_t*> in_data, out_data;
-
-        // organize input/output vectors from storage
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            in_data.push_back(ith_in_node(i)->get_data());
-        }
-
-        // resize outs and stuff to have room for every input sample in the batch
-        set_sample_count(in_data[0]->size());
-
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            out_data.push_back(ith_out_node(i)->get_data());
-            ith_out_node(i)->clear_grads();
-        }
-
-        forward_propagation(in_data, out_data);
-    }
-
-    void backward() {
-        std::vector<tensor_t*> in_data, out_data, in_grad, out_grad;
-
-        // organize input/output vectors from storage
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            in_data.push_back(ith_in_node(i)->get_data());
-        }
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            out_data.push_back(ith_out_node(i)->get_data());
-        }
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            in_grad.push_back(ith_in_node(i)->get_gradient());
-        }
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            out_grad.push_back(ith_out_node(i)->get_gradient());
-        }
-        back_propagation(in_data, out_data, out_grad, in_grad);
-    }
-
-    // allocate & reset weight
-    void setup(bool reset_weight) {
-        if (in_shape().size() != in_channels_ ||
-            out_shape().size() != out_channels_) {
-                throw nn_error("Connection mismatch at setup layer");
-        }
-
-        for (size_t i = 0; i < out_channels_; i++) {
-            if (!next_[i]) {
-                next_[i] = std::make_shared<edge>(
-                    this, out_shape()[i], out_type_[i]);
-            }
-        }
-
-        if (reset_weight || !initialized_) {
-            init_weight();
-        }
-    }
-
-    void init_weight() {
-        if (!trainable_) {
-            initialized_ = true;
-            return;
-        }
-
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            switch (in_type_[i]) {
-                case vector_type::weight:
-                    weight_init_->fill(get_weight_data(i),
-                                       fan_in_size(), fan_out_size());
-                    break;
-                case vector_type::bias:
-                    bias_init_->fill(get_weight_data(i),
-                                     fan_in_size(), fan_out_size());
-                    break;
-                default:
-                    break;
-            }
-        }
-        initialized_ = true;
-    }
-
-    void clear_grads() {
-        for (size_t i = 0; i < in_type_.size(); i++) {
-            ith_in_node(i)->clear_grads();
-        }
-    }
-
-    void update_weight(optimizer *o, cnn_size_t batch_size) {
-        float_t rcp_batch_size = float_t(1) / float_t(batch_size);
-        for (size_t i = 0; i < in_type_.size(); i++) {
-            if (trainable() && is_trainable_weight(in_type_[i])) {
-                vec_t diff;
-                vec_t& target = *get_weight_data(i);
-
-                ith_in_node(i)->merge_grads(&diff);
-                std::transform(diff.begin(), diff.end(),
-                               diff.begin(), [&](float_t x) { // NOLINT
-                                  return x * rcp_batch_size; });
-                o->update(diff, target);
-            }
-        }
-        clear_grads();
-        post_update();
-    }
-
-    bool has_same_weights(const layer& rhs, float_t eps) const {
-        auto w1 = weights();
-        auto w2 = rhs.weights();
-        if (w1.size() != w2.size()) return false;
-
-        for (size_t i = 0; i < w1.size(); i++) {
-            if (w1[i]->size() != w2[i]->size()) return false;
-
-            for (size_t j = 0; j < w1[i]->size(); j++) {
-                if (std::abs(w1[i]->at(j) - w2[i]->at(j)) > eps) return false;
-            }
-        }
-        return true;
-    }
-
-    virtual void set_sample_count(cnn_size_t sample_count) {
-
-        // increase the size if necessary - but do not decrease
-        auto resize = [sample_count](tensor_t* tensor) {
-            tensor->resize(sample_count, (*tensor)[0]);
-        };
-
-        for (cnn_size_t i = 0; i < in_channels_; i++) {
-            if (!is_trainable_weight(in_type_[i])) {
-                resize(ith_in_node(i)->get_data());
-            }
-            resize(ith_in_node(i)->get_gradient());
-        }
-
-        for (cnn_size_t i = 0; i < out_channels_; i++) {
-            if (!is_trainable_weight(out_type_[i])) {
-                resize(ith_out_node(i)->get_data());
-            }
-            resize(ith_out_node(i)->get_gradient());
-        }
-    }
-
-    /**
-    * generate layer from cereal's Archive
-    **/
-    template <typename InputArchive>
-    static std::shared_ptr<layer> load_layer(InputArchive & ia);
-
-    template <typename OutputArchive>
-    static void save_layer(OutputArchive & oa, const layer& l);
-
-    template <class Archive>
-    void serialize_prolog(Archive & ar);
+  }
+
+  /**
+  * generate layer from cereal's Archive
+  **/
+  template <typename InputArchive>
+  static std::shared_ptr<layer> load_layer(InputArchive& ia);
+
+  template <typename OutputArchive>
+  static void save_layer(OutputArchive& oa, const layer& l);
+
+  template <class Archive>
+  void serialize_prolog(Archive& ar);
 
  protected:
-    bool initialized_;
-    bool parallelize_;
-    cnn_size_t in_channels_;   // number of input vectors
-    cnn_size_t out_channels_;  // number of output vectors
-    std::vector<vector_type> in_type_;
-    std::vector<vector_type> out_type_;
-    
-    core::backend_t backend_type_;
-    std::shared_ptr<core::backend> backend_;
+  bool initialized_;
+  bool parallelize_;
+  cnn_size_t in_channels_;   // number of input vectors
+  cnn_size_t out_channels_;  // number of output vectors
+  std::vector<vector_type> in_type_;
+  std::vector<vector_type> out_type_;
 
-    Device* device_ptr_ = nullptr;
+  core::backend_t backend_type_;
+  std::shared_ptr<core::backend> backend_;
+
+  Device* device_ptr_ = nullptr;
 
  private:
-    bool trainable_;
-    std::shared_ptr<weight_init::function> weight_init_;
-    std::shared_ptr<weight_init::function> bias_init_;
+  bool trainable_;
+  std::shared_ptr<weight_init::function> weight_init_;
+  std::shared_ptr<weight_init::function> bias_init_;
 
-    void alloc_input(cnn_size_t i) const {
-        // TODO(nyanp): refactoring
-        // which type of refactoring do you have in mind for that?
-        prev_[i] = std::make_shared<edge>(nullptr, in_shape()[i], in_type_[i]);
-    }
+  void alloc_input(cnn_size_t i) const {
+    // TODO(nyanp): refactoring
+    // which type of refactoring do you have in mind for that?
+    prev_[i] = std::make_shared<edge>(nullptr, in_shape()[i], in_type_[i]);
+  }
 
-    void alloc_output(cnn_size_t i) const {
-        // TODO(nyanp): refactoring
-        // which type of refactoring do you have in mind for that?
-        next_[i] = std::make_shared<edge>((layer*)this,
-            out_shape()[i], out_type_[i]);
-    }
+  void alloc_output(cnn_size_t i) const {
+    // TODO(nyanp): refactoring
+    // which type of refactoring do you have in mind for that?
+    next_[i] =
+        std::make_shared<edge>((layer*)this, out_shape()[i], out_type_[i]);
+  }
 
-    edgeptr_t ith_in_node(cnn_size_t i) {
-        if (!prev_[i]) alloc_input(i);
-        return prev()[i];
-    }
+  edgeptr_t ith_in_node(cnn_size_t i) {
+    if (!prev_[i]) alloc_input(i);
+    return prev()[i];
+  }
 
-    edgeptr_t ith_out_node(cnn_size_t i) {
-        if (!next_[i]) alloc_output(i);
-        return next()[i];
-    }
+  edgeptr_t ith_out_node(cnn_size_t i) {
+    if (!next_[i]) alloc_output(i);
+    return next()[i];
+  }
 
-    vec_t* get_weight_data(cnn_size_t i) {
-        assert(is_trainable_weight(in_type_[i]));
-        return &(*(ith_in_node(i)->get_data()))[0];
-    }
+  vec_t* get_weight_data(cnn_size_t i) {
+    assert(is_trainable_weight(in_type_[i]));
+    return &(*(ith_in_node(i)->get_data()))[0];
+  }
 
-    const vec_t* get_weight_data(cnn_size_t i) const {
-        assert(is_trainable_weight(in_type_[i]));
-        return &(*(const_cast<layerptr_t>(this)->ith_in_node(i)->get_data()))[0];
-    }
+  const vec_t* get_weight_data(cnn_size_t i) const {
+    assert(is_trainable_weight(in_type_[i]));
+    return &(*(const_cast<layerptr_t>(this)->ith_in_node(i)->get_data()))[0];
+  }
 };
 
-inline void connect(layerptr_t head,
-                    layerptr_t tail,
-                    cnn_size_t head_index = 0,
+inline void connect(layerptr_t head, layerptr_t tail, cnn_size_t head_index = 0,
                     cnn_size_t tail_index = 0) {
-    auto out_shape = head->out_shape()[head_index];
-    auto in_shape = tail->in_shape()[tail_index];
+  auto out_shape = head->out_shape()[head_index];
+  auto in_shape = tail->in_shape()[tail_index];
 
-    head->setup(false);
+  head->setup(false);
 
-    if (out_shape.size() != in_shape.size()) {
-        connection_mismatch(*head, *tail);
-    }
+  if (out_shape.size() != in_shape.size()) {
+    connection_mismatch(*head, *tail);
+  }
 
-    if (!head->next_[head_index]) {
-        throw nn_error("output edge must not be null");
-    }
+  if (!head->next_[head_index]) {
+    throw nn_error("output edge must not be null");
+  }
 
-    tail->prev_[tail_index] = head->next_[head_index];
-    tail->prev_[tail_index]->add_next_node(tail);
+  tail->prev_[tail_index] = head->next_[head_index];
+  tail->prev_[tail_index]->add_next_node(tail);
 }
 
-inline layer& operator << (layer& lhs, layer& rhs) {
-    connect(&lhs, &rhs);
-    return rhs;
-}
-
-template <typename Char, typename CharTraits>
-std::basic_ostream<Char, CharTraits>& operator << (
-        std::basic_ostream<Char, CharTraits>& os, const layer& v) {
-    v.save(os);
-    return os;
+inline layer& operator<<(layer& lhs, layer& rhs) {
+  connect(&lhs, &rhs);
+  return rhs;
 }
 
 template <typename Char, typename CharTraits>
-std::basic_istream<Char, CharTraits>& operator >> (
-      std::basic_istream<Char, CharTraits>& os, layer& v) {
-    v.load(os);
-    return os;
+std::basic_ostream<Char, CharTraits>& operator<<(
+    std::basic_ostream<Char, CharTraits>& os, const layer& v) {
+  v.save(os);
+  return os;
+}
+
+template <typename Char, typename CharTraits>
+std::basic_istream<Char, CharTraits>& operator>>(
+    std::basic_istream<Char, CharTraits>& os, layer& v) {
+  v.load(os);
+  return os;
 }
 
 // error message functions
 
 inline void connection_mismatch(const layer& from, const layer& to) {
-    std::ostringstream os;
+  std::ostringstream os;
 
-    os << std::endl;
-    os << "output size of Nth layer must be equal to input of (N+1)th layer\n";
+  os << std::endl;
+  os << "output size of Nth layer must be equal to input of (N+1)th layer\n";
 
-    os << "layerN:   " << std::setw(12) << from.layer_type() << " in:"
-                                        << from.in_data_size() << "("
-                                        << from.in_shape() << "), " << "out:"
-                                        << from.out_data_size() << "("
-                                        << from.out_shape() << ")\n";
+  os << "layerN:   " << std::setw(12) << from.layer_type()
+     << " in:" << from.in_data_size() << "(" << from.in_shape() << "), "
+     << "out:" << from.out_data_size() << "(" << from.out_shape() << ")\n";
 
-    os << "layerN+1: " << std::setw(12) << to.layer_type() << " in:"
-                                        << to.in_data_size() << "("
-                                        << to.in_shape() << "), " << "out:"
-                                        << to.out_data_size() << "("
-                                        << to.out_shape() << ")\n";
+  os << "layerN+1: " << std::setw(12) << to.layer_type()
+     << " in:" << to.in_data_size() << "(" << to.in_shape() << "), "
+     << "out:" << to.out_data_size() << "(" << to.out_shape() << ")\n";
 
-    os << from.out_data_size() << " != " << to.in_data_size() << std::endl;
-    std::string detail_info = os.str();
+  os << from.out_data_size() << " != " << to.in_data_size() << std::endl;
+  std::string detail_info = os.str();
 
-    throw nn_error("layer dimension mismatch!" + detail_info);
+  throw nn_error("layer dimension mismatch!" + detail_info);
 }
 
 inline void data_mismatch(const layer& layer, const vec_t& data) {
-    std::ostringstream os;
+  std::ostringstream os;
 
-    os << std::endl;
-    os << "data dimension:    " << data.size() << "\n";
-    os << "network dimension: " << layer.in_data_size() << "("
-                                << layer.layer_type() << ":"
-                                << layer.in_shape() << ")\n";
+  os << std::endl;
+  os << "data dimension:    " << data.size() << "\n";
+  os << "network dimension: " << layer.in_data_size() << "("
+     << layer.layer_type() << ":" << layer.in_shape() << ")\n";
 
-    std::string detail_info = os.str();
+  std::string detail_info = os.str();
 
-    throw nn_error("input dimension mismatch!" + detail_info);
+  throw nn_error("input dimension mismatch!" + detail_info);
 }
 
-inline void pooling_size_mismatch(cnn_size_t in_width,
-                                  cnn_size_t in_height,
+inline void pooling_size_mismatch(cnn_size_t in_width, cnn_size_t in_height,
                                   cnn_size_t pooling_size) {
-    std::ostringstream os;
+  std::ostringstream os;
 
-    os << std::endl;
-    os << "WxH:" << in_width << "x" << in_height << std::endl;
-    os << "pooling-size:" << pooling_size << std::endl;
+  os << std::endl;
+  os << "WxH:" << in_width << "x" << in_height << std::endl;
+  os << "pooling-size:" << pooling_size << std::endl;
 
-    std::string detail_info = os.str();
+  std::string detail_info = os.str();
 
-    throw nn_error("width/height not multiple of pooling size" + detail_info);
+  throw nn_error("width/height not multiple of pooling size" + detail_info);
 }
-
 
 template <typename T, typename U>
-void graph_traverse(layer *root_node, T&& node_callback, U&& edge_callback) {
-    std::unordered_set<layer*> visited;
-    std::queue<layer*> S;
+void graph_traverse(layer* root_node, T&& node_callback, U&& edge_callback) {
+  std::unordered_set<layer*> visited;
+  std::queue<layer*> S;
 
-    S.push(root_node);
+  S.push(root_node);
 
-    while (!S.empty()) {
-        layer *curr = S.front();
-        S.pop();
-        visited.insert(curr);
+  while (!S.empty()) {
+    layer* curr = S.front();
+    S.pop();
+    visited.insert(curr);
 
-        node_callback(*curr);
+    node_callback(*curr);
 
-        auto edges = curr->next();
-        for (auto e : edges) {
-            if (e != nullptr)
-                edge_callback(*e);
-        }
-
-        auto prev = curr->prev_nodes();
-        for (auto p : prev) {
-            // TODO(nyanp): refactoring
-            // which type of refactoring do you have in mind for that?
-            layer* l = dynamic_cast<layer*>(p);
-            if (visited.find(l) == visited.end()) {
-                S.push(l);
-            }
-        }
-
-        auto next = curr->next_nodes();
-        for (auto n : next) {
-            // TODO(nyanp): refactoring
-            // which type of refactoring do you have in mind for that?
-            layer* l = dynamic_cast<layer*>(n);
-            if (visited.find(l) == visited.end()) {
-                S.push(l);
-            }
-        }
+    auto edges = curr->next();
+    for (auto e : edges) {
+      if (e != nullptr) edge_callback(*e);
     }
+
+    auto prev = curr->prev_nodes();
+    for (auto p : prev) {
+      // TODO(nyanp): refactoring
+      // which type of refactoring do you have in mind for that?
+      layer* l = dynamic_cast<layer*>(p);
+      if (visited.find(l) == visited.end()) {
+        S.push(l);
+      }
+    }
+
+    auto next = curr->next_nodes();
+    for (auto n : next) {
+      // TODO(nyanp): refactoring
+      // which type of refactoring do you have in mind for that?
+      layer* l = dynamic_cast<layer*>(n);
+      if (visited.find(l) == visited.end()) {
+        S.push(l);
+      }
+    }
+  }
 }
-
-
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/layers/layers.h
+++ b/tiny_dnn/layers/layers.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/layers/arithmetic_layer.h"

--- a/tiny_dnn/layers/layers.h
+++ b/tiny_dnn/layers/layers.h
@@ -3,7 +3,6 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/layers/arithmetic_layer.h"
 #include "tiny_dnn/layers/average_pooling_layer.h"
 #include "tiny_dnn/layers/average_unpooling_layer.h"
@@ -14,6 +13,7 @@
 #include "tiny_dnn/layers/dropout_layer.h"
 #include "tiny_dnn/layers/feedforward_layer.h"
 #include "tiny_dnn/layers/fully_connected_layer.h"
+#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/layers/linear_layer.h"
 #include "tiny_dnn/layers/lrn_layer.h"
 #include "tiny_dnn/layers/max_pooling_layer.h"

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -3,93 +3,97 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include <algorithm>
+#include "tiny_dnn/util/util.h"
 
 extern bool g_log_softmax;
-
 
 namespace tiny_dnn {
 
 /**
  * f(x) = h(scale*x+bias)
  */
-template<typename Activation>
+template <typename Activation>
 class linear_layer : public feedforward_layer<Activation> {
-public:
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  CNN_USE_LAYER_MEMBERS;
 
-    typedef feedforward_layer<Activation> Base;
+  typedef feedforward_layer<Activation> Base;
 
-    explicit linear_layer(cnn_size_t dim, float_t scale = float_t(1), float_t bias = float_t(0))
-        : Base({vector_type::data}),
-        dim_(dim), scale_(scale), bias_(bias) {}
+  explicit linear_layer(cnn_size_t dim, float_t scale = float_t(1),
+                        float_t bias = float_t(0))
+      : Base({vector_type::data}), dim_(dim), scale_(scale), bias_(bias) {}
 
-    std::vector<shape3d> in_shape() const override {
-        return {shape3d(dim_, 1, 1) };
+  std::vector<shape3d> in_shape() const override {
+    return {shape3d(dim_, 1, 1)};
+  }
+
+  std::vector<shape3d> out_shape() const override {
+    return {shape3d(dim_, 1, 1), shape3d(dim_, 1, 1)};
+  }
+
+  std::string layer_type() const override { return "linear"; }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    tensor_t& out = *out_data[0];
+    tensor_t& a = *out_data[1];
+
+    // do nothing
+    CNN_UNREFERENCED_PARAMETER(out);
+
+    // @todo revise the parallelism strategy
+    for_i(parallelize_, dim_, [&](int i) {
+      for (cnn_size_t sample = 0, sample_count = in.size();
+           sample < sample_count; ++sample)
+        a[sample][i] = scale_ * in[sample][i] + bias_;
+    });
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
+
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[1];
+
+    CNN_UNREFERENCED_PARAMETER(in_data);
+
+    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    // @todo revise parallelism strategy
+    for (cnn_size_t sample = 0, sample_count = prev_delta.size();
+         sample < sample_count; ++sample) {
+      for_i(parallelize_, dim_, [&](int i) {
+        prev_delta[sample][i] = curr_delta[sample][i] * scale_;
+      });
     }
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return{ shape3d(dim_, 1, 1), shape3d(dim_, 1, 1) };
-    }
+  template <class Archive>
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<linear_layer>& construct) {
+    cnn_size_t dim;
+    float_t scale, bias;
 
-    std::string layer_type() const override { return "linear"; }
+    ar(cereal::make_nvp("in_size", dim), cereal::make_nvp("scale", scale),
+       cereal::make_nvp("bias", bias));
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        const tensor_t& in  = *in_data[0];
-        tensor_t&       out = *out_data[0];
-        tensor_t&       a   = *out_data[1];
+    construct(dim, scale, bias);
+  }
 
-        // do nothing
-        CNN_UNREFERENCED_PARAMETER(out);
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", dim_), cereal::make_nvp("scale", scale_),
+       cereal::make_nvp("bias", bias_));
+  }
 
-        // @todo revise the parallelism strategy
-        for_i(parallelize_, dim_, [&](int i) {
-            for (cnn_size_t sample = 0, sample_count = in.size(); sample < sample_count; ++sample)
-                a[sample][i] = scale_ * in[sample][i] + bias_;
-        });
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        tensor_t& prev_delta = *in_grad[0];
-        tensor_t& curr_delta = *out_grad[1];
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-
-        this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        // @todo revise parallelism strategy
-        for (cnn_size_t sample = 0, sample_count = prev_delta.size(); sample < sample_count; ++sample) {
-            for_i(parallelize_, dim_, [&](int i) {
-                prev_delta[sample][i] = curr_delta[sample][i] * scale_;
-            });
-        }
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<linear_layer> & construct) {
-        cnn_size_t dim;
-        float_t scale, bias;
-
-        ar(cereal::make_nvp("in_size", dim), cereal::make_nvp("scale", scale), cereal::make_nvp("bias", bias));
-
-        construct(dim, scale, bias);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", dim_), cereal::make_nvp("scale", scale_), cereal::make_nvp("bias", bias_));
-    }
-
-protected:
-    cnn_size_t dim_;
-    float_t scale_, bias_;
+ protected:
+  cnn_size_t dim_;
+  float_t scale_, bias_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <algorithm>

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -3,199 +3,177 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include <algorithm>
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
-    enum class norm_region {
-        across_channels,
-        within_channels
-    };
+enum class norm_region { across_channels, within_channels };
 
 /**
  * local response normalization
  */
-template<typename Activation>
+template <typename Activation>
 class lrn_layer : public feedforward_layer<Activation> {
-public:
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  CNN_USE_LAYER_MEMBERS;
 
-    typedef feedforward_layer<Activation> Base;
+  typedef feedforward_layer<Activation> Base;
 
-    lrn_layer(const shape3d& in_shape,
-              cnn_size_t     local_size,
-              float_t        alpha  = 1.0,
-              float_t        beta   = 5.0,
-              norm_region    region = norm_region::across_channels)
-        : Base({ vector_type::data }),
+  lrn_layer(const shape3d& in_shape, cnn_size_t local_size, float_t alpha = 1.0,
+            float_t beta = 5.0,
+            norm_region region = norm_region::across_channels)
+      : Base({vector_type::data}),
         in_shape_(in_shape),
         size_(local_size),
         alpha_(alpha),
         beta_(beta),
         region_(region),
-        in_square_(in_shape_.area()) {
+        in_square_(in_shape_.area()) {}
+
+  /**
+  * @param layer       [in] the previous layer connected to this
+  * @param local_size  [in] the number of channels(depths) to sum over
+  * @param in_channels [in] the number of channels of input data
+  * @param alpha       [in] the scaling parameter (same to caffe's LRN)
+  * @param beta        [in] the scaling parameter (same to caffe's LRN)
+  **/
+  lrn_layer(layer* prev, cnn_size_t local_size, float_t alpha = 1.0,
+            float_t beta = 5.0,
+            norm_region region = norm_region::across_channels)
+      : lrn_layer(prev->out_data_shape()[0], local_size, alpha, beta, region) {}
+
+  /**
+   * @param in_width    [in] the width of input data
+   * @param in_height   [in] the height of input data
+   * @param local_size  [in] the number of channels(depths) to sum over
+   * @param in_channels [in] the number of channels of input data
+   * @param alpha       [in] the scaling parameter (same to caffe's LRN)
+   * @param beta        [in] the scaling parameter (same to caffe's LRN)
+   **/
+  lrn_layer(cnn_size_t in_width, cnn_size_t in_height, cnn_size_t local_size,
+            cnn_size_t in_channels, float_t alpha = 1.0, float_t beta = 5.0,
+            norm_region region = norm_region::across_channels)
+      : lrn_layer(shape3d{in_width, in_height, in_channels}, local_size, alpha,
+                  beta, region) {}
+
+  size_t fan_in_size() const override { return size_; }
+
+  size_t fan_out_size() const override { return size_; }
+
+  std::vector<shape3d> in_shape() const override { return {in_shape_}; }
+
+  std::vector<shape3d> out_shape() const override {
+    return {in_shape_, in_shape_};
+  }
+
+  std::string layer_type() const override { return "norm"; }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    // @todo revise the parallelism strategy
+    for (size_t sample = 0, sample_count = in_data[0]->size();
+         sample < sample_count; ++sample) {
+      vec_t& in = (*in_data[0])[sample];
+      vec_t& out = (*out_data[0])[sample];
+      vec_t& a = (*out_data[1])[sample];
+
+      if (region_ == norm_region::across_channels) {
+        forward_across(in, a);
+      } else {
+        forward_within(in, a);
+      }
+
+      for_i(parallelize_, out.size(), [&](int i) { out[i] = h_.f(a, i); });
+    }
+  }
+
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(out_grad);
+    CNN_UNREFERENCED_PARAMETER(in_grad);
+    throw nn_error("not implemented");
+  }
+
+  template <class Archive>
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<lrn_layer>& construct) {
+    shape3d in_shape;
+    cnn_size_t size;
+    float_t alpha, beta;
+    norm_region region;
+
+    ar(cereal::make_nvp("in_shape", in_shape), cereal::make_nvp("size", size),
+       cereal::make_nvp("alpha", alpha), cereal::make_nvp("beta", beta),
+       cereal::make_nvp("region", region));
+    construct(in_shape, size, alpha, beta, region);
+  }
+
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_shape", in_shape_), cereal::make_nvp("size", size_),
+       cereal::make_nvp("alpha", alpha_), cereal::make_nvp("beta", beta_),
+       cereal::make_nvp("region", region_));
+  }
+
+ private:
+  void forward_across(const vec_t& in, vec_t& out) {
+    std::fill(in_square_.begin(), in_square_.end(), float_t(0));
+
+    for (cnn_size_t i = 0; i < size_ / 2; i++) {
+      cnn_size_t idx = in_shape_.get_index(0, 0, i);
+      add_square_sum(&in[idx], in_shape_.area(), &in_square_[0]);
     }
 
-    /**
-    * @param layer       [in] the previous layer connected to this
-    * @param local_size  [in] the number of channels(depths) to sum over
-    * @param in_channels [in] the number of channels of input data
-    * @param alpha       [in] the scaling parameter (same to caffe's LRN)
-    * @param beta        [in] the scaling parameter (same to caffe's LRN)
-    **/
-    lrn_layer(layer*      prev,
-              cnn_size_t  local_size,
-              float_t     alpha = 1.0,
-              float_t     beta  = 5.0,
-              norm_region region = norm_region::across_channels)
-        : lrn_layer(prev->out_data_shape()[0], local_size, alpha, beta, region) {}
+    cnn_size_t head = size_ / 2;
+    long tail = static_cast<long>(head) - static_cast<long>(size_);
+    cnn_size_t channels = in_shape_.depth_;
+    const cnn_size_t wxh = in_shape_.area();
+    const float_t alpha_div_size = alpha_ / size_;
 
-    /**
-     * @param in_width    [in] the width of input data
-     * @param in_height   [in] the height of input data
-     * @param local_size  [in] the number of channels(depths) to sum over
-     * @param in_channels [in] the number of channels of input data
-     * @param alpha       [in] the scaling parameter (same to caffe's LRN)
-     * @param beta        [in] the scaling parameter (same to caffe's LRN)
-     **/
-    lrn_layer(cnn_size_t  in_width,
-              cnn_size_t  in_height,
-              cnn_size_t  local_size,
-              cnn_size_t  in_channels,
-              float_t     alpha = 1.0,
-              float_t     beta  = 5.0,
-              norm_region region = norm_region::across_channels)
-        : lrn_layer(shape3d{in_width, in_height, in_channels}, local_size, alpha, beta, region){}
+    for (cnn_size_t i = 0; i < channels; i++, head++, tail++) {
+      if (head < channels)
+        add_square_sum(&in[in_shape_.get_index(0, 0, head)], wxh,
+                       &in_square_[0]);
 
-    size_t fan_in_size() const override {
-        return size_;
+      if (tail >= 0)
+        sub_square_sum(&in[in_shape_.get_index(0, 0, tail)], wxh,
+                       &in_square_[0]);
+
+      float_t* dst = &out[in_shape_.get_index(0, 0, i)];
+      const float_t* src = &in[in_shape_.get_index(0, 0, i)];
+      for (cnn_size_t j = 0; j < wxh; j++)
+        dst[j] = src[j] *
+                 std::pow(float_t(1) + alpha_div_size * in_square_[j], -beta_);
     }
+  }
 
-    size_t fan_out_size() const override {
-        return size_;
-    }
+  void forward_within(const vec_t& in, vec_t& out) {
+    CNN_UNREFERENCED_PARAMETER(in);
+    CNN_UNREFERENCED_PARAMETER(out);
+    throw nn_error("not implemented");
+  }
 
-    std::vector<shape3d> in_shape() const override {
-        return { in_shape_ };
-    }
+  void add_square_sum(const float_t* src, cnn_size_t size, float_t* dst) {
+    for (cnn_size_t i = 0; i < size; i++) dst[i] += src[i] * src[i];
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return { in_shape_, in_shape_ };
-    }
+  void sub_square_sum(const float_t* src, cnn_size_t size, float_t* dst) {
+    for (cnn_size_t i = 0; i < size; i++) dst[i] -= src[i] * src[i];
+  }
 
-    std::string layer_type() const override { return "norm"; }
+  shape3d in_shape_;
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
+  cnn_size_t size_;
+  float_t alpha_, beta_;
+  norm_region region_;
 
-        // @todo revise the parallelism strategy
-        for (size_t sample = 0, sample_count = in_data[0]->size(); sample < sample_count; ++sample) {
-            vec_t& in  = (*in_data[0])[sample];
-            vec_t& out = (*out_data[0])[sample];
-            vec_t& a   = (*out_data[1])[sample];
-
-            if (region_ == norm_region::across_channels) {
-                forward_across(in, a);
-            }
-            else {
-                forward_within(in, a);
-            }
-
-            for_i(parallelize_, out.size(), [&](int i) {
-                out[i] = h_.f(a, i);
-            });
-        }
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        throw nn_error("not implemented");
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<lrn_layer> & construct) {
-        shape3d in_shape;
-        cnn_size_t size;
-        float_t alpha, beta;
-        norm_region region;
-
-        ar(cereal::make_nvp("in_shape", in_shape),
-           cereal::make_nvp("size", size),
-           cereal::make_nvp("alpha", alpha),
-           cereal::make_nvp("beta", beta),
-           cereal::make_nvp("region", region));
-        construct(in_shape, size, alpha, beta, region);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_shape", in_shape_),
-           cereal::make_nvp("size", size_),
-           cereal::make_nvp("alpha", alpha_),
-           cereal::make_nvp("beta", beta_),
-           cereal::make_nvp("region", region_));
-    }
-
-private:
-    void forward_across(const vec_t& in, vec_t& out) {
-        std::fill(in_square_.begin(), in_square_.end(), float_t(0));
-
-        for (cnn_size_t i = 0; i < size_ / 2; i++) {
-            cnn_size_t idx = in_shape_.get_index(0, 0, i);
-            add_square_sum(&in[idx], in_shape_.area(), &in_square_[0]);
-        }
-
-        cnn_size_t head = size_ / 2;
-        long tail = static_cast<long>(head) - static_cast<long>(size_);
-        cnn_size_t channels = in_shape_.depth_;
-        const cnn_size_t wxh = in_shape_.area();
-        const float_t alpha_div_size = alpha_ / size_;
-
-        for (cnn_size_t i = 0; i < channels; i++, head++, tail++) {
-            if (head < channels)
-                add_square_sum(&in[in_shape_.get_index(0, 0, head)], wxh, &in_square_[0]);
-
-            if (tail >= 0)
-                sub_square_sum(&in[in_shape_.get_index(0, 0, tail)], wxh, &in_square_[0]);
-
-            float_t *dst = &out[in_shape_.get_index(0, 0, i)];
-            const float_t *src = &in[in_shape_.get_index(0, 0, i)];
-            for (cnn_size_t j = 0; j < wxh; j++)
-                dst[j] = src[j] * std::pow(float_t(1) + alpha_div_size * in_square_[j], -beta_);
-        }
-    }
-
-    void forward_within(const vec_t& in, vec_t& out) {
-        CNN_UNREFERENCED_PARAMETER(in);
-        CNN_UNREFERENCED_PARAMETER(out);
-        throw nn_error("not implemented");
-    }
-
-    void add_square_sum(const float_t *src, cnn_size_t size, float_t *dst) {
-        for (cnn_size_t i = 0; i < size; i++)
-            dst[i] += src[i] * src[i];
-    }
-
-    void sub_square_sum(const float_t *src, cnn_size_t size, float_t *dst) {
-        for (cnn_size_t i = 0; i < size; i++)
-            dst[i] -= src[i] * src[i];
-    }
-
-    shape3d in_shape_;
-
-    cnn_size_t size_;
-    float_t alpha_, beta_;
-    norm_region region_;
-
-    vec_t in_square_;
+  vec_t in_square_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <algorithm>

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2015, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <string>

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -4,20 +4,20 @@
 
 #pragma once
 
+#include <algorithm>
 #include <string>
 #include <vector>
-#include <algorithm>
 
-#include "tiny_dnn/core/backend_tiny.h"
-#include "tiny_dnn/core/backend_nnp.h"
 #include "tiny_dnn/core/backend_dnn.h"
+#include "tiny_dnn/core/backend_nnp.h"
+#include "tiny_dnn/core/backend_tiny.h"
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/backend_avx.h"
 #endif
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
@@ -27,247 +27,233 @@ namespace tiny_dnn {
 template <typename Activation = activation::identity>
 class max_pooling_layer : public feedforward_layer<Activation> {
  public:
-    CNN_USE_LAYER_MEMBERS;
-    typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
+  typedef feedforward_layer<Activation> Base;
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pooling_size [in] factor by which to downscale
-     **/
-    max_pooling_layer(cnn_size_t     in_width,
-                      cnn_size_t     in_height,
-                      cnn_size_t     in_channels,
-                      cnn_size_t     pooling_size,
-                      backend_t      backend_type = core::default_engine(),
-                      backend_params b_params = backend_params())
-            : max_pooling_layer(in_width, in_height, in_channels, pooling_size, pooling_size, backend_type, b_params) {
-    }
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pooling_size [in] factor by which to downscale
+   **/
+  max_pooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                    cnn_size_t in_channels, cnn_size_t pooling_size,
+                    backend_t backend_type = core::default_engine(),
+                    backend_params b_params = backend_params())
+      : max_pooling_layer(in_width, in_height, in_channels, pooling_size,
+                          pooling_size, backend_type, b_params) {}
 
-    max_pooling_layer(const shape3d& in_shape,
-                      cnn_size_t     pooling_size,
-                      cnn_size_t     stride,
-                      backend_t      backend_type = core::default_engine(),
-                      backend_params b_params = backend_params())
-        : max_pooling_layer(in_shape.width_, in_shape.height_, in_shape.depth_, pooling_size, stride, backend_type, b_params) {
-    }
+  max_pooling_layer(const shape3d& in_shape, cnn_size_t pooling_size,
+                    cnn_size_t stride,
+                    backend_t backend_type = core::default_engine(),
+                    backend_params b_params = backend_params())
+      : max_pooling_layer(in_shape.width_, in_shape.height_, in_shape.depth_,
+                          pooling_size, stride, backend_type, b_params) {}
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param pooling_size [in] factor by which to downscale
-     * @param stride       [in] interval at which to apply the filters to the input
-    **/
-    max_pooling_layer(cnn_size_t     in_width,
-                      cnn_size_t     in_height,
-                      cnn_size_t     in_channels,
-                      cnn_size_t     pooling_size,
-                      cnn_size_t     stride,
-                      backend_t      backend_type = backend_t::tiny_dnn,
-                      backend_params b_params = backend_params())
-            : Base({ vector_type::data }) {
-        set_maxpool_params(
-            shape3d(in_width, in_height, in_channels),
-            shape3d(pool_out_dim(in_width, pooling_size, stride),
-                    pool_out_dim(in_height, pooling_size, stride),
-                    in_channels),
-            pooling_size, stride);
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param pooling_size [in] factor by which to downscale
+   * @param stride       [in] interval at which to apply the filters to the
+   *input
+  **/
+  max_pooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                    cnn_size_t in_channels, cnn_size_t pooling_size,
+                    cnn_size_t stride,
+                    backend_t backend_type = backend_t::tiny_dnn,
+                    backend_params b_params = backend_params())
+      : Base({vector_type::data}) {
+    set_maxpool_params(
+        shape3d(in_width, in_height, in_channels),
+        shape3d(pool_out_dim(in_width, pooling_size, stride),
+                pool_out_dim(in_height, pooling_size, stride), in_channels),
+        pooling_size, stride);
 
-        init_connection();
-        init_backend(backend_type);
-        Base::set_backend_type(backend_type);
-    }
+    init_connection();
+    init_backend(backend_type);
+    Base::set_backend_type(backend_type);
+  }
 
-    // move constructor
-    max_pooling_layer(max_pooling_layer&& other)  // NOLINT
-            : Base(std::move(other))
-            , params_(std::move(other.params_))
-            , out2in_(std::move(other.out2in_))
-            , in2out_(std::move(other.in2out_))
-            , max_pooling_layer_worker_storage_(
-                std::move(other.max_pooling_layer_worker_storage_)) {
-        init_connection();
-        init_backend(std::move(Base::backend_type()));
-    }
+  // move constructor
+  max_pooling_layer(max_pooling_layer&& other)  // NOLINT
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        out2in_(std::move(other.out2in_)),
+        in2out_(std::move(other.in2out_)),
+        max_pooling_layer_worker_storage_(
+            std::move(other.max_pooling_layer_worker_storage_)) {
+    init_connection();
+    init_backend(std::move(Base::backend_type()));
+  }
 
-    size_t fan_in_size() const override {
-        return out2in_[0].size();
-    }
+  size_t fan_in_size() const override { return out2in_[0].size(); }
 
-    size_t fan_out_size() const override {
-        return 1;
-    }
+  size_t fan_out_size() const override { return 1; }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) override {
-        // launch maxpool kernel
-        Base::backend_->maxpool(in_data, out_data);
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    // launch maxpool kernel
+    Base::backend_->maxpool(in_data, out_data);
 
-        // activations
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
+    // activations
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        // launch maxpool kernel
-        Base::backend_->maxpool(in_data, out_data, out_grad, in_grad);
-    }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    // launch maxpool kernel
+    Base::backend_->maxpool(in_data, out_data, out_grad, in_grad);
+  }
 
-    std::vector<index3d<cnn_size_t>>
-    in_shape() const override { return { params_.in_ }; }
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    return {params_.in_};
+  }
 
-    std::vector<index3d<cnn_size_t>>
-    out_shape() const override { return { params_.out_, params_.out_ }; }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {params_.out_, params_.out_};
+  }
 
-    std::string layer_type() const override {
-        return std::string("max-pool");
-    }
+  std::string layer_type() const override { return std::string("max-pool"); }
 
-    std::string kernel_file() const override {
-        return std::string("../tiny_cnn/core/kernels/cl_kernels/pooling.cl");
-    }
+  std::string kernel_file() const override {
+    return std::string("../tiny_cnn/core/kernels/cl_kernels/pooling.cl");
+  }
 
-    size_t pool_size() const { return params_.pool_size_; }
+  size_t pool_size() const { return params_.pool_size_; }
 
-    void set_sample_count(cnn_size_t sample_count) override {
-        Base::set_sample_count(sample_count);
-        max_pooling_layer_worker_storage_.out2inmax_.resize(sample_count, std::vector<cnn_size_t>(params_.out_.size()));
-    }
+  void set_sample_count(cnn_size_t sample_count) override {
+    Base::set_sample_count(sample_count);
+    max_pooling_layer_worker_storage_.out2inmax_.resize(
+        sample_count, std::vector<cnn_size_t>(params_.out_.size()));
+  }
 
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<max_pooling_layer>& construct) {
+    shape3d in;
+    size_t stride, pool_size;
 
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<max_pooling_layer> & construct) {
-        shape3d in;
-        size_t stride, pool_size;
+    ar(cereal::make_nvp("in_size", in),
+       cereal::make_nvp("pool_size", pool_size),
+       cereal::make_nvp("stride", stride));
+    construct(in, pool_size, stride);
+  }
 
-        ar(cereal::make_nvp("in_size", in), cereal::make_nvp("pool_size", pool_size), cereal::make_nvp("stride", stride));
-        construct(in, pool_size, stride);
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", params_.in_),
+       cereal::make_nvp("pool_size", params_.pool_size_),
+       cereal::make_nvp("stride", params_.stride_));
+  }
 
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in_), cereal::make_nvp("pool_size", params_.pool_size_), cereal::make_nvp("stride", params_.stride_));
-    }
+ private:
+  maxpool_params params_;
 
-private:
-    maxpool_params params_;
+  /* mapping out => in (1:N) */
+  std::vector<std::vector<cnn_size_t>> out2in_;
+  /* mapping in => out (N:1) */
+  std::vector<cnn_size_t> in2out_;
 
-    /* mapping out => in (1:N) */
-    std::vector<std::vector<cnn_size_t> > out2in_;
-    /* mapping in => out (N:1) */
-    std::vector<cnn_size_t> in2out_;
+  max_pooling_layer_worker_specific_storage max_pooling_layer_worker_storage_;
 
-    max_pooling_layer_worker_specific_storage
-    max_pooling_layer_worker_storage_;
+  static cnn_size_t pool_out_dim(cnn_size_t in_size, cnn_size_t pooling_size,
+                                 cnn_size_t stride) {
+    float_t tmp = static_cast<float_t>(in_size - pooling_size) / stride;
+    return static_cast<cnn_size_t>(std::ceil(tmp) + float_t(1.0));
+  }
 
-    static cnn_size_t pool_out_dim(cnn_size_t in_size,
-                                   cnn_size_t pooling_size,
-                                   cnn_size_t stride) {
-        float_t tmp = static_cast<float_t>(in_size - pooling_size) / stride;
-        return static_cast<cnn_size_t>(std::ceil(tmp) + float_t(1.0));
-    }
+  void connect_kernel(cnn_size_t pooling_size, cnn_size_t outx, cnn_size_t outy,
+                      cnn_size_t c) {
+    cnn_size_t dxmax = static_cast<cnn_size_t>(
+        std::min(static_cast<size_t>(pooling_size),
+                 params_.in_.width_ - outx * params_.stride_));
 
-    void connect_kernel(cnn_size_t pooling_size,
-                        cnn_size_t outx,
-                        cnn_size_t outy,
-                        cnn_size_t c) {
-        cnn_size_t dxmax = static_cast<cnn_size_t>(
-            std::min(static_cast<size_t>(pooling_size),
-                     params_.in_.width_ - outx * params_.stride_));
+    cnn_size_t dymax = static_cast<cnn_size_t>(
+        std::min(static_cast<size_t>(pooling_size),
+                 params_.in_.height_ - outy * params_.stride_));
 
-        cnn_size_t dymax = static_cast<cnn_size_t>(
-            std::min(static_cast<size_t>(pooling_size),
-                     params_.in_.height_ - outy * params_.stride_));
+    for (cnn_size_t dy = 0; dy < dymax; dy++) {
+      for (cnn_size_t dx = 0; dx < dxmax; dx++) {
+        cnn_size_t in_index = params_.in_.get_index(
+            static_cast<cnn_size_t>(outx * params_.stride_ + dx),
+            static_cast<cnn_size_t>(outy * params_.stride_ + dy), c);
+        cnn_size_t out_index = params_.out_.get_index(outx, outy, c);
 
-        for (cnn_size_t dy = 0; dy < dymax; dy++) {
-            for (cnn_size_t dx = 0; dx < dxmax; dx++) {
-                cnn_size_t in_index = params_.in_.get_index(
-                    static_cast<cnn_size_t>(outx * params_.stride_ + dx),
-                    static_cast<cnn_size_t>(outy * params_.stride_ + dy), c);
-                cnn_size_t out_index = params_.out_.get_index(outx, outy, c);
-
-                if (in_index >= in2out_.size()) {
-                    throw nn_error("index overflow");
-                }
-                if (out_index >= out2in_.size()) {
-                    throw nn_error("index overflow");
-                }
-                in2out_[in_index] = out_index;
-                out2in_[out_index].push_back(in_index);
-            }
+        if (in_index >= in2out_.size()) {
+          throw nn_error("index overflow");
         }
-    }
-
-    void init_connection() {
-        in2out_.resize(params_.in_.size());
-        out2in_.resize(params_.out_.size());
-        //max_pooling_layer_worker_storage_.out2inmax_.resize(params_.out_.size());
-
-        for (cnn_size_t c = 0; c < params_.in_.depth_; ++c) {
-            for (cnn_size_t y = 0; y < params_.out_.height_; ++y) {
-                for (cnn_size_t x = 0; x < params_.out_.width_; ++x) {
-                    connect_kernel(static_cast<cnn_size_t>(params_.pool_size_),
-                                   x, y, c);
-                }
-            }
+        if (out_index >= out2in_.size()) {
+          throw nn_error("index overflow");
         }
+        in2out_[in_index] = out_index;
+        out2in_[out_index].push_back(in_index);
+      }
     }
+  }
 
-    void init_backend(backend_t backend_type) {
-        std::shared_ptr<core::backend> backend = nullptr;
+  void init_connection() {
+    in2out_.resize(params_.in_.size());
+    out2in_.resize(params_.out_.size());
+    // max_pooling_layer_worker_storage_.out2inmax_.resize(params_.out_.size());
 
-        // allocate new backend
-        if (backend_type == backend_t::tiny_dnn) {
-            backend = std::make_shared<core::tiny_backend>(
-                &out2in_,
-                &in2out_,
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &max_pooling_layer_worker_storage_);
-        } else if (backend_type == backend_t::nnpack) {
-            backend = std::make_shared<core::nnp_backend>(&params_);
-        } else if (backend_type == backend_t::libdnn) {
-            backend = std::make_shared<core::dnn_backend>();
+    for (cnn_size_t c = 0; c < params_.in_.depth_; ++c) {
+      for (cnn_size_t y = 0; y < params_.out_.height_; ++y) {
+        for (cnn_size_t x = 0; x < params_.out_.width_; ++x) {
+          connect_kernel(static_cast<cnn_size_t>(params_.pool_size_), x, y, c);
+        }
+      }
+    }
+  }
+
+  void init_backend(backend_t backend_type) {
+    std::shared_ptr<core::backend> backend = nullptr;
+
+    // allocate new backend
+    if (backend_type == backend_t::tiny_dnn) {
+      backend = std::make_shared<core::tiny_backend>(
+          &out2in_, &in2out_,
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &max_pooling_layer_worker_storage_);
+    } else if (backend_type == backend_t::nnpack) {
+      backend = std::make_shared<core::nnp_backend>(&params_);
+    } else if (backend_type == backend_t::libdnn) {
+      backend = std::make_shared<core::dnn_backend>();
 #ifdef CNN_USE_AVX
-        } else if (backend_type == backend_t::avx) {
-            backend = std::make_shared<core::avx_backend>(
-                &out2in_,
-                &in2out_,
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &max_pooling_layer_worker_storage_);
+    } else if (backend_type == backend_t::avx) {
+      backend = std::make_shared<core::avx_backend>(
+          &out2in_, &in2out_,
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &max_pooling_layer_worker_storage_);
 #endif
-        } else {
-            throw nn_error("Not supported backend type.");
-        }
-
-        if (backend) {
-            Base::set_backend(backend);
-            Base::backend_->set_layer(this);
-        } else {
-            throw nn_error("Could not allocate the backend.");
-        }
+    } else {
+      throw nn_error("Not supported backend type.");
     }
 
-    void set_maxpool_params(const shape3d& in,
-                            const shape3d& out,
-                            cnn_size_t pooling_size,
-                            cnn_size_t stride) {
-        params_.in_        = in;
-        params_.out_       = out;
-        params_.pool_size_ = pooling_size;
-        params_.stride_    = stride;
+    if (backend) {
+      Base::set_backend(backend);
+      Base::backend_->set_layer(this);
+    } else {
+      throw nn_error("Could not allocate the backend.");
     }
+  }
+
+  void set_maxpool_params(const shape3d& in, const shape3d& out,
+                          cnn_size_t pooling_size, cnn_size_t stride) {
+    params_.in_ = in;
+    params_.out_ = out;
+    params_.pool_size_ = pooling_size;
+    params_.stride_ = stride;
+  }
 };
 
 }  // namespace tiny_dnn
-

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2015, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/util/image.h"

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -3,9 +3,9 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
@@ -14,182 +14,184 @@ namespace tiny_dnn {
  **/
 template <typename Activation = activation::identity>
 class max_unpooling_layer : public feedforward_layer<Activation> {
-public:
-    CNN_USE_LAYER_MEMBERS;
-    typedef feedforward_layer<Activation> Base;
+ public:
+  CNN_USE_LAYER_MEMBERS;
+  typedef feedforward_layer<Activation> Base;
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param unpooling_size [in] factor by which to upscale
-     **/
-    max_unpooling_layer(cnn_size_t in_width,
-                        cnn_size_t in_height,
-                        cnn_size_t in_channels,
-                        cnn_size_t unpooling_size)
-        : max_unpooling_layer(in_width, in_height, in_channels, unpooling_size, unpooling_size)
-    {}
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param unpooling_size [in] factor by which to upscale
+   **/
+  max_unpooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t in_channels, cnn_size_t unpooling_size)
+      : max_unpooling_layer(in_width, in_height, in_channels, unpooling_size,
+                            unpooling_size) {}
 
-    max_unpooling_layer(const shape3d& in_size,
-                        cnn_size_t unpooling_size,
-                        cnn_size_t stride)
-        : max_unpooling_layer(in_size.width_, in_size.height_, in_size.depth_, unpooling_size, unpooling_size)
-    {}
+  max_unpooling_layer(const shape3d& in_size, cnn_size_t unpooling_size,
+                      cnn_size_t stride)
+      : max_unpooling_layer(in_size.width_, in_size.height_, in_size.depth_,
+                            unpooling_size, unpooling_size) {}
 
-    /**
-     * @param in_width     [in] width of input image
-     * @param in_height    [in] height of input image
-     * @param in_channels  [in] the number of input image channels(depth)
-     * @param unpooling_size [in] factor by which to upscale
-     * @param stride       [in] interval at which to apply the filters to the input
-    **/
-    max_unpooling_layer(cnn_size_t in_width,
-                        cnn_size_t in_height,
-                        cnn_size_t in_channels,
-                        cnn_size_t unpooling_size,
-                        cnn_size_t stride)
-        : Base({vector_type::data}),
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels(depth)
+   * @param unpooling_size [in] factor by which to upscale
+   * @param stride       [in] interval at which to apply the filters to the
+   *input
+  **/
+  max_unpooling_layer(cnn_size_t in_width, cnn_size_t in_height,
+                      cnn_size_t in_channels, cnn_size_t unpooling_size,
+                      cnn_size_t stride)
+      : Base({vector_type::data}),
         unpool_size_(unpooling_size),
         stride_(stride),
         in_(in_width, in_height, in_channels),
-        out_(unpool_out_dim(in_width, unpooling_size, stride), unpool_out_dim(in_height, unpooling_size, stride), in_channels)
-    {
-        //set_worker_count(CNN_TASK_SIZE);
-        init_connection();
+        out_(unpool_out_dim(in_width, unpooling_size, stride),
+             unpool_out_dim(in_height, unpooling_size, stride), in_channels) {
+    // set_worker_count(CNN_TASK_SIZE);
+    init_connection();
+  }
+
+  size_t fan_in_size() const override { return 1; }
+
+  size_t fan_out_size() const override { return in2out_[0].size(); }
+
+  void forward_propagation(cnn_size_t index, const std::vector<vec_t*>& in_data,
+                           std::vector<vec_t*>& out_data) override {
+    const vec_t& in = *in_data[0];
+    vec_t& out = *out_data[0];
+    vec_t& a = *out_data[1];
+    std::vector<cnn_size_t>& max_idx =
+        max_unpooling_layer_worker_storage_[index].in2outmax_;
+
+    for_(parallelize_, 0, in2out_.size(), [&](const blocked_range& r) {
+      for (int i = r.begin(); i < r.end(); i++) {
+        const auto& in_index = out2in_[i];
+        a[i] = (max_idx[in_index] == i) ? in[in_index] : float_t(0);
+      }
+    });
+
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
+
+  void back_propagation(cnn_size_t index, const std::vector<vec_t*>& in_data,
+                        const std::vector<vec_t*>& out_data,
+                        std::vector<vec_t*>& out_grad,
+                        std::vector<vec_t*>& in_grad) override {
+    vec_t& prev_delta = *in_grad[0];
+    vec_t& curr_delta = *out_grad[1];
+    std::vector<cnn_size_t>& max_idx =
+        max_unpooling_layer_worker_storage_[index].in2outmax_;
+
+    CNN_UNREFERENCED_PARAMETER(in_data);
+
+    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
+
+    for_(parallelize_, 0, in2out_.size(), [&](const blocked_range& r) {
+      for (int i = r.begin(); i != r.end(); i++) {
+        cnn_size_t outi = out2in_[i];
+        prev_delta[i] = (max_idx[outi] == i) ? curr_delta[outi] : float_t(0);
+      }
+    });
+  }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override { return {in_}; }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {out_, out_};
+  }
+  std::string layer_type() const override { return "max-unpool"; }
+  size_t unpool_size() const { return unpool_size_; }
+
+  virtual void set_worker_count(cnn_size_t worker_count) override {
+    Base::set_worker_count(worker_count);
+    max_unpooling_layer_worker_storage_.resize(worker_count);
+    for (max_unpooling_layer_worker_specific_storage& mws :
+         max_unpooling_layer_worker_storage_) {
+      mws.in2outmax_.resize(out_.size());
+    }
+  }
+
+  template <class Archive>
+  static void load_and_construct(
+      Archive& ar, cereal::construct<max_unpooling_layer>& construct) {
+    shape3d in;
+    size_t stride, unpool_size;
+
+    ar(cereal::make_nvp("in_size", in),
+       cereal::make_nvp("unpool_size", unpool_size),
+       cereal::make_nvp("stride", stride));
+    construct(in, unpool_size, stride);
+  }
+
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", in_),
+       cereal::make_nvp("unpool_size", unpool_size_),
+       cereal::make_nvp("stride", stride_));
+  }
+
+ private:
+  size_t unpool_size_;
+  size_t stride_;
+  std::vector<cnn_size_t> out2in_;               // mapping out => in (N:1)
+  std::vector<std::vector<cnn_size_t>> in2out_;  // mapping in => out (1:N)
+
+  struct max_unpooling_layer_worker_specific_storage {
+    std::vector<cnn_size_t> in2outmax_;  // mapping max_index(out) => in (1:1)
+  };
+
+  std::vector<max_unpooling_layer_worker_specific_storage>
+      max_unpooling_layer_worker_storage_;
+
+  index3d<cnn_size_t> in_;
+  index3d<cnn_size_t> out_;
+
+  static cnn_size_t unpool_out_dim(cnn_size_t in_size,
+                                   cnn_size_t unpooling_size,
+                                   cnn_size_t stride) {
+    return (int)(float_t)in_size * stride + unpooling_size - 1;
+  }
+
+  void connect_kernel(cnn_size_t unpooling_size, cnn_size_t inx, cnn_size_t iny,
+                      cnn_size_t c) {
+    cnn_size_t dxmax = static_cast<cnn_size_t>(
+        std::min((size_t)unpooling_size, inx * stride_ - out_.width_));
+    cnn_size_t dymax = static_cast<cnn_size_t>(
+        std::min((size_t)unpooling_size, iny * stride_ - out_.height_));
+
+    for (cnn_size_t dy = 0; dy < dymax; dy++) {
+      for (cnn_size_t dx = 0; dx < dxmax; dx++) {
+        cnn_size_t out_index =
+            out_.get_index(static_cast<cnn_size_t>(inx * stride_ + dx),
+                           static_cast<cnn_size_t>(iny * stride_ + dy), c);
+        cnn_size_t in_index = in_.get_index(inx, iny, c);
+
+        if (in_index >= in2out_.size()) throw nn_error("index overflow");
+        if (out_index >= out2in_.size()) throw nn_error("index overflow");
+        out2in_[out_index] = in_index;
+        in2out_[in_index].push_back(out_index);
+      }
+    }
+  }
+
+  void init_connection() {
+    in2out_.resize(in_.size());
+    out2in_.resize(out_.size());
+
+    for (max_unpooling_layer_worker_specific_storage& mws :
+         max_unpooling_layer_worker_storage_) {
+      mws.in2outmax_.resize(in_.size());
     }
 
-    size_t fan_in_size() const override {
-        return 1;
-    }
-
-    size_t fan_out_size() const override {
-        return in2out_[0].size();
-    }
-
-    void forward_propagation(cnn_size_t index,
-                             const std::vector<vec_t*>& in_data,
-                             std::vector<vec_t*>&       out_data)  override {
-        const vec_t& in  = *in_data[0];
-        vec_t&       out = *out_data[0];
-        vec_t&       a   = *out_data[1];
-        std::vector<cnn_size_t>& max_idx = max_unpooling_layer_worker_storage_[index].in2outmax_;
-
-        for_(parallelize_, 0, in2out_.size(), [&](const blocked_range& r) {
-            for (int i = r.begin(); i < r.end(); i++) {
-                const auto& in_index = out2in_[i];
-                a[i] = (max_idx[in_index] == i) ? in[in_index] : float_t(0);
-            }
-        });
-
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
-
-    void back_propagation(cnn_size_t                 index,
-                          const std::vector<vec_t*>& in_data,
-                          const std::vector<vec_t*>& out_data,
-                          std::vector<vec_t*>&       out_grad,
-                          std::vector<vec_t*>&       in_grad) override {
-        vec_t&       prev_delta = *in_grad[0];
-        vec_t&       curr_delta = *out_grad[1];
-        std::vector<cnn_size_t>& max_idx = max_unpooling_layer_worker_storage_[index].in2outmax_;
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-
-        this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        for_(parallelize_, 0, in2out_.size(), [&](const blocked_range& r) {
-            for (int i = r.begin(); i != r.end(); i++) {
-                cnn_size_t outi = out2in_[i];
-                prev_delta[i] = (max_idx[outi] == i) ? curr_delta[outi] : float_t(0);
-            }
-        });
-    }
-
-    std::vector<index3d<cnn_size_t>> in_shape() const override { return {in_}; }
-    std::vector<index3d<cnn_size_t>> out_shape() const override { return {out_, out_}; }
-    std::string layer_type() const override { return "max-unpool"; }
-    size_t unpool_size() const {return unpool_size_;}
-
-    virtual void set_worker_count(cnn_size_t worker_count) override {
-        Base::set_worker_count(worker_count);
-        max_unpooling_layer_worker_storage_.resize(worker_count);
-        for (max_unpooling_layer_worker_specific_storage& mws : max_unpooling_layer_worker_storage_) {
-            mws.in2outmax_.resize(out_.size());
-        }
-    }
-
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<max_unpooling_layer> & construct) {
-        shape3d in;
-        size_t stride, unpool_size;
-
-        ar(cereal::make_nvp("in_size", in), cereal::make_nvp("unpool_size", unpool_size), cereal::make_nvp("stride", stride));
-        construct(in, unpool_size, stride);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_), cereal::make_nvp("unpool_size", unpool_size_), cereal::make_nvp("stride", stride_));
-    }
-
-private:
-    size_t unpool_size_;
-    size_t stride_;
-    std::vector<cnn_size_t> out2in_; // mapping out => in (N:1)
-    std::vector<std::vector<cnn_size_t> > in2out_; // mapping in => out (1:N)
-
-    struct max_unpooling_layer_worker_specific_storage {
-        std::vector<cnn_size_t> in2outmax_; // mapping max_index(out) => in (1:1)
-    };
-
-    std::vector<max_unpooling_layer_worker_specific_storage> max_unpooling_layer_worker_storage_;
-
-    index3d<cnn_size_t> in_;
-    index3d<cnn_size_t> out_;
-
-    static cnn_size_t unpool_out_dim(cnn_size_t in_size, cnn_size_t unpooling_size, cnn_size_t stride) {
-        return (int) (float_t)in_size * stride + unpooling_size - 1;
-    }
-
-    void connect_kernel(cnn_size_t unpooling_size, cnn_size_t inx, cnn_size_t iny, cnn_size_t  c)
-    {
-        cnn_size_t dxmax = static_cast<cnn_size_t>(std::min((size_t)unpooling_size, inx * stride_ - out_.width_));
-        cnn_size_t dymax = static_cast<cnn_size_t>(std::min((size_t)unpooling_size, iny * stride_ - out_.height_));
-
-        for (cnn_size_t dy = 0; dy < dymax; dy++) {
-            for (cnn_size_t dx = 0; dx < dxmax; dx++) {
-                cnn_size_t out_index = out_.get_index(static_cast<cnn_size_t>(inx * stride_ + dx),
-                                                      static_cast<cnn_size_t>(iny * stride_ + dy), c);
-                cnn_size_t in_index = in_.get_index(inx, iny, c);
-
-                if (in_index >= in2out_.size())
-                    throw nn_error("index overflow");
-                if (out_index >= out2in_.size())
-                    throw nn_error("index overflow");
-                out2in_[out_index] = in_index;
-                in2out_[in_index].push_back(out_index);
-            }
-        }
-    }
-
-    void init_connection()
-    {
-        in2out_.resize(in_.size());
-        out2in_.resize(out_.size());
-
-        for (max_unpooling_layer_worker_specific_storage& mws : max_unpooling_layer_worker_storage_) {
-            mws.in2outmax_.resize(in_.size());
-        }
-
-        for (cnn_size_t c = 0; c < in_.depth_; ++c)
-            for (cnn_size_t y = 0; y < in_.height_; ++y)
-                for (cnn_size_t x = 0; x < in_.width_; ++x)
-                    connect_kernel(static_cast<cnn_size_t>(unpool_size_),
-                                   x, y, c);
-    }
-
+    for (cnn_size_t c = 0; c < in_.depth_; ++c)
+      for (cnn_size_t y = 0; y < in_.height_; ++y)
+        for (cnn_size_t x = 0; x < in_.width_; ++x)
+          connect_kernel(static_cast<cnn_size_t>(unpool_size_), x, y, c);
+  }
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/partial_connected_layer.h
+++ b/tiny_dnn/layers/partial_connected_layer.h
@@ -3,149 +3,148 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
-template<typename Activation>
+template <typename Activation>
 class partial_connected_layer : public feedforward_layer<Activation> {
-public:
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  CNN_USE_LAYER_MEMBERS;
 
-    typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > io_connections;
-    typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > wi_connections;
-    typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > wo_connections;
-    typedef feedforward_layer<Activation> Base;
+  typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > io_connections;
+  typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > wi_connections;
+  typedef std::vector<std::pair<cnn_size_t, cnn_size_t> > wo_connections;
+  typedef feedforward_layer<Activation> Base;
 
-    partial_connected_layer(cnn_size_t in_dim,
-                            cnn_size_t out_dim,
-                            size_t     weight_dim,
-                            size_t     bias_dim,
-                            float_t    scale_factor = float_t(1))
-        : Base(std_input_order(bias_dim > 0)),
-          weight2io_(weight_dim),
-          out2wi_(out_dim),
-          in2wo_(in_dim),
-          bias2out_(bias_dim),
-          out2bias_(out_dim),
-          scale_factor_(scale_factor){}
+  partial_connected_layer(cnn_size_t in_dim, cnn_size_t out_dim,
+                          size_t weight_dim, size_t bias_dim,
+                          float_t scale_factor = float_t(1))
+      : Base(std_input_order(bias_dim > 0)),
+        weight2io_(weight_dim),
+        out2wi_(out_dim),
+        in2wo_(in_dim),
+        bias2out_(bias_dim),
+        out2bias_(out_dim),
+        scale_factor_(scale_factor) {}
 
-    size_t param_size() const {
-        size_t total_param = 0;
-        for (auto w : weight2io_)
-            if (w.size() > 0) total_param++;
-        for (auto b : bias2out_)
-            if (b.size() > 0) total_param++;
-        return total_param;
+  size_t param_size() const {
+    size_t total_param = 0;
+    for (auto w : weight2io_)
+      if (w.size() > 0) total_param++;
+    for (auto b : bias2out_)
+      if (b.size() > 0) total_param++;
+    return total_param;
+  }
+
+  size_t fan_in_size() const override { return max_size(out2wi_); }
+
+  size_t fan_out_size() const override { return max_size(in2wo_); }
+
+  void connect_weight(cnn_size_t input_index, cnn_size_t output_index,
+                      cnn_size_t weight_index) {
+    weight2io_[weight_index].emplace_back(input_index, output_index);
+    out2wi_[output_index].emplace_back(weight_index, input_index);
+    in2wo_[input_index].emplace_back(weight_index, output_index);
+  }
+
+  void connect_bias(cnn_size_t bias_index, cnn_size_t output_index) {
+    out2bias_[output_index] = bias_index;
+    bias2out_[bias_index].push_back(output_index);
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    const tensor_t& in = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    const vec_t& b = (*in_data[2])[0];
+    tensor_t& a = *out_data[1];
+
+    // @todo revise the parallelism strategy
+    for (cnn_size_t sample = 0, sample_count = in.size(); sample < sample_count;
+         ++sample) {
+      vec_t& a_sample = a[sample];
+
+      for_i(parallelize_, out2wi_.size(), [&](int i) {
+        const wi_connections& connections = out2wi_[i];
+
+        float_t& a_element = a_sample[i];
+
+        a_element = float_t(0);
+
+        for (auto connection : connections)  // 13.1%
+          a_element +=
+              W[connection.first] * in[sample][connection.second];  // 3.2%
+
+        a_element *= scale_factor_;
+        a_element += b[out2bias_[i]];
+      });
     }
 
-    size_t fan_in_size() const override {
-        return max_size(out2wi_);
-    }
+    this->forward_activation(*out_data[0], *out_data[1]);
+  }
 
-    size_t fan_out_size() const override {
-        return max_size(in2wo_);
-    }
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    const tensor_t& prev_out = *in_data[0];
+    const vec_t& W = (*in_data[1])[0];
+    vec_t& dW = (*in_grad[1])[0];
+    vec_t& db = (*in_grad[2])[0];
+    tensor_t& prev_delta = *in_grad[0];
+    tensor_t& curr_delta = *out_grad[0];
 
-    void connect_weight(cnn_size_t input_index, cnn_size_t output_index, cnn_size_t weight_index) {
-        weight2io_[weight_index].emplace_back(input_index, output_index);
-        out2wi_[output_index].emplace_back(weight_index, input_index);
-        in2wo_[input_index].emplace_back(weight_index, output_index);
-    }
+    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
-    void connect_bias(cnn_size_t bias_index, cnn_size_t output_index) {
-        out2bias_[output_index] = bias_index;
-        bias2out_[bias_index].push_back(output_index);
-    }
+    // @todo revise the parallelism strategy
+    for (cnn_size_t sample = 0, sample_count = prev_out.size();
+         sample < sample_count; ++sample) {
+      for_(parallelize_, 0, in2wo_.size(), [&](const blocked_range& r) {
+        for (int i = r.begin(); i != r.end(); i++) {
+          const wo_connections& connections = in2wo_[i];
+          float_t delta = float_t(0);
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        const tensor_t& in  = *in_data[0];
-        const vec_t&    W   = (*in_data[1])[0];
-        const vec_t&    b   = (*in_data[2])[0];
-        tensor_t&       a   = *out_data[1];
+          for (auto connection : connections)
+            delta += W[connection.first] *
+                     curr_delta[sample][connection.second];  // 40.6%
 
-        // @todo revise the parallelism strategy
-        for (cnn_size_t sample = 0, sample_count = in.size(); sample < sample_count; ++sample) {
-            vec_t& a_sample = a[sample];
-
-            for_i(parallelize_, out2wi_.size(), [&](int i) {
-                const wi_connections& connections = out2wi_[i];
-
-                float_t& a_element = a_sample[i];
-
-                a_element = float_t(0);
-
-                for (auto connection : connections)// 13.1%
-                    a_element += W[connection.first] * in[sample][connection.second]; // 3.2%
-
-                a_element *= scale_factor_;
-                a_element += b[out2bias_[i]];
-            });
+          prev_delta[sample][i] = delta * scale_factor_;  // 2.1%
         }
+      });
 
-        this->forward_activation(*out_data[0], *out_data[1]);
-    }
+      for_(parallelize_, 0, weight2io_.size(), [&](const blocked_range& r) {
+        for (int i = r.begin(); i < r.end(); i++) {
+          const io_connections& connections = weight2io_[i];
+          float_t diff = float_t(0);
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        const tensor_t& prev_out    = *in_data[0];
-        const vec_t&    W           = (*in_data[1])[0];
-        vec_t&          dW          = (*in_grad[1])[0];
-        vec_t&          db          = (*in_grad[2])[0];
-        tensor_t&       prev_delta  = *in_grad[0];
-        tensor_t&       curr_delta  = *out_grad[0];
+          for (auto connection : connections)  // 11.9%
+            diff += prev_out[sample][connection.first] *
+                    curr_delta[sample][connection.second];
 
-        this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        // @todo revise the parallelism strategy
-        for (cnn_size_t sample = 0, sample_count = prev_out.size(); sample < sample_count; ++sample) {
-            for_(parallelize_, 0, in2wo_.size(), [&](const blocked_range& r) {
-                for (int i = r.begin(); i != r.end(); i++) {
-                    const wo_connections& connections = in2wo_[i];
-                    float_t delta = float_t(0);
-
-                    for (auto connection : connections)
-                        delta += W[connection.first] * curr_delta[sample][connection.second]; // 40.6%
-
-                    prev_delta[sample][i] = delta * scale_factor_; // 2.1%
-                }
-            });
-
-            for_(parallelize_, 0, weight2io_.size(), [&](const blocked_range& r) {
-                for (int i = r.begin(); i < r.end(); i++) {
-                    const io_connections& connections = weight2io_[i];
-                    float_t diff = float_t(0);
-
-                    for (auto connection : connections) // 11.9%
-                        diff += prev_out[sample][connection.first] * curr_delta[sample][connection.second];
-
-                    dW[i] += diff * scale_factor_;
-                }
-            });
-
-            for (size_t i = 0; i < bias2out_.size(); i++) {
-                const std::vector<cnn_size_t>& outs = bias2out_[i];
-                float_t diff = float_t(0);
-
-                for (auto o : outs)
-                    diff += curr_delta[sample][o];
-
-                db[i] += diff;
-            }
+          dW[i] += diff * scale_factor_;
         }
-    }
+      });
 
-protected:
-    std::vector<io_connections> weight2io_; // weight_id -> [(in_id, out_id)]
-    std::vector<wi_connections> out2wi_; // out_id -> [(weight_id, in_id)]
-    std::vector<wo_connections> in2wo_; // in_id -> [(weight_id, out_id)]
-    std::vector<std::vector<cnn_size_t> > bias2out_;
-    std::vector<size_t> out2bias_;
-    float_t scale_factor_;
+      for (size_t i = 0; i < bias2out_.size(); i++) {
+        const std::vector<cnn_size_t>& outs = bias2out_[i];
+        float_t diff = float_t(0);
+
+        for (auto o : outs) diff += curr_delta[sample][o];
+
+        db[i] += diff;
+      }
+    }
+  }
+
+ protected:
+  std::vector<io_connections> weight2io_;  // weight_id -> [(in_id, out_id)]
+  std::vector<wi_connections> out2wi_;     // out_id -> [(weight_id, in_id)]
+  std::vector<wo_connections> in2wo_;      // in_id -> [(weight_id, out_id)]
+  std::vector<std::vector<cnn_size_t> > bias2out_;
+  std::vector<size_t> out2bias_;
+  float_t scale_factor_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/partial_connected_layer.h
+++ b/tiny_dnn/layers/partial_connected_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/layers/power_layer.h
+++ b/tiny_dnn/layers/power_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -4,20 +4,20 @@
 
 #pragma once
 
-#include <vector>
-#include <string>
 #include <algorithm>
+#include <string>
+#include <vector>
 
-#include "tiny_dnn/core/backend_tiny.h"
-#include "tiny_dnn/core/backend_nnp.h"
 #include "tiny_dnn/core/backend_dnn.h"
+#include "tiny_dnn/core/backend_nnp.h"
+#include "tiny_dnn/core/backend_tiny.h"
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/backend_avx.h"
 #endif
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 using namespace tiny_dnn::core;
 
@@ -28,459 +28,452 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class quantized_convolutional_layer : public feedforward_layer<Activation> {
  public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width     [in] input image width
-    * @param in_height    [in] input image height
-    * @param window_size  [in] window(kernel) size of convolution
-    * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels [in] output image channels
-    * @param padding      [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_convolutional_layer(cnn_size_t     in_width,
-                                  cnn_size_t     in_height,
-                                  cnn_size_t     window_size,
-                                  cnn_size_t     in_channels,
-                                  cnn_size_t     out_channels,
-                                  padding        pad_type = padding::valid,
-                                  bool           has_bias = true,
-                                  cnn_size_t     w_stride = 1,
-                                  cnn_size_t     h_stride = 1,
-                                  backend_t      backend_type = backend_t::tiny_dnn,
-                                  backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            conv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_size, window_size,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride);
-            init_backend(backend_type);
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width     [in] input image width
+  * @param in_height    [in] input image height
+  * @param window_size  [in] window(kernel) size of convolution
+  * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels [in] output image channels
+  * @param padding      [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  quantized_convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                cnn_size_t window_size, cnn_size_t in_channels,
+                                cnn_size_t out_channels,
+                                padding pad_type = padding::valid,
+                                bool has_bias = true, cnn_size_t w_stride = 1,
+                                cnn_size_t h_stride = 1,
+                                backend_t backend_type = backend_t::tiny_dnn,
+                                backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    conv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                    window_size, out_channels, pad_type, has_bias, w_stride,
+                    h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width      [in] input image width
+  * @param in_height     [in] input image height
+  * @param window_width  [in] window_width(kernel) size of convolution
+  * @param window_height [in] window_height(kernel) size of convolution
+  * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels  [in] output image channels
+  * @param padding       [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_width + 1) * (in-height - window_height + 1) *
+  *out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  quantized_convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                cnn_size_t window_width,
+                                cnn_size_t window_height,
+                                cnn_size_t in_channels, cnn_size_t out_channels,
+                                padding pad_type = padding::valid,
+                                bool has_bias = true, cnn_size_t w_stride = 1,
+                                cnn_size_t h_stride = 1,
+                                backend_t backend_type = backend_t::tiny_dnn,
+                                backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                    window_height, out_channels, pad_type, has_bias, w_stride,
+                    h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_size      [in] window(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  quantized_convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                cnn_size_t window_size, cnn_size_t in_channels,
+                                cnn_size_t out_channels,
+                                const connection_table& connection_table,
+                                padding pad_type = padding::valid,
+                                bool has_bias = true, cnn_size_t w_stride = 1,
+                                cnn_size_t h_stride = 1,
+                                backend_t backend_type = backend_t::tiny_dnn,
+                                backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    conv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                    window_size, out_channels, pad_type, has_bias, w_stride,
+                    h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing convolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_width     [in] window_width(kernel) size of convolution
+  * @param window_height    [in] window_height(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  quantized_convolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                cnn_size_t window_width,
+                                cnn_size_t window_height,
+                                cnn_size_t in_channels, cnn_size_t out_channels,
+                                const connection_table& connection_table,
+                                padding pad_type = padding::valid,
+                                bool has_bias = true, cnn_size_t w_stride = 1,
+                                cnn_size_t h_stride = 1,
+                                backend_t backend_type = backend_t::tiny_dnn,
+                                backend_params b_params = backend_params())
+      : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
+    conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                    window_height, out_channels, pad_type, has_bias, w_stride,
+                    h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  // move constructor
+  quantized_convolutional_layer(
+      quantized_convolutional_layer&& other)  // NOLINT
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        cws_(std::move(other.cws_)) {
+    init_backend(std::move(Base::get_backend_type()));
+  }
+
+  ///< number of incoming connections for each output unit
+  size_t fan_in_size() const override {
+    return params_.weight.width_ * params_.weight.height_ * params_.in.depth_;
+  }
+
+  ///< number of outgoing connections for each input unit
+  size_t fan_out_size() const override {
+    return (params_.weight.width_ / params_.w_stride) *
+           (params_.weight.height_ / params_.h_stride) * params_.out.depth_;
+  }
+
+  /**
+   * @param in_data      input vectors of this layer (data, weight, bias)
+   * @param out_data     output vectors
+   **/
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) {
+    // launch convolutional kernel
+    if (in_data.size() == 3) {
+      Base::backend_->conv2d_q(in_data, out_data);
+
+      // activations
+      this->forward_activation(*out_data[0], *out_data[1]);
+    } else if (in_data.size() == 6) {
+      Base::backend_->conv2d_eq(in_data, out_data);
     }
+  }
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width      [in] input image width
-    * @param in_height     [in] input image height
-    * @param window_width  [in] window_width(kernel) size of convolution
-    * @param window_height [in] window_height(kernel) size of convolution
-    * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels  [in] output image channels
-    * @param padding       [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_width + 1) * (in-height - window_height + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_convolutional_layer(cnn_size_t     in_width,
-                                  cnn_size_t     in_height,
-                                  cnn_size_t     window_width,
-                                  cnn_size_t     window_height,
-                                  cnn_size_t     in_channels,
-                                  cnn_size_t     out_channels,
-                                  padding        pad_type = padding::valid,
-                                  bool           has_bias = true,
-                                  cnn_size_t     w_stride = 1,
-                                  cnn_size_t     h_stride = 1,
-                                  backend_t      backend_type = backend_t::tiny_dnn,
-                                  backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            conv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_width, window_height,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride);
-            init_backend(backend_type);
+  /**
+   * return delta of previous layer (delta=\frac{dE}{da}, a=wx in
+   *fully-connected layer)
+   * @param in_data      input vectors (same vectors as forward_propagation)
+   * @param out_data     output vectors (same vectors as forward_propagation)
+   * @param out_grad     gradient of output vectors (i-th vector correspond with
+   *out_data[i])
+   * @param in_grad      gradient of input vectors (i-th vector correspond with
+   *in_data[i])
+   **/
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) {
+    Base::backend_->conv2d_q(in_data, out_data, out_grad, in_grad);
+  }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias) {
+      return {params_.in, params_.weight,
+              index3d<cnn_size_t>(1, 1, params_.out.depth_)};
+    } else {
+      return {params_.in, params_.weight};
     }
+  }
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_size      [in] window(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_convolutional_layer(cnn_size_t              in_width,
-                                  cnn_size_t              in_height,
-                                  cnn_size_t              window_size,
-                                  cnn_size_t              in_channels,
-                                  cnn_size_t              out_channels,
-                                  const connection_table& connection_table,
-                                  padding                 pad_type = padding::valid,
-                                  bool                    has_bias = true,
-                                  cnn_size_t              w_stride = 1,
-                                  cnn_size_t              h_stride = 1,
-                                  backend_t      backend_type = backend_t::tiny_dnn,
-                                  backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            conv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_size, window_size,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride,
-                            connection_table);
-            init_backend(backend_type);
-    }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {params_.out, params_.out};
+  }
 
-    /**
-    * constructing convolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_width     [in] window_width(kernel) size of convolution
-    * @param window_height    [in] window_height(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_convolutional_layer(cnn_size_t              in_width,
-                                  cnn_size_t              in_height,
-                                  cnn_size_t              window_width,
-                                  cnn_size_t              window_height,
-                                  cnn_size_t              in_channels,
-                                  cnn_size_t              out_channels,
-                                  const connection_table& connection_table,
-                                  padding                 pad_type = padding::valid,
-                                  bool                    has_bias = true,
-                                  cnn_size_t              w_stride = 1,
-                                  cnn_size_t              h_stride = 1,
-                                  backend_t      backend_type = backend_t::tiny_dnn,
-                                  backend_params b_params = backend_params())
-        : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
-            conv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_width, window_height,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride,
-                            connection_table);
-            init_backend(backend_type);
-    }
+  std::string layer_type() const override { return "q_conv"; }
 
-    // move constructor
-    quantized_convolutional_layer(quantized_convolutional_layer&& other)  // NOLINT
-            : Base(std::move(other))
-            , params_(std::move(other.params_))
-            , cws_(std::move(other.cws_)) {
-        init_backend(std::move(Base::get_backend_type()));
-    }
+  image<> weight_to_image() const {
+    image<> img;
+    const cnn_size_t border_width = 1;
+    const auto pitch = params_.weight.width_ + border_width;
+    const auto width = params_.out.depth_ * pitch + border_width;
+    const auto height = params_.in.depth_ * pitch + border_width;
+    const image<>::intensity_t bg_color = 255;
+    const vec_t& W = *this->get_weights()[0];
 
-    ///< number of incoming connections for each output unit
-    size_t fan_in_size() const override {
-        return params_.weight.width_  *
-               params_.weight.height_ * params_.in.depth_;
-    }
+    img.resize(width, height);
+    img.fill(bg_color);
 
-    ///< number of outgoing connections for each input unit
-    size_t fan_out_size() const override  {
-        return (params_.weight.width_  / params_.w_stride)  *
-               (params_.weight.height_ / params_.h_stride) *
-                params_.out.depth_;
-    }
+    auto minmax = std::minmax_element(W.begin(), W.end());
 
-    /**
-     * @param in_data      input vectors of this layer (data, weight, bias)
-     * @param out_data     output vectors
-     **/
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) {
-        // launch convolutional kernel
-        if (in_data.size() == 3) {
-            Base::backend_->conv2d_q(in_data, out_data);
+    for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
+      for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
+        if (!params_.tbl.is_connected(c, r)) continue;
 
-            // activations
-            this->forward_activation(*out_data[0], *out_data[1]);
-        } else if (in_data.size() == 6) {
-            Base::backend_->conv2d_eq(in_data, out_data);
+        const auto top = r * pitch + border_width;
+        const auto left = c * pitch + border_width;
+
+        cnn_size_t idx = 0;
+
+        for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
+          for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
+            idx = c * params_.in.depth_ + r;
+            idx = params_.weight.get_index(x, y, idx);
+            const float_t w = W[idx];
+
+            img.at(left + x, top + y) = static_cast<image<>::intensity_t>(
+                rescale(w, *minmax.first, *minmax.second, 0, 255));
+          }
         }
-    }
-
-    /**
-     * return delta of previous layer (delta=\frac{dE}{da}, a=wx in fully-connected layer)
-     * @param in_data      input vectors (same vectors as forward_propagation)
-     * @param out_data     output vectors (same vectors as forward_propagation)
-     * @param out_grad     gradient of output vectors (i-th vector correspond with out_data[i])
-     * @param in_grad      gradient of input vectors (i-th vector correspond with in_data[i])
-     **/
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) {
-        Base::backend_->conv2d_q(in_data, out_data, out_grad, in_grad);
       }
-
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias) {
-            return { params_.in, params_.weight,
-                     index3d<cnn_size_t>(1, 1, params_.out.depth_) };
-        } else {
-            return { params_.in, params_.weight };
-        }
     }
-
-    std::vector<index3d<cnn_size_t>>
-    out_shape() const override { return { params_.out, params_.out }; }
-
-    std::string layer_type() const override { return "q_conv"; }
-
-    image<> weight_to_image() const {
-        image<> img;
-        const cnn_size_t border_width = 1;
-        const auto pitch = params_.weight.width_ + border_width;
-        const auto width = params_.out.depth_ * pitch + border_width;
-        const auto height = params_.in.depth_ * pitch + border_width;
-        const image<>::intensity_t bg_color = 255;
-        const vec_t& W = *this->get_weights()[0];
-
-        img.resize(width, height);
-        img.fill(bg_color);
-
-        auto minmax = std::minmax_element(W.begin(), W.end());
-
-        for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
-            for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
-                if (!params_.tbl.is_connected(c, r)) continue;
-
-                const auto top  = r * pitch + border_width;
-                const auto left = c * pitch + border_width;
-
-                cnn_size_t idx = 0;
-
-                for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
-                    for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
-                        idx = c * params_.in.depth_ + r;
-                        idx = params_.weight.get_index(x, y, idx);
-                        const float_t w = W[idx];
-
-                        img.at(left + x, top + y)
-                            = static_cast<image<>::intensity_t>(
-                                rescale(w, *minmax.first,
-                                        *minmax.second, 0, 255));
-                    }
-                }
-            }
-        }
-        return img;
-    }
+    return img;
+  }
 
  private:
-    void conv_set_params(const shape3d& in,
-                         cnn_size_t     w_width,
-                         cnn_size_t     w_height,
-                         cnn_size_t     outc,
-                         padding        ptype,
-                         bool           has_bias,
-                         cnn_size_t     w_stride,
-                         cnn_size_t     h_stride,
-                         const connection_table& tbl = connection_table()) {
-        params_.in = in;
-        params_.in_padded = shape3d(in_length(in.width_, w_width, ptype),
-                                    in_length(in.height_, w_height, ptype),
-                                    in.depth_);
-        params_.out =
-            shape3d(conv_out_length(in.width_, w_width, w_stride, ptype),
-                    conv_out_length(in.height_, w_height, h_stride, ptype),
-                    outc);
-        params_.weight   = shape3d(w_width, w_height, in.depth_ * outc);
-        params_.has_bias = has_bias;
-        params_.pad_type = ptype;
-        params_.w_stride = w_stride;
-        params_.h_stride = h_stride;
-        params_.tbl      = tbl;
+  void conv_set_params(const shape3d& in, cnn_size_t w_width,
+                       cnn_size_t w_height, cnn_size_t outc, padding ptype,
+                       bool has_bias, cnn_size_t w_stride, cnn_size_t h_stride,
+                       const connection_table& tbl = connection_table()) {
+    params_.in = in;
+    params_.in_padded =
+        shape3d(in_length(in.width_, w_width, ptype),
+                in_length(in.height_, w_height, ptype), in.depth_);
+    params_.out =
+        shape3d(conv_out_length(in.width_, w_width, w_stride, ptype),
+                conv_out_length(in.height_, w_height, h_stride, ptype), outc);
+    params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
+    params_.has_bias = has_bias;
+    params_.pad_type = ptype;
+    params_.w_stride = w_stride;
+    params_.h_stride = h_stride;
+    params_.tbl = tbl;
+  }
+
+  void init() {
+    if (params_.pad_type == padding::same) {
+      cws_.prev_out_buf_.resize(1, vec_t(params_.in_padded.size(), float_t(0)));
+      cws_.prev_delta_padded_.resize(
+          1, vec_t(params_.in_padded.size(), float_t(0)));
+    } else {
+      cws_.prev_out_buf_.clear();
+    }
+  }
+
+  cnn_size_t in_length(cnn_size_t in_length, cnn_size_t window_size,
+                       padding pad_type) const {
+    return pad_type == padding::same ? (in_length + window_size - 1)
+                                     : in_length;
+  }
+
+  static cnn_size_t conv_out_length(cnn_size_t in_length,
+                                    cnn_size_t window_size, cnn_size_t stride,
+                                    padding pad_type) {
+    float_t tmp;
+    if (pad_type == padding::same) {
+      tmp = static_cast<float_t>(in_length) / stride;
+    } else if (pad_type == padding::valid) {
+      tmp = static_cast<float_t>(in_length - window_size + 1) / stride;
+    } else {
+      throw nn_error("Not recognized pad_type.");
+    }
+    return static_cast<cnn_size_t>(ceil(tmp));
+  }
+
+  static cnn_size_t conv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                                 cnn_size_t window_size, cnn_size_t w_stride,
+                                 cnn_size_t h_stride, padding pad_type) {
+    return conv_out_length(in_width, window_size, w_stride, pad_type) *
+           conv_out_length(in_height, window_size, h_stride, pad_type);
+  }
+
+  cnn_size_t conv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                          cnn_size_t window_width, cnn_size_t window_height,
+                          cnn_size_t w_stride, cnn_size_t h_stride,
+                          padding pad_type) const {
+    return conv_out_length(in_width, window_width, w_stride, pad_type) *
+           conv_out_length(in_height, window_height, h_stride, pad_type);
+  }
+
+  void copy_and_pad_input(const tensor_t& in) {
+    conv_layer_worker_specific_storage& cws = cws_;
+
+    cnn_size_t sample_count = in.size();
+
+    cws.prev_out_padded_.resize(sample_count);
+
+    if (params_.pad_type == padding::same) {
+      cws.prev_out_buf_.resize(sample_count, cws.prev_out_buf_[0]);
+      cws.prev_delta_padded_.resize(sample_count, cws.prev_delta_padded_[0]);
     }
 
-    void init() {
-        if (params_.pad_type == padding::same) {
-            cws_.prev_out_buf_.resize(1, vec_t(params_.in_padded.size(), float_t(0)));
-            cws_.prev_delta_padded_.resize(1, vec_t(params_.in_padded.size(), float_t(0)));
+    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+      if (params_.pad_type == padding::valid) {
+        cws.prev_out_padded_[sample] = &(in[sample]);
+      } else {
+        vec_t* dst = &cws.prev_out_buf_[sample];
+
+        // make padded version in order to avoid corner-case in fprop/bprop
+        for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+          float_t* pimg = &(*dst)[params_.in_padded.get_index(
+              params_.weight.width_ / 2, params_.weight.height_ / 2, c)];
+          const float_t* pin = &in[sample][params_.in.get_index(0, 0, c)];
+
+          for (cnn_size_t y = 0; y < params_.in.height_; y++,
+                          pin += params_.in.width_,
+                          pimg += params_.in_padded.width_) {
+            std::copy(pin, pin + params_.in.width_, pimg);
+          }
         }
-        else {
-            cws_.prev_out_buf_.clear();
+
+        cws.prev_out_padded_[sample] = &(cws.prev_out_buf_[sample]);
+      }
+    }
+  }
+
+  void copy_and_unpad_delta(const tensor_t& delta, tensor_t& delta_unpadded) {
+    if (params_.pad_type == padding::valid) {
+      delta_unpadded = delta;
+    } else {
+      for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
+        cnn_size_t idx = 0;
+        const vec_t& src = delta[sample];
+        vec_t& dst = delta_unpadded[sample];
+
+        for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+          float_t* pdst = &dst[params_.in.get_index(0, 0, c)];
+          idx = params_.in_padded.get_index(params_.weight.width_ / 2,
+                                            params_.weight.height_ / 2, c);
+          const float_t* pin = &src[idx];
+
+          for (cnn_size_t y = 0; y < params_.in.height_; y++) {
+            std::copy(pin, pin + params_.in.width_, pdst);
+            pdst += params_.in.width_;
+            pin += params_.in_padded.width_;
+          }
         }
+      }
     }
+  }
 
-    cnn_size_t in_length(cnn_size_t in_length,
-                         cnn_size_t window_size, padding pad_type) const {
-        return pad_type == padding::same ?
-               (in_length + window_size - 1) : in_length;
-    }
+  void init_backend(const backend_t backend_type) {
+    std::shared_ptr<core::backend> backend = nullptr;
 
-    static cnn_size_t conv_out_length(cnn_size_t in_length,
-                                      cnn_size_t window_size,
-                                      cnn_size_t stride, padding pad_type) {
-        float_t tmp;
-        if (pad_type == padding::same) {
-            tmp = static_cast<float_t>(in_length) / stride;
-        } else if (pad_type == padding::valid) {
-            tmp = static_cast<float_t>(in_length - window_size + 1) / stride;
-        } else {
-            throw nn_error("Not recognized pad_type.");
-        }
-        return static_cast<cnn_size_t>(ceil(tmp));
-    }
-
-    static cnn_size_t conv_out_dim(cnn_size_t in_width,
-                                   cnn_size_t in_height,
-                                   cnn_size_t window_size,
-                                   cnn_size_t w_stride,
-                                   cnn_size_t h_stride, padding pad_type) {
-        return conv_out_length(in_width, window_size, w_stride, pad_type) *
-               conv_out_length(in_height, window_size, h_stride, pad_type);
-    }
-
-    cnn_size_t conv_out_dim(cnn_size_t in_width,
-                            cnn_size_t in_height,
-                            cnn_size_t window_width,
-                            cnn_size_t window_height,
-                            cnn_size_t w_stride,
-                            cnn_size_t h_stride, padding pad_type) const {
-        return conv_out_length(in_width, window_width, w_stride, pad_type) *
-               conv_out_length(in_height, window_height, h_stride, pad_type);
-    }
-
-    void copy_and_pad_input(const tensor_t& in) {
-        conv_layer_worker_specific_storage& cws = cws_;
-
-        cnn_size_t sample_count = in.size();
-
-        cws.prev_out_padded_.resize(sample_count);
-
-        if (params_.pad_type == padding::same) {
-            cws.prev_out_buf_.resize(sample_count, cws.prev_out_buf_[0]);
-            cws.prev_delta_padded_.resize(sample_count, cws.prev_delta_padded_[0]);
-        }
-
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            if (params_.pad_type == padding::valid) {
-                cws.prev_out_padded_[sample] = &(in[sample]);
-            }
-            else {
-                vec_t* dst = &cws.prev_out_buf_[sample];
-
-                // make padded version in order to avoid corner-case in fprop/bprop
-                for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                    float_t *pimg = &(*dst)[params_.in_padded.get_index(params_.weight.width_ / 2, params_.weight.height_ / 2, c)];
-                    const float_t *pin = &in[sample][params_.in.get_index(0, 0, c)];
-
-                    for (cnn_size_t y = 0; y < params_.in.height_; y++, pin += params_.in.width_, pimg += params_.in_padded.width_) {
-                        std::copy(pin, pin + params_.in.width_, pimg);
-                    }
-                }
-
-                cws.prev_out_padded_[sample] = &(cws.prev_out_buf_[sample]);
-            }
-        }
-    }
-
-    void copy_and_unpad_delta(const tensor_t& delta, tensor_t& delta_unpadded) {
-        if (params_.pad_type == padding::valid) {
-            delta_unpadded = delta;
-        }
-        else {
-            for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
-                cnn_size_t idx = 0;
-                const vec_t& src = delta[sample];
-                vec_t& dst = delta_unpadded[sample];
-
-                for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                    float_t *pdst = &dst[params_.in.get_index(0, 0, c)];
-                    idx = params_.in_padded.get_index(params_.weight.width_ / 2,
-                        params_.weight.height_ / 2, c);
-                    const float_t *pin = &src[idx];
-
-                    for (cnn_size_t y = 0; y < params_.in.height_; y++) {
-                        std::copy(pin, pin + params_.in.width_, pdst);
-                        pdst += params_.in.width_;
-                        pin += params_.in_padded.width_;
-                    }
-                }
-            }
-        }
-    }
-
-    void init_backend(const backend_t backend_type) {
-        std::shared_ptr<core::backend> backend = nullptr;
-
-        // allocate new backend
-        if (backend_type == backend_t::tiny_dnn) {
-            backend = std::make_shared<core::tiny_backend>(&params_,
-                [this](const tensor_t& in) {
-                    return copy_and_pad_input(in);
-                },
-                [this](const tensor_t& delta, tensor_t& dst) {
-                    return copy_and_unpad_delta(delta, dst);
-                },
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &cws_);
-        } else if (backend_type == backend_t::nnpack) {
-            backend = std::make_shared<core::nnp_backend>(&params_,
-                [this](const tensor_t& in) {
-                    return copy_and_pad_input(in);
-                },
-                &cws_);
-        } else if (backend_type == backend_t::libdnn) {
-            backend = std::make_shared<core::dnn_backend>();
+    // allocate new backend
+    if (backend_type == backend_t::tiny_dnn) {
+      backend = std::make_shared<core::tiny_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_pad_input(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_unpad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &cws_);
+    } else if (backend_type == backend_t::nnpack) {
+      backend = std::make_shared<core::nnp_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_pad_input(in); }, &cws_);
+    } else if (backend_type == backend_t::libdnn) {
+      backend = std::make_shared<core::dnn_backend>();
 #ifdef CNN_USE_AVX
-        } else if (backend_type == backend_t::avx) {
-            backend = std::make_shared<core::avx_backend>(&params_,
-                [this](const tensor_t& in) {
-                    return copy_and_pad_input(in);
-                },
-                [this](const tensor_t& delta, tensor_t& dst) {
-                    return copy_and_unpad_delta(delta, dst);
-                },
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &cws_);
+    } else if (backend_type == backend_t::avx) {
+      backend = std::make_shared<core::avx_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_pad_input(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_unpad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &cws_);
 #endif
-        } else {
-            throw nn_error("Not supported backend type.");
-        }
-
-        if (backend) {
-            Base::set_backend(backend);
-            Base::backend_->set_layer(this);
-        } else {
-            throw nn_error("Could not allocate the backend.");
-        }
+    } else {
+      throw nn_error("Not supported backend type.");
     }
 
-    /* The convolution parameters */
-    conv_params params_;
+    if (backend) {
+      Base::set_backend(backend);
+      Base::backend_->set_layer(this);
+    } else {
+      throw nn_error("Could not allocate the backend.");
+    }
+  }
 
-    /* The type of backend */
-    //backend_t backend_type_;
+  /* The convolution parameters */
+  conv_params params_;
 
-    /* Workers buffers */
-    conv_layer_worker_specific_storage cws_;
+  /* The type of backend */
+  // backend_t backend_type_;
+
+  /* Workers buffers */
+  conv_layer_worker_specific_storage cws_;
 };
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/layers/quantized_deconvolutional_layer.h
+++ b/tiny_dnn/layers/quantized_deconvolutional_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <deque>

--- a/tiny_dnn/layers/quantized_deconvolutional_layer.h
+++ b/tiny_dnn/layers/quantized_deconvolutional_layer.h
@@ -4,20 +4,20 @@
 
 #pragma once
 
+#include <algorithm>
 #include <deque>
 #include <string>
-#include <algorithm>
 
-#include "tiny_dnn/core/backend_tiny.h"
-#include "tiny_dnn/core/backend_nnp.h"
 #include "tiny_dnn/core/backend_dnn.h"
+#include "tiny_dnn/core/backend_nnp.h"
+#include "tiny_dnn/core/backend_tiny.h"
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/backend_avx.h"
 #endif
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/util.h"
 
 using namespace tiny_dnn::core;
 
@@ -28,456 +28,453 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template<typename Activation = activation::identity>
+template <typename Activation = activation::identity>
 class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
-public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width     [in] input image width
-    * @param in_height    [in] input image height
-    * @param window_size  [in] window(kernel) size of convolution
-    * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels [in] output image channels
-    * @param padding      [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_deconvolutional_layer(cnn_size_t     in_width,
-                                    cnn_size_t     in_height,
-                                    cnn_size_t     window_size,
-                                    cnn_size_t     in_channels,
-                                    cnn_size_t     out_channels,
-                                    padding        pad_type = padding::valid,
-                                    bool           has_bias = true,
-                                    cnn_size_t     w_stride = 1,
-                                    cnn_size_t     h_stride = 1,
-                                    backend_t      backend_type = backend_t::tiny_dnn,
-                                    backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_size, window_size,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride);
-            init_backend(backend_type);
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width     [in] input image width
+  * @param in_height    [in] input image height
+  * @param window_size  [in] window(kernel) size of convolution
+  * @param in_channels  [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels [in] output image channels
+  * @param padding      [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  quantized_deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                  cnn_size_t window_size,
+                                  cnn_size_t in_channels,
+                                  cnn_size_t out_channels,
+                                  padding pad_type = padding::valid,
+                                  bool has_bias = true, cnn_size_t w_stride = 1,
+                                  cnn_size_t h_stride = 1,
+                                  backend_t backend_type = backend_t::tiny_dnn,
+                                  backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                      window_size, out_channels, pad_type, has_bias, w_stride,
+                      h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width      [in] input image width
+  * @param in_height     [in] input image height
+  * @param window_width  [in] window_width(kernel) size of convolution
+  * @param window_height [in] window_height(kernel) size of convolution
+  * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels  [in] output image channels
+  * @param padding       [in] rounding strategy
+  *                          valid: use valid pixels of input only. output-size
+  *= (in-width - window_width + 1) * (in-height - window_height + 1) *
+  *out_channels
+  *                          same: add zero-padding to keep same width/height.
+  *output-size = in-width * in-height * out_channels
+  * @param has_bias     [in] whether to add a bias vector to the filter outputs
+  * @param w_stride     [in] specify the horizontal interval at which to apply
+  *the filters to the input
+  * @param h_stride     [in] specify the vertical interval at which to apply the
+  *filters to the input
+  **/
+  quantized_deconvolutional_layer(
+      cnn_size_t in_width, cnn_size_t in_height, cnn_size_t window_width,
+      cnn_size_t window_height, cnn_size_t in_channels, cnn_size_t out_channels,
+      padding pad_type = padding::valid, bool has_bias = true,
+      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+      backend_t backend_type = backend_t::tiny_dnn,
+      backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                      window_height, out_channels, pad_type, has_bias, w_stride,
+                      h_stride);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_size      [in] window(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  quantized_deconvolutional_layer(cnn_size_t in_width, cnn_size_t in_height,
+                                  cnn_size_t window_size,
+                                  cnn_size_t in_channels,
+                                  cnn_size_t out_channels,
+                                  const connection_table& connection_table,
+                                  padding pad_type = padding::valid,
+                                  bool has_bias = true, cnn_size_t w_stride = 1,
+                                  cnn_size_t h_stride = 1,
+                                  backend_t backend_type = backend_t::tiny_dnn,
+                                  backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
+                      window_size, out_channels, pad_type, has_bias, w_stride,
+                      h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  /**
+  * constructing deconvolutional layer
+  *
+  * @param in_width         [in] input image width
+  * @param in_height        [in] input image height
+  * @param window_width     [in] window_width(kernel) size of convolution
+  * @param window_height    [in] window_height(kernel) size of convolution
+  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
+  * @param out_channels     [in] output image channels
+  * @param connection_table [in] definition of connections between in-channels
+  *and out-channels
+  * @param pad_type         [in] rounding strategy
+  *                               valid: use valid pixels of input only.
+  *output-size = (in-width - window_size + 1) * (in-height - window_size + 1) *
+  *out_channels
+  *                               same: add zero-padding to keep same
+  *width/height. output-size = in-width * in-height * out_channels
+  * @param has_bias         [in] whether to add a bias vector to the filter
+  *outputs
+  * @param w_stride         [in] specify the horizontal interval at which to
+  *apply the filters to the input
+  * @param h_stride         [in] specify the vertical interval at which to apply
+  *the filters to the input
+  **/
+  quantized_deconvolutional_layer(
+      cnn_size_t in_width, cnn_size_t in_height, cnn_size_t window_width,
+      cnn_size_t window_height, cnn_size_t in_channels, cnn_size_t out_channels,
+      const connection_table& connection_table,
+      padding pad_type = padding::valid, bool has_bias = true,
+      cnn_size_t w_stride = 1, cnn_size_t h_stride = 1,
+      backend_t backend_type = backend_t::tiny_dnn,
+      backend_params b_params = backend_params())
+      : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
+    deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
+                      window_height, out_channels, pad_type, has_bias, w_stride,
+                      h_stride, connection_table);
+    init_backend(backend_type);
+  }
+
+  // move constructor
+  quantized_deconvolutional_layer(quantized_deconvolutional_layer&& other)
+      : Base(std::move(other)),
+        params_(std::move(other.params_)),
+        backend_type_(std::move(other.backend_type_)),
+        deconv_layer_worker_storage_(
+            std::move(other.deconv_layer_worker_storage_)) {
+    init_backend(std::move(Base::get_backend_type()));
+  }
+
+  ///< number of incoming connections for each output unit
+  virtual size_t fan_in_size() const override {
+    return params_.weight.width_ * params_.weight.height_ * params_.in.depth_;
+  }
+
+  ///< number of outgoing connections for each input unit
+  virtual size_t fan_out_size() const override {
+    return (params_.weight.width_ * params_.w_stride) *
+           (params_.weight.height_ * params_.h_stride) * params_.out.depth_;
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    // launch deconvolutional kernel
+    if (in_data.size() == 3) {
+      Base::backend_->deconv2d_q(in_data, out_data);
+
+      // activations
+      this->forward_activation(*out_data[0], *out_data[1]);
+    } else if (in_data.size() == 6) {
+      Base::backend_->deconv2d_eq(in_data, out_data);
     }
+  }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width      [in] input image width
-    * @param in_height     [in] input image height
-    * @param window_width  [in] window_width(kernel) size of convolution
-    * @param window_height [in] window_height(kernel) size of convolution
-    * @param in_channels   [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels  [in] output image channels
-    * @param padding       [in] rounding strategy
-    *                          valid: use valid pixels of input only. output-size = (in-width - window_width + 1) * (in-height - window_height + 1) * out_channels
-    *                          same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias     [in] whether to add a bias vector to the filter outputs
-    * @param w_stride     [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride     [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_deconvolutional_layer(cnn_size_t     in_width,
-                                    cnn_size_t     in_height,
-                                    cnn_size_t     window_width,
-                                    cnn_size_t     window_height,
-                                    cnn_size_t     in_channels,
-                                    cnn_size_t     out_channels,
-                                    padding        pad_type = padding::valid,
-                                    bool           has_bias = true,
-                                    cnn_size_t     w_stride = 1,
-                                    cnn_size_t     h_stride = 1,
-                                    backend_t      backend_type = backend_t::tiny_dnn,
-                                    backend_params b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_width, window_height,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride);
-            init_backend(backend_type);
+  /**
+   * return delta of previous layer (delta=\frac{dE}{da}, a=wx in
+   *fully-connected layer)
+   * @param in_data      input vectors (same vectors as forward_propagation)
+   * @param out_data     output vectors (same vectors as forward_propagation)
+   * @param out_grad     gradient of output vectors (i-th vector correspond with
+   *out_data[i])
+   * @param in_grad      gradient of input vectors (i-th vector correspond with
+   *in_data[i])
+   **/
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    Base::backend_->deconv2d_q(in_data, out_data, out_grad, in_grad);
+  }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias) {
+      return {params_.in, params_.weight,
+              index3d<cnn_size_t>(1, 1, params_.out.depth_)};
+    } else {
+      return {params_.in, params_.weight};
     }
+  }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_size      [in] window(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_deconvolutional_layer(cnn_size_t              in_width,
-                                    cnn_size_t              in_height,
-                                    cnn_size_t              window_size,
-                                    cnn_size_t              in_channels,
-                                    cnn_size_t              out_channels,
-                                    const connection_table& connection_table,
-                                    padding                 pad_type = padding::valid,
-                                    bool                    has_bias = true,
-                                    cnn_size_t              w_stride = 1,
-                                    cnn_size_t              h_stride = 1,
-                                    backend_t               backend_type = backend_t::tiny_dnn,
-                                    backend_params          b_params = backend_params())
-        : Base(std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_size, window_size,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride,
-                            connection_table);
-            init_backend(backend_type);
-    }
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {params_.out_unpadded, params_.out_unpadded};
+  }
 
-    /**
-    * constructing deconvolutional layer
-    *
-    * @param in_width         [in] input image width
-    * @param in_height        [in] input image height
-    * @param window_width     [in] window_width(kernel) size of convolution
-    * @param window_height    [in] window_height(kernel) size of convolution
-    * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-    * @param out_channels     [in] output image channels
-    * @param connection_table [in] definition of connections between in-channels and out-channels
-    * @param pad_type         [in] rounding strategy
-    *                               valid: use valid pixels of input only. output-size = (in-width - window_size + 1) * (in-height - window_size + 1) * out_channels
-    *                               same: add zero-padding to keep same width/height. output-size = in-width * in-height * out_channels
-    * @param has_bias         [in] whether to add a bias vector to the filter outputs
-    * @param w_stride         [in] specify the horizontal interval at which to apply the filters to the input
-    * @param h_stride         [in] specify the vertical interval at which to apply the filters to the input
-    **/
-    quantized_deconvolutional_layer(cnn_size_t              in_width,
-                                    cnn_size_t              in_height,
-                                    cnn_size_t              window_width,
-                                    cnn_size_t              window_height,
-                                    cnn_size_t              in_channels,
-                                    cnn_size_t              out_channels,
-                                    const connection_table& connection_table,
-                                    padding                 pad_type = padding::valid,
-                                    bool                    has_bias = true,
-                                    cnn_size_t              w_stride = 1,
-                                    cnn_size_t              h_stride = 1,
-                                    backend_t               backend_type = backend_t::tiny_dnn,
-                                    backend_params          b_params = backend_params())
-        : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
-            deconv_set_params(shape3d(in_width, in_height, in_channels),
-                            window_width, window_height,
-                            out_channels, pad_type, has_bias,
-                            w_stride, h_stride,
-                            connection_table);
-            init_backend(backend_type);
-    }
+  std::string layer_type() const override { return "q_deconv"; }
 
-    // move constructor
-    quantized_deconvolutional_layer(quantized_deconvolutional_layer&& other)
-        : Base(std::move(other))
-        , params_(std::move(other.params_))
-        , backend_type_(std::move(other.backend_type_))
-        , deconv_layer_worker_storage_(std::move(other.deconv_layer_worker_storage_)) {
-            init_backend(std::move(Base::get_backend_type()));
-    }
+  image<> weightto_image() const {
+    image<> img;
+    const cnn_size_t border_width = 1;
+    const auto pitch = params_.weight.width_ + border_width;
+    const auto width = params_.out.depth_ * pitch + border_width;
+    const auto height = params_.in.depth_ * pitch + border_width;
+    const image<>::intensity_t bg_color = 255;
+    const vec_t& W = *this->get_weights()[0];
 
-    ///< number of incoming connections for each output unit
-    virtual size_t fan_in_size() const override {
-        return  params_.weight.width_ *
-                params_.weight.height_ *
-                params_.in.depth_;
-    }
+    img.resize(width, height);
+    img.fill(bg_color);
 
-    ///< number of outgoing connections for each input unit
-    virtual size_t fan_out_size() const override {
-        return  (params_.weight.width_ * params_.w_stride) *
-                (params_.weight.height_ * params_.h_stride) *
-                params_.out.depth_;
-    }
+    auto minmax = std::minmax_element(W.begin(), W.end());
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>&       out_data) override {
-        // launch deconvolutional kernel
-        if (in_data.size() == 3) {
-            Base::backend_->deconv2d_q(in_data, out_data);
+    for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
+      for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
+        if (!params_.tbl.is_connected(c, r)) continue;
 
-            // activations
-            this->forward_activation(*out_data[0], *out_data[1]);
-        } else if (in_data.size() == 6) {
-            Base::backend_->deconv2d_eq(in_data, out_data);
+        const auto top = r * pitch + border_width;
+        const auto left = c * pitch + border_width;
+
+        cnn_size_t idx = 0;
+
+        for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
+          for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
+            idx = params_.weight.get_index(x, y, c * params_.in.depth_ + r);
+            const float_t w = W[idx];
+
+            img.at(left + x, top + y) = static_cast<image<>::intensity_t>(
+                rescale(w, *minmax.first, *minmax.second, 0, 255));
+          }
         }
+      }
     }
+    return img;
+  }
 
-    /**
-     * return delta of previous layer (delta=\frac{dE}{da}, a=wx in fully-connected layer)
-     * @param in_data      input vectors (same vectors as forward_propagation)
-     * @param out_data     output vectors (same vectors as forward_propagation)
-     * @param out_grad     gradient of output vectors (i-th vector correspond with out_data[i])
-     * @param in_grad      gradient of input vectors (i-th vector correspond with in_data[i])
-     **/
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        Base::backend_->deconv2d_q(in_data, out_data, out_grad, in_grad);
-    }
+ private:
+  void init_backend(const backend_t backend_type) {
+    std::shared_ptr<core::backend> backend = nullptr;
 
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias) {
-            return { params_.in, params_.weight,
-                     index3d<cnn_size_t>(1, 1, params_.out.depth_) };
-        } else {
-            return { params_.in, params_.weight };
-        }
-    }
-
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return {params_.out_unpadded, params_.out_unpadded};
-    }
-
-    std::string layer_type() const override { return "q_deconv"; }
-
-    image<> weightto_image() const {
-        image<> img;
-        const cnn_size_t border_width = 1;
-        const auto pitch = params_.weight.width_ + border_width;
-        const auto width = params_.out.depth_ * pitch + border_width;
-        const auto height = params_.in.depth_ * pitch + border_width;
-        const image<>::intensity_t bg_color = 255;
-        const vec_t& W = *this->get_weights()[0];
-
-        img.resize(width, height);
-        img.fill(bg_color);
-
-        auto minmax = std::minmax_element(W.begin(), W.end());
-
-        for (cnn_size_t r = 0; r < params_.in.depth_; ++r) {
-            for (cnn_size_t c = 0; c < params_.out.depth_; ++c) {
-                if (!params_.tbl.is_connected(c, r)) continue;
-
-                const auto top = r * pitch + border_width;
-                const auto left = c * pitch + border_width;
-
-                cnn_size_t idx = 0;
-
-                for (cnn_size_t y = 0; y < params_.weight.height_; ++y) {
-                    for (cnn_size_t x = 0; x < params_.weight.width_; ++x) {
-                        idx = params_.weight.get_index(x, y, c * params_.in.depth_ + r);
-                        const float_t w = W[idx];
-
-                        img.at(left + x, top + y)
-                            = static_cast<image<>::intensity_t>(
-                                rescale(w, *minmax.first,
-                                        *minmax.second, 0, 255));
-                    }
-                }
-            }
-        }
-        return img;
-    }
-
-private:
-    void init_backend(const backend_t backend_type) {
-        std::shared_ptr<core::backend> backend = nullptr;
-
-        // allocate new backend
-        if (backend_type == backend_t::tiny_dnn) {
-            backend = std::make_shared<core::tiny_backend>(&params_,
-                [this](const tensor_t& in) {
-                    return copy_and_unpad_output(in);
-                },
-                [this](const tensor_t& delta, tensor_t& dst) {
-                    return copy_and_pad_delta(delta, dst);
-                },
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &deconv_layer_worker_storage_);
-        } else if (backend_type == backend_t::nnpack) {
-            backend = std::make_shared<core::nnp_backend>();
-        } else if (backend_type == backend_t::libdnn) {
-            backend = std::make_shared<core::dnn_backend>();
+    // allocate new backend
+    if (backend_type == backend_t::tiny_dnn) {
+      backend = std::make_shared<core::tiny_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_unpad_output(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_pad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &deconv_layer_worker_storage_);
+    } else if (backend_type == backend_t::nnpack) {
+      backend = std::make_shared<core::nnp_backend>();
+    } else if (backend_type == backend_t::libdnn) {
+      backend = std::make_shared<core::dnn_backend>();
 #ifdef CNN_USE_AVX
-        } else if (backend_type == backend_t::avx) {
-            backend = std::make_shared<core::avx_backend>(&params_,
-                [this](const tensor_t& in) {
-                    return copy_and_unpad_output(in);
-                },
-                [this](const tensor_t& delta, tensor_t& dst) {
-                    return copy_and_pad_delta(delta, dst);
-                },
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                    return Base::backward_activation(p_delta, out, c_delta);
-                },
-                &deconv_layer_worker_storage_);
+    } else if (backend_type == backend_t::avx) {
+      backend = std::make_shared<core::avx_backend>(
+          &params_,
+          [this](const tensor_t& in) { return copy_and_unpad_output(in); },
+          [this](const tensor_t& delta, tensor_t& dst) {
+            return copy_and_pad_delta(delta, dst);
+          },
+          [this](const tensor_t& p_delta, const tensor_t& out,
+                 tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          },
+          &deconv_layer_worker_storage_);
 #endif
-        } else {
-            throw nn_error("Not supported backend type.");
-        }
-
-        if (backend) {
-            Base::set_backend(backend);
-            Base::backend_->set_layer(this);
-        } else {
-            throw nn_error("Could not allocate the backend.");
-        }
+    } else {
+      throw nn_error("Not supported backend type.");
     }
 
-    void deconv_set_params(const shape3d& in,
-                         cnn_size_t     w_width,
-                         cnn_size_t     w_height,
-                         cnn_size_t     outc,
-                         padding        ptype,
-                         bool           has_bias,
-                         cnn_size_t     w_stride,
-                         cnn_size_t     h_stride,
+    if (backend) {
+      Base::set_backend(backend);
+      Base::backend_->set_layer(this);
+    } else {
+      throw nn_error("Could not allocate the backend.");
+    }
+  }
+
+  void deconv_set_params(const shape3d& in, cnn_size_t w_width,
+                         cnn_size_t w_height, cnn_size_t outc, padding ptype,
+                         bool has_bias, cnn_size_t w_stride,
+                         cnn_size_t h_stride,
                          const connection_table& tbl = connection_table()) {
-        params_.in = in;
-        params_.out =
-              shape3d(deconv_out_length(in.width_, w_width, w_stride),
-                      deconv_out_length(in.height_, w_height, h_stride),
-                      outc);
-        params_.out_unpadded =
-              shape3d(deconv_out_unpadded_length(in.width_, w_width, w_stride, ptype),
-                      deconv_out_unpadded_length(in.height_, w_height, h_stride, ptype),
-                      outc);
-        params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
-        params_.has_bias = has_bias;
-        params_.pad_type = ptype;
-        params_.w_stride = w_stride;
-        params_.h_stride = h_stride;
-        params_.tbl      = tbl;
+    params_.in = in;
+    params_.out =
+        shape3d(deconv_out_length(in.width_, w_width, w_stride),
+                deconv_out_length(in.height_, w_height, h_stride), outc);
+    params_.out_unpadded = shape3d(
+        deconv_out_unpadded_length(in.width_, w_width, w_stride, ptype),
+        deconv_out_unpadded_length(in.height_, w_height, h_stride, ptype),
+        outc);
+    params_.weight = shape3d(w_width, w_height, in.depth_ * outc);
+    params_.has_bias = has_bias;
+    params_.pad_type = ptype;
+    params_.w_stride = w_stride;
+    params_.h_stride = h_stride;
+    params_.tbl = tbl;
+  }
+
+  void init() {
+    deconv_layer_worker_specific_storage& dws = deconv_layer_worker_storage_;
+
+    if (params_.pad_type == padding::same) {
+      dws.curr_out_buf_.resize(1, vec_t(params_.in.size(), float_t(0)));
+      dws.curr_delta_padded.resize(1, vec_t(params_.out.size(), float_t(0)));
+    } else {
+      dws.curr_out_buf_.clear();
     }
+  }
 
-    void init() {
-        deconv_layer_worker_specific_storage& dws =  deconv_layer_worker_storage_;
+  cnn_size_t in_length(cnn_size_t in_length, cnn_size_t window_size,
+                       padding pad_type) const {
+    return in_length;
+  }
 
-        if (params_.pad_type == padding::same) {
-            dws.curr_out_buf_.resize(1, vec_t(params_.in.size(), float_t(0)));
-            dws.curr_delta_padded.resize(1, vec_t(params_.out.size(), float_t(0)));
+  static cnn_size_t deconv_out_length(cnn_size_t in_length,
+                                      cnn_size_t window_size,
+                                      cnn_size_t stride) {
+    return (cnn_size_t)ceil((float_t)(in_length)*stride + window_size - 1);
+  }
+
+  static cnn_size_t deconv_out_unpadded_length(cnn_size_t in_length,
+                                               cnn_size_t window_size,
+                                               cnn_size_t stride,
+                                               padding pad_type) {
+    return pad_type == padding::same
+               ? (cnn_size_t)ceil((float_t)in_length * stride)
+               : (cnn_size_t)ceil((float_t)(in_length)*stride + window_size -
+                                  1);
+  }
+
+  static cnn_size_t deconv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                                   cnn_size_t window_size, cnn_size_t w_stride,
+                                   cnn_size_t h_stride, padding pad_type) {
+    return deconv_out_unpadded_length(in_width, window_size, w_stride,
+                                      pad_type) *
+           deconv_out_unpadded_length(in_height, window_size, h_stride,
+                                      pad_type);
+  }
+
+  cnn_size_t deconv_out_dim(cnn_size_t in_width, cnn_size_t in_height,
+                            cnn_size_t window_width, cnn_size_t window_height,
+                            cnn_size_t w_stride, cnn_size_t h_stride,
+                            padding pad_type) const {
+    return deconv_out_unpadded_length(in_width, window_width, w_stride,
+                                      pad_type) *
+           deconv_out_unpadded_length(in_height, window_height, h_stride,
+                                      pad_type);
+  }
+
+  void copy_and_pad_delta(const tensor_t& delta, tensor_t& delta_padded) {
+    if (params_.pad_type == padding::valid) {
+      delta_padded = delta;
+    } else {
+      for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
+        vec_t& dst = delta_padded[sample];
+        const vec_t& src = delta[sample];
+
+        for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
+          float_t* pdst = &dst[params_.in.get_index(0, 0, c)];
+          const float_t* pin = &src[params_.in.get_index(0, 0, c)];
+
+          for (cnn_size_t y = 0; y < params_.in.height_;
+               y++, pdst += params_.in.width_, pin += params_.in.width_) {
+            std::copy(pin, pin + params_.in.width_, pdst);
+          }
         }
-        else {
-            dws.curr_out_buf_.clear();
+      }
+    }
+  }
+
+  void copy_and_unpad_output(const tensor_t& out) {
+    deconv_layer_worker_specific_storage& dws = deconv_layer_worker_storage_;
+
+    dws.curr_out_buf_ =
+        tensor_t(out.size(), vec_t(params_.out_unpadded.width_ *
+                                       params_.out_unpadded.height_ *
+                                       params_.out_unpadded.depth_,
+                                   0));
+    tensor_t* dst_tensor = &dws.curr_out_buf_;
+
+    if (params_.pad_type == padding::valid) {
+      dws.curr_out_unpadded_ = &out;
+    } else {
+      // make unpadded version in order to restore scale in fprop/bprop
+      for (cnn_size_t sample = 0; sample < out.size(); sample++) {
+        cnn_size_t idx = 0;
+        vec_t& dst = (*dst_tensor)[sample];
+
+        for (cnn_size_t c = 0; c < params_.out_unpadded.depth_; c++) {
+          float_t* pimg = &dst[params_.out_unpadded.get_index(0, 0, c)];
+          idx = params_.out.get_index(
+              static_cast<size_t>(floor(params_.weight.width_ / 2)),
+              static_cast<size_t>(floor(params_.weight.height_ / 2)), c);
+
+          const float_t* pout = &out[sample][idx];
+
+          for (cnn_size_t y = static_cast<cnn_size_t>(
+                              floor(params_.weight.height_ / 2));
+               y <
+               params_.out_unpadded.height_ +
+                   static_cast<cnn_size_t>(floor(params_.weight.height_ / 2));
+               y++, pout += params_.out.width_,
+                          pimg += params_.out_unpadded.width_) {
+            std::copy(pout, pout + params_.out_unpadded.width_, pimg);
+          }
         }
+        dws.curr_out_unpadded_ = &dws.curr_out_buf_;
+      }
     }
+  }
 
-    cnn_size_t in_length(cnn_size_t in_length,
-                        cnn_size_t window_size, padding pad_type) const {
-        return in_length;
-    }
+  /* The convolution parameters */
+  deconv_params params_;
 
-    static cnn_size_t deconv_out_length(cnn_size_t in_length,
-                                        cnn_size_t window_size,
-                                        cnn_size_t stride) {
-        return (cnn_size_t)ceil((float_t)(in_length) * stride + window_size - 1);
-    }
+  /* The type of backend */
+  backend_t backend_type_;
 
-    static cnn_size_t deconv_out_unpadded_length(cnn_size_t in_length,
-                                                 cnn_size_t window_size,
-                                                 cnn_size_t stride, padding pad_type) {
-        return pad_type == padding::same ?
-                (cnn_size_t)ceil((float_t)in_length * stride) :
-                (cnn_size_t)ceil((float_t)(in_length) * stride + window_size - 1);
-    }
-
-    static cnn_size_t deconv_out_dim(cnn_size_t in_width,
-                                     cnn_size_t in_height,
-                                     cnn_size_t window_size,
-                                     cnn_size_t w_stride,
-                                     cnn_size_t h_stride, padding pad_type) {
-        return deconv_out_unpadded_length(in_width, window_size, w_stride, pad_type) *
-                deconv_out_unpadded_length(in_height, window_size, h_stride, pad_type);
-    }
-
-    cnn_size_t deconv_out_dim(cnn_size_t in_width,
-                              cnn_size_t in_height,
-                              cnn_size_t window_width,
-                              cnn_size_t window_height,
-                              cnn_size_t w_stride,
-                              cnn_size_t h_stride, padding pad_type) const {
-        return deconv_out_unpadded_length(in_width, window_width, w_stride, pad_type) *
-                deconv_out_unpadded_length(in_height, window_height, h_stride, pad_type);
-    }
-
-    void copy_and_pad_delta(const tensor_t& delta, tensor_t& delta_padded) {
-        if (params_.pad_type == padding::valid) {
-            delta_padded = delta;
-        }
-        else {
-            for (cnn_size_t sample = 0; sample < delta.size(); sample++) {
-                vec_t& dst = delta_padded[sample];
-                const vec_t& src = delta[sample];
-
-                for (cnn_size_t c = 0; c < params_.in.depth_; c++) {
-                    float_t *pdst = &dst[params_.in.get_index(0, 0, c)];
-                    const float_t *pin = &src[params_.in.get_index(0, 0, c)];
-
-                    for (cnn_size_t y = 0; y < params_.in.height_; y++, pdst +=
-                        params_.in.width_, pin += params_.in.width_) {
-                        std::copy(pin, pin + params_.in.width_, pdst);
-                    }
-                }
-            }
-        }
-    }
-
-    void copy_and_unpad_output(const tensor_t& out) {
-        deconv_layer_worker_specific_storage& dws =
-            deconv_layer_worker_storage_;
-
-        dws.curr_out_buf_ = tensor_t(out.size(), vec_t(params_.out_unpadded.width_*
-                                  params_.out_unpadded.height_*
-                                  params_.out_unpadded.depth_,0));
-        tensor_t* dst_tensor = &dws.curr_out_buf_;
-
-        if (params_.pad_type == padding::valid) {
-            dws.curr_out_unpadded_ = &out;
-        } else {
-            // make unpadded version in order to restore scale in fprop/bprop
-            for (cnn_size_t sample = 0; sample < out.size(); sample++) {
-                cnn_size_t idx = 0;
-                vec_t& dst = (*dst_tensor)[sample];
-
-                for (cnn_size_t c = 0; c < params_.out_unpadded.depth_; c++) {
-                    float_t *pimg = &dst[params_.out_unpadded.get_index(0, 0, c)];
-                    idx = params_.out.get_index(static_cast<size_t>(floor(params_.weight.width_ / 2)),
-                                                static_cast<size_t>(floor(params_.weight.height_ / 2)), c);
-
-                    const float_t *pout = &out[sample][idx];
-
-                    for (cnn_size_t y = static_cast<cnn_size_t>(floor(params_.weight.height_ / 2));
-                        y < params_.out_unpadded.height_ + static_cast<cnn_size_t>(floor(params_.weight.height_ / 2));
-                        y++,
-                        pout += params_.out.width_,
-                        pimg += params_.out_unpadded.width_) {
-                        std::copy(pout,
-                                  pout + params_.out_unpadded.width_,
-                                  pimg);
-                    }
-                }
-                dws.curr_out_unpadded_ = &dws.curr_out_buf_;
-            }
-        }
-    }
-
-    /* The convolution parameters */
-    deconv_params params_;
-
-    /* The type of backend */
-    backend_t backend_type_;
-
-    /* Workers buffers */
-    deconv_layer_worker_specific_storage deconv_layer_worker_storage_;
+  /* Workers buffers */
+  deconv_layer_worker_specific_storage deconv_layer_worker_storage_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/quantized_fully_connected_layer.h
+++ b/tiny_dnn/layers/quantized_fully_connected_layer.h
@@ -11,117 +11,108 @@ namespace tiny_dnn {
 /**
  * compute fully-connected(matmul) operation
  **/
-template<typename Activation>
+template <typename Activation>
 class quantized_fully_connected_layer : public feedforward_layer<Activation> {
-public:
-    typedef feedforward_layer<Activation> Base;
-    CNN_USE_LAYER_MEMBERS;
+ public:
+  typedef feedforward_layer<Activation> Base;
+  CNN_USE_LAYER_MEMBERS;
 
-    /**
-     * @param in_dim [in] number of elements of the input
-     * @param out_dim [in] number of elements of the output
-     * @param has_bias [in] whether to include additional bias to the layer
-     **/
-    quantized_fully_connected_layer(cnn_size_t     in_dim,
-                                    cnn_size_t     out_dim,
-                                    bool           has_bias = true,
-                                    backend_t      backend_type = backend_t::tiny_dnn,
-                                    backend_params b_params = backend_params())
-            : Base(std_input_order(has_bias)) {
-        set_params(in_dim, out_dim, has_bias);
-        init_backend(backend_type);
+  /**
+   * @param in_dim [in] number of elements of the input
+   * @param out_dim [in] number of elements of the output
+   * @param has_bias [in] whether to include additional bias to the layer
+   **/
+  quantized_fully_connected_layer(cnn_size_t in_dim, cnn_size_t out_dim,
+                                  bool has_bias = true,
+                                  backend_t backend_type = backend_t::tiny_dnn,
+                                  backend_params b_params = backend_params())
+      : Base(std_input_order(has_bias)) {
+    set_params(in_dim, out_dim, has_bias);
+    init_backend(backend_type);
+  }
+
+  // move constructor
+  quantized_fully_connected_layer(quantized_fully_connected_layer&& other)
+      : Base(std::move(other)), params_(std::move(other.params_)) {
+    init_backend(std::move(Base::get_backend_type()));
+  }
+
+  size_t fan_in_size() const override { return params_.in_size_; }
+
+  size_t fan_out_size() const override { return params_.out_size_; }
+
+  std::vector<index3d<cnn_size_t>> in_shape() const override {
+    if (params_.has_bias_) {
+      return {index3d<cnn_size_t>(params_.in_size_, 1, 1),
+              index3d<cnn_size_t>(params_.in_size_, params_.out_size_, 1),
+              index3d<cnn_size_t>(params_.out_size_, 1, 1)};
+    } else {
+      return {index3d<cnn_size_t>(params_.in_size_, 1, 1),
+              index3d<cnn_size_t>(params_.in_size_, params_.out_size_, 1)};
+    }
+  }
+
+  std::vector<index3d<cnn_size_t>> out_shape() const override {
+    return {index3d<cnn_size_t>(params_.out_size_, 1, 1),
+            index3d<cnn_size_t>(params_.out_size_, 1, 1)};
+  }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    if (in_data.size() == 2 || in_data.size() == 3) {
+      Base::backend_->fully_q(in_data, out_data);
+
+      // activations
+      this->forward_activation(*out_data[0], *out_data[1]);
+    } else if (in_data.size() == 4 || in_data.size() == 6) {
+      Base::backend_->fully_eq(in_data, out_data);
+    }
+  }
+
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    Base::backend_->fully_q(in_data, out_data, out_grad, in_grad);
+  }
+
+  std::string layer_type() const override { return "q_fully-connected"; }
+
+ protected:
+  fully_params params_;
+
+  void set_params(const cnn_size_t in_size, const cnn_size_t out_size,
+                  bool has_bias) {
+    params_.in_size_ = in_size;
+    params_.out_size_ = out_size;
+    params_.has_bias_ = has_bias;
+  }
+
+  void init_backend(backend_t backend_type) {
+    std::shared_ptr<core::backend> backend = nullptr;
+
+    // allocate new backend
+    if (backend_type == backend_t::tiny_dnn) {
+      backend = std::make_shared<core::tiny_backend>(
+          &params_, [this](const tensor_t& p_delta, const tensor_t& out,
+                           tensor_t& c_delta) {
+            return Base::backward_activation(p_delta, out, c_delta);
+          });
+    } else if (backend_type == backend_t::nnpack) {
+      backend = std::make_shared<core::nnp_backend>(&params_);
+    } else if (backend_type == backend_t::libdnn) {
+      backend = std::make_shared<core::dnn_backend>();
+    } else {
+      throw nn_error("Not supported backend type.");
     }
 
-    // move constructor
-    quantized_fully_connected_layer(quantized_fully_connected_layer&& other)
-            : Base(std::move(other))
-            , params_(std::move(other.params_)) {
-        init_backend(std::move(Base::get_backend_type()));
+    if (backend) {
+      Base::set_backend(backend);
+      Base::backend_->set_layer(this);
+    } else {
+      throw nn_error("Could not allocate the backend.");
     }
-
-    size_t fan_in_size() const override {
-        return params_.in_size_;
-    }
-
-    size_t fan_out_size() const override {
-        return params_.out_size_;
-    }
-
-    std::vector<index3d<cnn_size_t>> in_shape() const override {
-        if (params_.has_bias_) {
-            return { index3d<cnn_size_t>(params_.in_size_, 1, 1),
-                     index3d<cnn_size_t>(params_.in_size_,
-                                         params_.out_size_, 1),
-                     index3d<cnn_size_t>(params_.out_size_, 1, 1) };
-        } else {
-            return { index3d<cnn_size_t>(params_.in_size_, 1, 1),
-                     index3d<cnn_size_t>(params_.in_size_,
-                                         params_.out_size_, 1) };
-        }
-    }
-
-    std::vector<index3d<cnn_size_t>> out_shape() const override {
-        return { index3d<cnn_size_t>(params_.out_size_, 1, 1),
-                 index3d<cnn_size_t>(params_.out_size_, 1, 1) };
-    }
-
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        if (in_data.size() == 2 || in_data.size() == 3) {
-            Base::backend_->fully_q(in_data, out_data);
-
-            // activations
-            this->forward_activation(*out_data[0], *out_data[1]);
-        } else if (in_data.size() == 4 || in_data.size() == 6) {
-            Base::backend_->fully_eq(in_data, out_data);
-        }
-    }
-
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        Base::backend_->fully_q(in_data, out_data, out_grad, in_grad);
-    }
-
-    std::string layer_type() const override { return "q_fully-connected"; }
-
-protected:
-    fully_params params_;
-
-    void set_params(const cnn_size_t in_size,
-                    const cnn_size_t out_size,
-                    bool             has_bias) {
-        params_.in_size_  = in_size;
-        params_.out_size_ = out_size;
-        params_.has_bias_ = has_bias;
-    }
-
-    void init_backend(backend_t backend_type) {
-        std::shared_ptr<core::backend> backend = nullptr;
-
-        // allocate new backend
-        if (backend_type == backend_t::tiny_dnn) {
-            backend = std::make_shared<core::tiny_backend>(&params_,
-                [this](const tensor_t& p_delta,
-                       const tensor_t& out, tensor_t& c_delta) {
-                     return Base::backward_activation(p_delta, out, c_delta);
-                });
-        } else if (backend_type == backend_t::nnpack) {
-            backend = std::make_shared<core::nnp_backend>(&params_);
-        } else if (backend_type == backend_t::libdnn) {
-            backend = std::make_shared<core::dnn_backend>();
-        } else {
-            throw nn_error("Not supported backend type.");
-        }
-
-        if (backend) {
-            Base::set_backend(backend);
-            Base::backend_->set_layer(this);
-        } else {
-            throw nn_error("Could not allocate the backend.");
-        }
-    }
+  }
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/quantized_fully_connected_layer.h
+++ b/tiny_dnn/layers/quantized_fully_connected_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/util/product.h"

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -3,232 +3,235 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
-    enum class slice_type {
-        slice_samples,
-        slice_channels
-    };
-
+enum class slice_type { slice_samples, slice_channels };
 
 /**
  * slice an input data into multiple outputs along a given slice dimension.
  **/
 class slice_layer : public layer {
-public:
-    typedef layer Base;
+ public:
+  typedef layer Base;
 
-    /**
-     * @param in_shape �@ [in] size (width * height * channels) of input data
-     * @param slice_type  [in] target axis of slicing
-     * @param num_outputs [in] number of output layers
-     *
-     * example1:
-     *   input:       NxKxWxH = 4x3x2x2  (N:batch-size, K:channels, W:width, H:height)
-     *   slice_type:  slice_samples
-     *   num_outputs: 3
-     *
-     *   output[0]: 1x3x2x2
-     *   output[1]: 1x3x2x2
-     *   output[2]: 2x3x2x2  (mod data is assigned to the last output)
-     *
-     * example2:
-     *   input:       NxKxWxH = 4x6x2x2
-     *   slice_type:  slice_channels
-     *   num_outputs: 3
-     *
-     *   output[0]: 4x2x2x2
-     *   output[1]: 4x2x2x2
-     *   output[2]: 4x2x2x2
-    **/
-    slice_layer(const shape3d& in_shape, slice_type slice_type, cnn_size_t num_outputs)
-    : layer(std::vector<vector_type>(1, vector_type::data), std::vector<vector_type>(num_outputs, vector_type::data)),
-      in_shape_(in_shape), slice_type_(slice_type), num_outputs_(num_outputs) {
-        set_shape();
+  /**
+   * @param in_shape �@ [in] size (width * height * channels) of input data
+   * @param slice_type  [in] target axis of slicing
+   * @param num_outputs [in] number of output layers
+   *
+   * example1:
+   *   input:       NxKxWxH = 4x3x2x2  (N:batch-size, K:channels, W:width,
+   *H:height)
+   *   slice_type:  slice_samples
+   *   num_outputs: 3
+   *
+   *   output[0]: 1x3x2x2
+   *   output[1]: 1x3x2x2
+   *   output[2]: 2x3x2x2  (mod data is assigned to the last output)
+   *
+   * example2:
+   *   input:       NxKxWxH = 4x6x2x2
+   *   slice_type:  slice_channels
+   *   num_outputs: 3
+   *
+   *   output[0]: 4x2x2x2
+   *   output[1]: 4x2x2x2
+   *   output[2]: 4x2x2x2
+  **/
+  slice_layer(const shape3d& in_shape, slice_type slice_type,
+              cnn_size_t num_outputs)
+      : layer(std::vector<vector_type>(1, vector_type::data),
+              std::vector<vector_type>(num_outputs, vector_type::data)),
+        in_shape_(in_shape),
+        slice_type_(slice_type),
+        num_outputs_(num_outputs) {
+    set_shape();
+  }
+
+  slice_layer(const layer& prev_layer, slice_type slice_type,
+              cnn_size_t num_outputs)
+      : layer(std::vector<vector_type>(1, vector_type::data),
+              std::vector<vector_type>(num_outputs, vector_type::data)),
+        in_shape_(prev_layer.out_shape()[0]),
+        slice_type_(slice_type),
+        num_outputs_(num_outputs) {
+    set_shape();
+  }
+
+  std::string layer_type() const override { return "slice"; }
+
+  std::vector<shape3d> in_shape() const override { return {in_shape_}; }
+
+  std::vector<shape3d> out_shape() const override { return out_shapes_; }
+
+  void forward_propagation(const std::vector<tensor_t*>& in_data,
+                           std::vector<tensor_t*>& out_data) override {
+    switch (slice_type_) {
+      case slice_type::slice_samples:
+        slice_data_forward(*in_data[0], out_data);
+        break;
+      case slice_type::slice_channels:
+        slice_channels_forward(*in_data[0], out_data);
+        break;
+      default:
+        throw nn_not_implemented_error();
     }
+  }
 
-    slice_layer(const layer& prev_layer, slice_type slice_type, cnn_size_t num_outputs)
-        : layer(std::vector<vector_type>(1, vector_type::data), std::vector<vector_type>(num_outputs, vector_type::data)),
-        in_shape_(prev_layer.out_shape()[0]), slice_type_(slice_type), num_outputs_(num_outputs) {
-        set_shape();
+  void back_propagation(const std::vector<tensor_t*>& in_data,
+                        const std::vector<tensor_t*>& out_data,
+                        std::vector<tensor_t*>& out_grad,
+                        std::vector<tensor_t*>& in_grad) override {
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+
+    switch (slice_type_) {
+      case slice_type::slice_samples:
+        slice_data_backward(out_grad, *in_grad[0]);
+        break;
+      case slice_type::slice_channels:
+        slice_channels_backward(out_grad, *in_grad[0]);
+        break;
+      default:
+        throw nn_not_implemented_error();
     }
+  }
 
-    std::string layer_type() const override {
-        return "slice";
+  template <class Archive>
+  static void load_and_construct(Archive& ar,
+                                 cereal::construct<slice_layer>& construct) {
+    shape3d in_shape;
+    slice_type slice_type;
+    cnn_size_t num_outputs;
+
+    ar(cereal::make_nvp("in_size", in_shape),
+       cereal::make_nvp("slice_type", slice_type),
+       cereal::make_nvp("num_outputs", num_outputs));
+    construct(in_shape, slice_type, num_outputs);
+  }
+
+  template <class Archive>
+  void serialize(Archive& ar) {
+    layer::serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", in_shape_),
+       cereal::make_nvp("slice_type", slice_type_),
+       cereal::make_nvp("num_outputs", num_outputs_));
+  }
+
+ private:
+  void slice_data_forward(const tensor_t& in_data,
+                          std::vector<tensor_t*>& out_data) {
+    const vec_t* in = &in_data[0];
+
+    for (cnn_size_t i = 0; i < num_outputs_; i++) {
+      tensor_t& out = *out_data[i];
+
+      std::copy(in, in + slice_size_[i], &out[0]);
+
+      in += slice_size_[i];
     }
+  }
 
-    std::vector<shape3d> in_shape() const override {
-        return {in_shape_};
+  void slice_data_backward(std::vector<tensor_t*>& out_grad,
+                           tensor_t& in_grad) {
+    vec_t* in = &in_grad[0];
+
+    for (cnn_size_t i = 0; i < num_outputs_; i++) {
+      tensor_t& out = *out_grad[i];
+
+      std::copy(&out[0], &out[0] + slice_size_[i], in);
+
+      in += slice_size_[i];
     }
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return out_shapes_;
+  void slice_channels_forward(const tensor_t& in_data,
+                              std::vector<tensor_t*>& out_data) {
+    cnn_size_t num_samples = in_data.size();
+    cnn_size_t channel_idx = 0;
+    cnn_size_t spatial_dim = in_shape_.area();
+
+    for (cnn_size_t i = 0; i < num_outputs_; i++) {
+      for (cnn_size_t s = 0; s < num_samples; s++) {
+        float_t* out = &(*out_data[i])[s][0];
+        const float_t* in = &in_data[s][0] + channel_idx * spatial_dim;
+
+        std::copy(in, in + slice_size_[i] * spatial_dim, out);
+      }
+      channel_idx += slice_size_[i];
     }
+  }
 
-    void forward_propagation(const std::vector<tensor_t*>& in_data,
-                             std::vector<tensor_t*>& out_data) override {
-        switch (slice_type_) {
-        case slice_type::slice_samples:
-            slice_data_forward(*in_data[0], out_data);
-            break;
-        case slice_type::slice_channels:
-            slice_channels_forward(*in_data[0], out_data);
-            break;
-        default:
-            throw nn_not_implemented_error();
-        }
+  void slice_channels_backward(std::vector<tensor_t*>& out_grad,
+                               tensor_t& in_grad) {
+    cnn_size_t num_samples = in_grad.size();
+    cnn_size_t channel_idx = 0;
+    cnn_size_t spatial_dim = in_shape_.area();
+
+    for (cnn_size_t i = 0; i < num_outputs_; i++) {
+      for (cnn_size_t s = 0; s < num_samples; s++) {
+        const float_t* out = &(*out_grad[i])[s][0];
+        float_t* in = &in_grad[s][0] + channel_idx * spatial_dim;
+
+        std::copy(out, out + slice_size_[i] * spatial_dim, in);
+      }
+      channel_idx += slice_size_[i];
     }
+  }
 
-    void back_propagation(const std::vector<tensor_t*>& in_data,
-                          const std::vector<tensor_t*>& out_data,
-                          std::vector<tensor_t*>&       out_grad,
-                          std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
+  void set_sample_count(cnn_size_t sample_count) override {
+    if (slice_type_ == slice_type::slice_samples) {
+      if (num_outputs_ == 0)
+        throw nn_error("num_outputs must be positive integer");
 
-        switch (slice_type_) {
-        case slice_type::slice_samples:
-            slice_data_backward(out_grad, *in_grad[0]);
-            break;
-        case slice_type::slice_channels:
-            slice_channels_backward(out_grad, *in_grad[0]);
-            break;
-        default:
-            throw nn_not_implemented_error();
-        }
+      cnn_size_t sample_per_out = sample_count / num_outputs_;
+
+      slice_size_.resize(num_outputs_, sample_per_out);
+      slice_size_.back() = sample_count - (sample_per_out * (num_outputs_ - 1));
     }
+    Base::set_sample_count(sample_count);
+  }
 
-    template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<slice_layer> & construct) {
-        shape3d in_shape;
-        slice_type slice_type;
-        cnn_size_t num_outputs;
-
-        ar(cereal::make_nvp("in_size", in_shape), cereal::make_nvp("slice_type", slice_type), cereal::make_nvp("num_outputs", num_outputs));
-        construct(in_shape, slice_type, num_outputs);
+  void set_shape() {
+    switch (slice_type_) {
+      case slice_type::slice_samples:
+        set_shape_data();
+        break;
+      case slice_type::slice_channels:
+        set_shape_channels();
+        break;
+      default:
+        throw nn_not_implemented_error();
     }
+  }
 
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_shape_), cereal::make_nvp("slice_type", slice_type_), cereal::make_nvp("num_outputs", num_outputs_));
+  void set_shape_data() { out_shapes_.resize(num_outputs_, in_shape_); }
+
+  void set_shape_channels() {
+    cnn_size_t channel_per_out = in_shape_.depth_ / num_outputs_;
+
+    out_shapes_.clear();
+    for (cnn_size_t i = 0; i < num_outputs_; i++) {
+      cnn_size_t ch = channel_per_out;
+
+      if (i == num_outputs_ - 1) {
+        assert(in_shape_.depth_ >= i * channel_per_out);
+        ch = in_shape_.depth_ - i * channel_per_out;
+      }
+
+      slice_size_.push_back(ch);
+      out_shapes_.push_back(shape3d(in_shape_.width_, in_shape_.height_, ch));
     }
-private:
-    void slice_data_forward(const tensor_t& in_data,
-                            std::vector<tensor_t*>& out_data) {
-        const vec_t* in  = &in_data[0];
+  }
 
-        for (cnn_size_t i = 0; i < num_outputs_; i++) {
-            tensor_t& out = *out_data[i];
-
-            std::copy(in, in + slice_size_[i], &out[0]);
-
-            in += slice_size_[i];
-        }
-    }
-
-    void slice_data_backward(std::vector<tensor_t*>& out_grad,
-                             tensor_t& in_grad) {
-        vec_t* in = &in_grad[0];
-
-        for (cnn_size_t i = 0; i < num_outputs_; i++) {
-            tensor_t& out = *out_grad[i];
-
-            std::copy(&out[0], &out[0] + slice_size_[i], in);
-
-            in += slice_size_[i];
-        }
-    }
-
-    void slice_channels_forward(const tensor_t& in_data,
-                                std::vector<tensor_t*>& out_data) {
-        cnn_size_t num_samples = in_data.size();
-        cnn_size_t channel_idx = 0;
-        cnn_size_t spatial_dim = in_shape_.area();
-
-        for (cnn_size_t i = 0; i < num_outputs_; i++) {
-            for (cnn_size_t s = 0; s < num_samples; s++) {
-                float_t       *out = &(*out_data[i])[s][0];
-                const float_t *in  = &in_data[s][0] + channel_idx*spatial_dim;
-
-                std::copy(in, in + slice_size_[i] * spatial_dim, out);
-            }
-            channel_idx += slice_size_[i];
-        }
-    }
-
-    void slice_channels_backward(std::vector<tensor_t*>& out_grad,
-                                 tensor_t&               in_grad) {
-        cnn_size_t num_samples = in_grad.size();
-        cnn_size_t channel_idx = 0;
-        cnn_size_t spatial_dim = in_shape_.area();
-
-        for (cnn_size_t i = 0; i < num_outputs_; i++) {
-            for (cnn_size_t s = 0; s < num_samples; s++) {
-                const float_t *out = &(*out_grad[i])[s][0];
-                float_t       *in = &in_grad[s][0] + channel_idx*spatial_dim;
-
-                std::copy(out, out + slice_size_[i] * spatial_dim, in);
-            }
-            channel_idx += slice_size_[i];
-        }
-    }
-
-    void set_sample_count(cnn_size_t sample_count) override {
-        if (slice_type_ == slice_type::slice_samples) {
-            if (num_outputs_ == 0)
-                throw nn_error("num_outputs must be positive integer");
-
-            cnn_size_t sample_per_out = sample_count / num_outputs_;
-
-            slice_size_.resize(num_outputs_, sample_per_out);
-            slice_size_.back() = sample_count - (sample_per_out*(num_outputs_-1));
-        }
-        Base::set_sample_count(sample_count);
-    }
-
-    void set_shape() {
-        switch (slice_type_) {
-        case slice_type::slice_samples:
-            set_shape_data();
-            break;
-        case slice_type::slice_channels:
-            set_shape_channels();
-            break;
-        default:
-            throw nn_not_implemented_error();
-        }
-    }
-
-    void set_shape_data() {
-        out_shapes_.resize(num_outputs_, in_shape_);
-    }
-
-    void set_shape_channels() {
-        cnn_size_t channel_per_out = in_shape_.depth_ / num_outputs_;
-
-        out_shapes_.clear();
-        for (cnn_size_t i = 0; i < num_outputs_; i++) {
-            cnn_size_t ch = channel_per_out;
-
-            if (i == num_outputs_ - 1) {
-                assert(in_shape_.depth_ >= i * channel_per_out);
-                ch = in_shape_.depth_ - i * channel_per_out;
-            }
-
-            slice_size_.push_back(ch);
-            out_shapes_.push_back(shape3d(in_shape_.width_, in_shape_.height_, ch));
-        }
-    }
-
-    shape3d in_shape_;
-    slice_type slice_type_;
-    cnn_size_t num_outputs_;
-    std::vector<shape3d> out_shapes_;
-    std::vector<cnn_size_t> slice_size_;
+  shape3d in_shape_;
+  slice_type slice_type_;
+  cnn_size_t num_outputs_;
+  std::vector<shape3d> out_shapes_;
+  std::vector<cnn_size_t> slice_size_;
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
@@ -44,7 +22,7 @@ public:
     typedef layer Base;
 
     /**
-     * @param in_shape Å@ [in] size (width * height * channels) of input data
+     * @param in_shape ÔøΩ@ [in] size (width * height * channels) of input data
      * @param slice_type  [in] target axis of slicing
      * @param num_outputs [in] number of output layers
      *

--- a/tiny_dnn/lossfunctions/loss_function.h
+++ b/tiny_dnn/lossfunctions/loss_function.h
@@ -9,212 +9,210 @@ namespace tiny_dnn {
 
 // mean-squared-error loss function for regression
 class mse {
-public:
-    static float_t f(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        float_t d = 0.0;
+ public:
+  static float_t f(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    float_t d = 0.0;
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d += (y[i] - t[i]) * (y[i] - t[i]);
+    for (cnn_size_t i = 0; i < y.size(); ++i)
+      d += (y[i] - t[i]) * (y[i] - t[i]);
 
-        return d/y.size();
-    }
+    return d / y.size();
+  }
 
-    static vec_t df(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        vec_t d(t.size());
-        float_t factor = float_t(2) / static_cast<float_t>(t.size());
+  static vec_t df(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    vec_t d(t.size());
+    float_t factor = float_t(2) / static_cast<float_t>(t.size());
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d[i] = factor * (y[i] - t[i]);
+    for (cnn_size_t i = 0; i < y.size(); ++i) d[i] = factor * (y[i] - t[i]);
 
-        return d;
-    }
+    return d;
+  }
 };
 
 // absolute loss function for regression
 class absolute {
-public:
-    static float_t f(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        float_t d = float_t(0);
+ public:
+  static float_t f(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    float_t d = float_t(0);
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d += std::abs(y[i] - t[i]);
+    for (cnn_size_t i = 0; i < y.size(); ++i) d += std::abs(y[i] - t[i]);
 
-        return d/y.size();
+    return d / y.size();
+  }
+
+  static vec_t df(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    vec_t d(t.size());
+    float_t factor = float_t(1) / static_cast<float_t>(t.size());
+
+    for (cnn_size_t i = 0; i < y.size(); ++i) {
+      float_t sign = y[i] - t[i];
+      if (sign < 0.f)
+        d[i] = -float_t(1) * factor;
+      else if (sign > 0.f)
+        d[i] = float_t(1) * factor;
+      else
+        d[i] = float_t(0);
     }
 
-    static vec_t df(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        vec_t d(t.size());
-        float_t factor = float_t(1) / static_cast<float_t>(t.size());
-
-        for(cnn_size_t i = 0; i < y.size(); ++i) {
-            float_t sign = y[i] - t[i];
-            if(sign < 0.f)
-                d[i] = -float_t(1) * factor;
-            else if(sign > 0.f)
-                d[i] =  float_t(1) * factor;
-            else
-                d[i] =  float_t(0);
-        }
-
-        return d;
-    }
+    return d;
+  }
 };
 
 // absolute loss with epsilon range for regression
 // epsilon range [-eps, eps] with eps = 1./fraction
-template<int fraction>
+template <int fraction>
 class absolute_eps {
-public:
-    static float_t f(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        float_t d = float_t(0);
-        const float_t eps = float_t(1) / fraction;
+ public:
+  static float_t f(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    float_t d = float_t(0);
+    const float_t eps = float_t(1) / fraction;
 
-        for(cnn_size_t i = 0; i < y.size(); ++i) {
-            float_t diff = std::abs(y[i] - t[i]);
-            if(diff > eps)
-                d += diff;
-        }
-        return d / y.size();
+    for (cnn_size_t i = 0; i < y.size(); ++i) {
+      float_t diff = std::abs(y[i] - t[i]);
+      if (diff > eps) d += diff;
     }
+    return d / y.size();
+  }
 
-    static vec_t df(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        vec_t d(t.size());
-        const float_t factor = float_t(1) / static_cast<float_t>(t.size());
-        const float_t eps    = float_t(1) / fraction;
+  static vec_t df(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    vec_t d(t.size());
+    const float_t factor = float_t(1) / static_cast<float_t>(t.size());
+    const float_t eps = float_t(1) / fraction;
 
-        for(cnn_size_t i = 0; i < y.size(); ++i) {
-            float_t sign = y[i] - t[i];
-            if(sign < -eps)
-                d[i] = -float_t(1) * factor;
-            else if(sign > eps)
-                d[i] =  float_t(1) * factor;
-            else
-                d[i] = 0.f;
-        }
-        return d;
+    for (cnn_size_t i = 0; i < y.size(); ++i) {
+      float_t sign = y[i] - t[i];
+      if (sign < -eps)
+        d[i] = -float_t(1) * factor;
+      else if (sign > eps)
+        d[i] = float_t(1) * factor;
+      else
+        d[i] = 0.f;
     }
+    return d;
+  }
 };
 
 // cross-entropy loss function for (multiple independent) binary classifications
 class cross_entropy {
-public:
-    static float_t f(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        float_t d = float_t(0);
+ public:
+  static float_t f(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    float_t d = float_t(0);
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d += -t[i] * std::log(y[i]) - (float_t(1) - t[i]) * std::log(float_t(1) - y[i]);
+    for (cnn_size_t i = 0; i < y.size(); ++i)
+      d += -t[i] * std::log(y[i]) -
+           (float_t(1) - t[i]) * std::log(float_t(1) - y[i]);
 
-        return d;
-    }
+    return d;
+  }
 
-    static vec_t df(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        vec_t d(t.size());
+  static vec_t df(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    vec_t d(t.size());
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d[i] = (y[i] - t[i]) / (y[i] * (float_t(1) - y[i]));
+    for (cnn_size_t i = 0; i < y.size(); ++i)
+      d[i] = (y[i] - t[i]) / (y[i] * (float_t(1) - y[i]));
 
-        return d;
-    }
+    return d;
+  }
 };
 
 // cross-entropy loss function for multi-class classification
 class cross_entropy_multiclass {
-public:
-    static float_t f(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        float_t d = 0.0;
+ public:
+  static float_t f(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    float_t d = 0.0;
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d += -t[i] * std::log(y[i]);
+    for (cnn_size_t i = 0; i < y.size(); ++i) d += -t[i] * std::log(y[i]);
 
-        return d;
-    }
+    return d;
+  }
 
-    static vec_t df(const vec_t& y, const vec_t& t) {
-        assert(y.size() == t.size());
-        vec_t d(t.size());
+  static vec_t df(const vec_t& y, const vec_t& t) {
+    assert(y.size() == t.size());
+    vec_t d(t.size());
 
-        for(cnn_size_t i = 0; i < y.size(); ++i)
-            d[i] = - t[i] / y[i];
+    for (cnn_size_t i = 0; i < y.size(); ++i) d[i] = -t[i] / y[i];
 
-        return d;
-    }
+    return d;
+  }
 };
 
 template <typename E>
 vec_t gradient(const vec_t& y, const vec_t& t) {
-    assert(y.size() == t.size());
-    return E::df(y, t);
+  assert(y.size() == t.size());
+  return E::df(y, t);
 }
 
 template <typename E>
-std::vector<vec_t> gradient(const std::vector<vec_t>& y, const std::vector<vec_t>& t) {
-    std::vector<vec_t> grads;
- 
-    assert(y.size() == t.size());
+std::vector<vec_t> gradient(const std::vector<vec_t>& y,
+                            const std::vector<vec_t>& t) {
+  std::vector<vec_t> grads;
 
-    for (cnn_size_t i = 0; i < y.size(); i++)
-        grads.push_back(gradient<E>(y[i], t[i]));
+  assert(y.size() == t.size());
 
-    return grads;
+  for (cnn_size_t i = 0; i < y.size(); i++)
+    grads.push_back(gradient<E>(y[i], t[i]));
+
+  return grads;
 }
 
 namespace {
-void apply_cost_if_defined(std::vector<vec_t>& sample_gradient, const std::vector<vec_t>& sample_cost)
-{
-    if (sample_gradient.size() == sample_cost.size()) {
-        // @todo consider adding parallelism
-        for (cnn_size_t channel = 0, channel_count = sample_gradient.size(); channel < channel_count; ++channel) {
-            if (sample_gradient[channel].size() == sample_cost[channel].size()) {
-                const cnn_size_t element_count = sample_gradient[channel].size();
+void apply_cost_if_defined(std::vector<vec_t>& sample_gradient,
+                           const std::vector<vec_t>& sample_cost) {
+  if (sample_gradient.size() == sample_cost.size()) {
+    // @todo consider adding parallelism
+    for (cnn_size_t channel = 0, channel_count = sample_gradient.size();
+         channel < channel_count; ++channel) {
+      if (sample_gradient[channel].size() == sample_cost[channel].size()) {
+        const cnn_size_t element_count = sample_gradient[channel].size();
 
-                // @todo optimize? (use AVX or so)
-                for (cnn_size_t element = 0; element < element_count; ++element) {
-                    sample_gradient[channel][element] *= sample_cost[channel][element];
-                }
-            }
+        // @todo optimize? (use AVX or so)
+        for (cnn_size_t element = 0; element < element_count; ++element) {
+          sample_gradient[channel][element] *= sample_cost[channel][element];
         }
+      }
     }
+  }
 }
-} // namespace
+}  // namespace
 
 // gradient for a minibatch
 template <typename E>
 std::vector<tensor_t> gradient(const std::vector<tensor_t>& y,
                                const std::vector<tensor_t>& t,
                                const std::vector<tensor_t>& t_cost) {
+  const cnn_size_t sample_count = y.size();
+  const cnn_size_t channel_count = y[0].size();
 
-    const cnn_size_t sample_count = y.size();
-    const cnn_size_t channel_count = y[0].size();
+  std::vector<tensor_t> gradients(sample_count);
 
-    std::vector<tensor_t> gradients(sample_count);
- 
-    CNN_UNREFERENCED_PARAMETER(channel_count);
-    assert(y.size() == t.size());
-    assert(t_cost.empty() || t_cost.size() == t.size());
+  CNN_UNREFERENCED_PARAMETER(channel_count);
+  assert(y.size() == t.size());
+  assert(t_cost.empty() || t_cost.size() == t.size());
 
-    // @todo add parallelism
-    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-        assert(y[sample].size() == channel_count);
-        assert(t[sample].size() == channel_count);
-        assert(t_cost.empty() || t_cost[sample].empty() || t_cost[sample].size() == channel_count);
+  // @todo add parallelism
+  for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+    assert(y[sample].size() == channel_count);
+    assert(t[sample].size() == channel_count);
+    assert(t_cost.empty() || t_cost[sample].empty() ||
+           t_cost[sample].size() == channel_count);
 
-        gradients[sample] = gradient<E>(y[sample], t[sample]);
+    gradients[sample] = gradient<E>(y[sample], t[sample]);
 
-        if (sample < t_cost.size()) {
-            apply_cost_if_defined(gradients[sample], t_cost[sample]);
-        }
+    if (sample < t_cost.size()) {
+      apply_cost_if_defined(gradients[sample], t_cost[sample]);
     }
+  }
 
-    return gradients;
+  return gradients;
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/lossfunctions/loss_function.h
+++ b/tiny_dnn/lossfunctions/loss_function.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 

--- a/tiny_dnn/models/alexnet.h
+++ b/tiny_dnn/models/alexnet.h
@@ -2,7 +2,6 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-
 //#include "tiny_dnn/tiny_dnn.h"
 
 using namespace tiny_dnn::activation;
@@ -10,20 +9,20 @@ using namespace tiny_dnn::layers;
 
 namespace models {
 
-// Based on: https://github.com/DeepMark/deepmark/blob/master/torch/image%2Bvideo/alexnet.lua
+// Based on:
+// https://github.com/DeepMark/deepmark/blob/master/torch/image%2Bvideo/alexnet.lua
 class alexnet : public network<sequential> {
  public:
-    explicit alexnet(const std::string& name = "")
-            : network<sequential>(name) {
-        *this << conv<relu>(224, 224, 11, 11, 3, 64, padding::valid, true, 4, 4);
-        *this << max_pool<identity>(54, 54, 64, 2);
-        *this << conv<relu>(27, 27, 5, 5, 64, 192, padding::valid, true, 1, 1);
-        *this << max_pool<identity>(23, 23, 192, 1);
-        *this << conv<relu>(23, 23, 3, 3, 192, 384, padding::valid, true, 1, 1);
-        *this << conv<relu>(21, 21, 3, 3, 384, 256, padding::valid, true, 1, 1);
-        *this << conv<relu>(19, 19, 3, 3, 256, 256, padding::valid, true, 1, 1);
-        *this << max_pool<identity>(17, 17, 256, 1);
-    }
+  explicit alexnet(const std::string& name = "") : network<sequential>(name) {
+    *this << conv<relu>(224, 224, 11, 11, 3, 64, padding::valid, true, 4, 4);
+    *this << max_pool<identity>(54, 54, 64, 2);
+    *this << conv<relu>(27, 27, 5, 5, 64, 192, padding::valid, true, 1, 1);
+    *this << max_pool<identity>(23, 23, 192, 1);
+    *this << conv<relu>(23, 23, 3, 3, 192, 384, padding::valid, true, 1, 1);
+    *this << conv<relu>(21, 21, 3, 3, 384, 256, padding::valid, true, 1, 1);
+    *this << conv<relu>(19, 19, 3, 3, 256, 256, padding::valid, true, 1, 1);
+    *this << max_pool<identity>(17, 17, 256, 1);
+  }
 };
 
 }  // namespace models

--- a/tiny_dnn/models/alexnet.h
+++ b/tiny_dnn/models/alexnet.h
@@ -1,30 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    Copyright (c) 2016, Taiga Nomi, Edgar Riba
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi, Edgar Riba. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 
 //#include "tiny_dnn/tiny_dnn.h"
 

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -3,98 +3,90 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <iostream>
-#include <stdexcept>
 #include <algorithm>
-#include <iterator>
 #include <iomanip>
+#include <iostream>
+#include <iterator>
+#include <limits>
 #include <map>
 #include <set>
-#include <limits>
+#include <stdexcept>
 #include <string>
 #include <vector>
 
+#include "tiny_dnn/activations/activation_function.h"
+#include "tiny_dnn/lossfunctions/loss_function.h"
 #include "tiny_dnn/nodes.h"
 #include "tiny_dnn/util/util.h"
-#include "tiny_dnn/lossfunctions/loss_function.h"
-#include "tiny_dnn/activations/activation_function.h"
 
 namespace tiny_dnn {
 
 enum class content_type {
-    weights,  ///< save/load the weights
-    model,    ///< save/load the network architecture
-    weights_and_model  ///< save/load both the weights and the architecture
+  weights,           ///< save/load the weights
+  model,             ///< save/load the network architecture
+  weights_and_model  ///< save/load both the weights and the architecture
 };
 
-enum class file_format {
-    binary,
-    json
-};
+enum class file_format { binary, json };
 
 struct result {
-    result() : num_success(0), num_total(0) {}
+  result() : num_success(0), num_total(0) {}
 
-    float_t accuracy() const {
-        return float_t(num_success * 100.0 / num_total);
+  float_t accuracy() const { return float_t(num_success * 100.0 / num_total); }
+
+  template <typename Char, typename CharTraits>
+  void print_summary(std::basic_ostream<Char, CharTraits>& os) const {
+    os << "accuracy:" << accuracy() << "% (" << num_success << "/" << num_total
+       << ")" << std::endl;
+  }
+
+  template <typename Char, typename CharTraits>
+  void print_detail(std::basic_ostream<Char, CharTraits>& os) {
+    print_summary(os);
+    auto all_labels = labels();
+
+    os << std::setw(5) << "*"
+       << " ";
+    for (auto c : all_labels) os << std::setw(5) << c << " ";
+    os << std::endl;
+
+    for (auto r : all_labels) {
+      os << std::setw(5) << r << " ";
+      for (auto c : all_labels)
+        os << std::setw(5) << confusion_matrix[r][c] << " ";
+      os << std::endl;
     }
+  }
 
-    template <typename Char, typename CharTraits>
-    void print_summary(std::basic_ostream<Char, CharTraits>& os) const {
-      os << "accuracy:" << accuracy()
-         << "% (" << num_success << "/"
-         << num_total << ")" << std::endl;
+  std::set<label_t> labels() const {
+    std::set<label_t> all_labels;
+    for (auto r : confusion_matrix) {
+      all_labels.insert(r.first);
+      for (auto c : r.second) all_labels.insert(c.first);
     }
+    return all_labels;
+  }
 
-    template <typename Char, typename CharTraits>
-    void print_detail(std::basic_ostream<Char, CharTraits>& os) {
-        print_summary(os);
-        auto all_labels = labels();
-
-        os << std::setw(5) << "*" << " ";
-        for (auto c : all_labels)
-            os << std::setw(5) << c << " ";
-        os << std::endl;
-
-        for (auto r : all_labels) {
-            os << std::setw(5) << r << " ";
-            for (auto c : all_labels)
-                os << std::setw(5) << confusion_matrix[r][c] << " ";
-            os << std::endl;
-        }
-    }
-
-    std::set<label_t> labels() const {
-        std::set<label_t> all_labels;
-        for (auto r : confusion_matrix) {
-            all_labels.insert(r.first);
-            for (auto c : r.second)
-                all_labels.insert(c.first);
-        }
-        return all_labels;
-    }
-
-    int num_success;
-    int num_total;
-    std::map<label_t, std::map<label_t, int> > confusion_matrix;
+  int num_success;
+  int num_total;
+  std::map<label_t, std::map<label_t, int>> confusion_matrix;
 };
 
 enum grad_check_mode {
-    GRAD_CHECK_ALL,    ///< check all elements of weights
-    GRAD_CHECK_RANDOM  ///< check 10 randomly selected weights
+  GRAD_CHECK_ALL,    ///< check all elements of weights
+  GRAD_CHECK_RANDOM  ///< check 10 randomly selected weights
 };
 
 template <typename NetType>
 class network;
 
 template <typename Layer>
-network<sequential>& operator << (network<sequential>& n, Layer&& l);
+network<sequential>& operator<<(network<sequential>& n, Layer&& l);
 
 void construct_graph(network<graph>& graph,
                      const std::vector<std::shared_ptr<layer>>& inputs,
                      const std::vector<std::shared_ptr<layer>>& outputs);
-void construct_graph(network<graph>& graph,
-                     const std::vector<layer*>& inputs,
+void construct_graph(network<graph>& graph, const std::vector<layer*>& inputs,
                      const std::vector<layer*>& outputs);
 /**
  * A model of neural networks in tiny-dnn
@@ -105,7 +97,8 @@ void construct_graph(network<graph>& graph,
  * its gradients. Sequential representation describe network as linked list -
  * each layer has at most one predecessor and one successor layer.
  *
- * Two types of network is represented as network<sequential> and network<graph> class.
+ * Two types of network is represented as network<sequential> and network<graph>
+ *class.
  * These two classes have same API, except for its construction.
  *
  *     using namespace tiny_dnn;
@@ -128,869 +121,831 @@ void construct_graph(network<graph>& graph,
  *
  *
  * @param NetType specify the network is "sequential" or "graph".
- *                "sequential" means the network doesn't have any branch or merge pass.
+ *                "sequential" means the network doesn't have any branch or
+ *merge pass.
  *                if the network has branch/merge, "graph" can be used.
  **/
-template<typename NetType>
+template <typename NetType>
 class network {
  public:
-    typedef typename std::vector<layerptr_t>::iterator iterator;
-    typedef typename std::vector<layerptr_t>::const_iterator const_iterator;
+  typedef typename std::vector<layerptr_t>::iterator iterator;
+  typedef typename std::vector<layerptr_t>::const_iterator const_iterator;
 
-    explicit network(const std::string& name = "") : name_(name) {}
+  explicit network(const std::string& name = "") : name_(name) {}
 
-    /**
-     * name of the network
-     **/
-    std::string  name() const           { return name_; }
+  /**
+   * name of the network
+   **/
+  std::string name() const { return name_; }
 
-    /**
-     * explicitly initialize weights of all layers
-     **/
-    void         init_weight()          { net_.setup(true); }
+  /**
+   * explicitly initialize weights of all layers
+   **/
+  void init_weight() { net_.setup(true); }
 
-    /**
-     * executes forward-propagation and returns output
-     **/
-    vec_t        predict(const vec_t& in) { return fprop(in); }
+  /**
+   * executes forward-propagation and returns output
+   **/
+  vec_t predict(const vec_t& in) { return fprop(in); }
 
-    /**
-     * executes forward-propagation and returns output
-     **/
-    tensor_t predict(const tensor_t& in) { return fprop(in); }
+  /**
+   * executes forward-propagation and returns output
+   **/
+  tensor_t predict(const tensor_t& in) { return fprop(in); }
 
-    /**
-     * executes forward-propagation and returns maximum output
-     **/
-    float_t      predict_max_value(const vec_t& in) {
-        return fprop_max(in);
+  /**
+   * executes forward-propagation and returns maximum output
+   **/
+  float_t predict_max_value(const vec_t& in) { return fprop_max(in); }
+
+  /**
+   * executes forward-propagation and returns maximum output index
+   **/
+  label_t predict_label(const vec_t& in) { return fprop_max_index(in); }
+
+  /**
+   * executes forward-propagation and returns output
+   *
+   * @param in input value range(double[], std::vector<double>,
+   *std::list<double> etc)
+   **/
+  template <typename Range>
+  vec_t predict(const Range& in) {
+    using std::begin;  // for ADL
+    using std::end;
+    return predict(vec_t(begin(in), end(in)));
+  }
+
+  /**
+   * trains the network for a fixed number of epochs (for classification task)
+   *
+   * The difference between train and fit method is how to specify desired
+   * output.
+   * This method takes label_t argument and convert to target vector
+   * automatically.
+   * To train correctly, output dimension of last layer must be greater or equal
+   * to
+   * number of label-ids.
+   *
+   * @param optimizer          optimizing algorithm for training
+   * @param inputs             array of input data
+   * @param class_labels       array of label-id for each input data(0-origin)
+   * @param batch_size         number of samples per parameter update
+   * @param epoch              number of training epochs
+   * @param on_batch_enumerate callback for each mini-batch enumerate
+   * @param on_epoch_enumerate callback for each epoch
+   * @param reset_weights      set true if reset current network weights
+   * @param n_threads          number of tasks
+   * @param t_cost             target costs (leave to nullptr in order to assume
+   * equal cost for every target)
+   */
+  template <typename Error, typename Optimizer, typename OnBatchEnumerate,
+            typename OnEpochEnumerate>
+  bool train(Optimizer& optimizer, const std::vector<vec_t>& inputs,
+             const std::vector<label_t>& class_labels, size_t batch_size,
+             int epoch, OnBatchEnumerate on_batch_enumerate,
+             OnEpochEnumerate on_epoch_enumerate,
+             const bool reset_weights = false,
+             const int n_threads = CNN_TASK_SIZE,
+             const std::vector<vec_t>& t_cost = std::vector<vec_t>()) {
+    std::vector<tensor_t> input_tensor, output_tensor, t_cost_tensor;
+    normalize_tensor(inputs, input_tensor);
+    normalize_tensor(class_labels, output_tensor);
+    if (!t_cost.empty()) normalize_tensor(t_cost, t_cost_tensor);
+
+    return fit<Error>(optimizer, input_tensor, output_tensor, batch_size, epoch,
+                      on_batch_enumerate, on_epoch_enumerate, reset_weights,
+                      n_threads, t_cost_tensor);
+  }
+
+  /**
+  * trains the network for a fixed number of epochs to generate desired output.
+  *
+  * This method execute fixed number of training steps and invoke callbacks for
+  * each mini-batch/epochs.
+  * The network is trained to minimize given loss function(specified by template
+  * parameter).
+  *
+  * Shape of inputs and desired_outputs must be same to network inputs. For
+  * example, if your network
+  * has 2 input layers that takes N dimensional array, for each element of
+  * inputs must be [2xN]
+  * array.
+  *
+  * @code
+  * network<sequential> net;
+  * adagrad opt;
+  *
+  * net << layers::fc<tan_h>(2,3) << layers::fc<relu>(3,1);
+  *
+  * // 2training data, each data is float_t[2]
+  * std::vector<vec_t> data { { 1, 0 }, { 0, 2 } };
+  * std::vector<vec_t> out  {    { 2 },    { 1 } };
+  *
+  * net.fit<mse>(opt, data, out, 1, 1);
+  *
+  * // 2training data, each data is float_t[1][2]
+  * // this form is also valid
+  * std::vector<tensor_t> data2{ { { 1, 0 } }, { { 0, 2 } } };
+  * std::vector<tensor_t> out2 { {    { 2 } }, {    { 1 } } };
+  *
+  * net.fit<mse>(opt, data2, out2, 1, 1);
+  * @endcode
+  *
+  *
+  * @param optimizer          optimizing algorithm for training
+  * @param inputs             array of input data
+  * @param desired_outputs    array of desired output
+  * @param batch_size         number of samples per parameter update
+  * @param epoch              number of training epochs
+  * @param on_batch_enumerate callback for each mini-batch enumerate
+  * @param on_epoch_enumerate callback for each epoch
+  * @param reset_weights      set true if reset current network weights
+  * @param n_threads          number of tasks
+  * @param t_cost             target costs (leave to nullptr in order to assume
+  * equal cost for every target)
+  */
+  template <typename Error, typename Optimizer, typename OnBatchEnumerate,
+            typename OnEpochEnumerate, typename T, typename U>
+  bool fit(Optimizer& optimizer, const std::vector<T>& inputs,
+           const std::vector<U>& desired_outputs, size_t batch_size, int epoch,
+           OnBatchEnumerate on_batch_enumerate,
+           OnEpochEnumerate on_epoch_enumerate,
+           const bool reset_weights = false,
+           const int n_threads = CNN_TASK_SIZE,
+           const std::vector<U>& t_cost = std::vector<U>()) {
+    std::vector<tensor_t> input_tensor, output_tensor, t_cost_tensor;
+    normalize_tensor(inputs, input_tensor);
+    normalize_tensor(desired_outputs, output_tensor);
+    if (!t_cost.empty()) normalize_tensor(t_cost, t_cost_tensor);
+
+    return fit<Error>(optimizer, input_tensor, output_tensor, batch_size, epoch,
+                      on_batch_enumerate, on_epoch_enumerate, reset_weights,
+                      n_threads, t_cost_tensor);
+  }
+
+  /**
+   * @param optimizer          optimizing algorithm for training
+   * @param inputs             array of input data
+   * @param desired_outputs    array of desired output
+   * @param batch_size         number of samples per parameter update
+   * @param epoch              number of training epochs
+   **/
+  template <typename Error, typename Optimizer, typename T, typename U>
+  bool fit(Optimizer& optimizer, const std::vector<T>& inputs,
+           const std::vector<U>& desired_outputs, size_t batch_size = 1,
+           int epoch = 1) {
+    return fit<Error>(optimizer, inputs, desired_outputs, batch_size, epoch,
+                      nop, nop);
+  }
+
+  /**
+   * @param optimizer          optimizing algorithm for training
+   * @param inputs             array of input data
+   * @param class_labels       array of label-id for each input data(0-origin)
+   * @param batch_size         number of samples per parameter update
+   * @param epoch              number of training epochs
+   **/
+  template <typename Error, typename Optimizer>
+  bool train(Optimizer& optimizer, const std::vector<vec_t>& inputs,
+             const std::vector<label_t>& class_labels, size_t batch_size = 1,
+             int epoch = 1) {
+    return train<Error>(optimizer, inputs, class_labels, batch_size, epoch, nop,
+                        nop);
+  }
+
+  /**
+   * @deprecated use fit instead for regression task
+   **/
+  template <typename Error, typename Optimizer>
+  bool train(Optimizer& optimizer, const std::vector<vec_t>& in,
+             const std::vector<vec_t>& t, size_t batch_size = 1,
+             int epoch = 1) {
+    return fit<Error>(optimizer, in, t, batch_size, epoch, nop, nop);
+  }
+
+  /**
+   * set the netphase to train or test
+   * @param phase phase of network, could be train or test
+   */
+  void set_netphase(net_phase phase) {
+    for (auto n : net_) {
+      n->set_context(phase);
+    }
+  }
+
+  /**
+   * test and generate confusion-matrix for classification task
+   **/
+  result test(const std::vector<vec_t>& in, const std::vector<label_t>& t) {
+    result test_result;
+    set_netphase(net_phase::test);
+    for (size_t i = 0; i < in.size(); i++) {
+      const label_t predicted = fprop_max_index(in[i]);
+      const label_t actual = t[i];
+
+      if (predicted == actual) test_result.num_success++;
+      test_result.num_total++;
+      test_result.confusion_matrix[predicted][actual]++;
+    }
+    return test_result;
+  }
+
+  /**
+   * generate output for each input
+   **/
+  std::vector<vec_t> test(const std::vector<vec_t>& in) {
+    std::vector<vec_t> test_result(in.size());
+    set_netphase(net_phase::test);
+    for (size_t i = 0; i < in.size(); i++) {
+      test_result[i] = predict(in[i]);
+    }
+    return test_result;
+  }
+
+  /**
+   * calculate loss value (the smaller, the better) for regression task
+   **/
+  template <typename E>
+  float_t get_loss(const std::vector<vec_t>& in, const std::vector<vec_t>& t) {
+    float_t sum_loss = float_t(0);
+
+    for (size_t i = 0; i < in.size(); i++) {
+      const vec_t predicted = predict(in[i]);
+      sum_loss += E::f(predicted, t[i]);
+    }
+    return sum_loss;
+  }
+
+  /**
+   * calculate loss value (the smaller, the better) for regression task
+   **/
+  template <typename E, typename T>
+  float_t get_loss(const std::vector<T>& in, const std::vector<tensor_t>& t) {
+    float_t sum_loss = float_t(0);
+    std::vector<tensor_t> in_tensor;
+    normalize_tensor(in, in_tensor);
+
+    for (size_t i = 0; i < in.size(); i++) {
+      const tensor_t predicted = predict(in_tensor[i]);
+      for (size_t j = 0; j < predicted.size(); j++) {
+        sum_loss += E::f(predicted[j], t[i][j]);
+      }
+    }
+    return sum_loss;
+  }
+
+  /**
+  * checking gradients calculated by bprop
+  * detail information:
+  * http://ufldl.stanford.edu/wiki/index.php/Gradient_checking_and_advanced_optimization
+  **/
+  template <typename E>
+  bool gradient_check(const std::vector<tensor_t>& in,
+                      const std::vector<std::vector<label_t>>& t, float_t eps,
+                      grad_check_mode mode) {
+    assert(in.size() == t.size());
+
+    std::vector<tensor_t> v(t.size());
+    const cnn_size_t sample_count = t.size();
+    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+      net_.label2vec(&t[sample][0], t[sample].size(), &v[sample]);
     }
 
-    /**
-     * executes forward-propagation and returns maximum output index
-     **/
-    label_t      predict_label(const vec_t& in) {
-        return fprop_max_index(in);
-    }
+    for (auto current : net_) {  // ignore first input layer
+      if (current->weights().size() < 2) {
+        continue;
+      }
+      vec_t& w = *current->weights()[0];
+      vec_t& b = *current->weights()[1];
+      tensor_t& dw = (*current->weights_grads()[0]);
+      tensor_t& db = (*current->weights_grads()[1]);
 
-    /**
-     * executes forward-propagation and returns output
-     *
-     * @param in input value range(double[], std::vector<double>, std::list<double> etc)
-     **/
-    template <typename Range>
-    vec_t        predict(const Range& in) {
-        using std::begin;  // for ADL
-        using std::end;
-        return predict(vec_t(begin(in), end(in)));
-    }
+      if (w.empty()) continue;
 
-
-    /**
-     * trains the network for a fixed number of epochs (for classification task)
-     *
-     * The difference between train and fit method is how to specify desired output.
-     * This method takes label_t argument and convert to target vector automatically.
-     * To train correctly, output dimension of last layer must be greater or equal to
-     * number of label-ids.
-     *
-     * @param optimizer          optimizing algorithm for training
-     * @param inputs             array of input data
-     * @param class_labels       array of label-id for each input data(0-origin)
-     * @param batch_size         number of samples per parameter update
-     * @param epoch              number of training epochs
-     * @param on_batch_enumerate callback for each mini-batch enumerate
-     * @param on_epoch_enumerate callback for each epoch
-     * @param reset_weights      set true if reset current network weights
-     * @param n_threads          number of tasks
-     * @param t_cost             target costs (leave to nullptr in order to assume equal cost for every target)
-     */
-    template <typename Error, typename Optimizer,
-              typename OnBatchEnumerate, typename OnEpochEnumerate>
-    bool train(Optimizer&                  optimizer,
-               const std::vector<vec_t>&   inputs,
-               const std::vector<label_t>& class_labels,
-               size_t                      batch_size,
-               int                         epoch,
-               OnBatchEnumerate            on_batch_enumerate,
-               OnEpochEnumerate            on_epoch_enumerate,
-               const bool                  reset_weights = false,
-               const int                   n_threads = CNN_TASK_SIZE,
-               const std::vector<vec_t>&   t_cost = std::vector<vec_t>()) {
-        std::vector<tensor_t> input_tensor, output_tensor, t_cost_tensor;
-        normalize_tensor(inputs, input_tensor);
-        normalize_tensor(class_labels, output_tensor);
-        if (!t_cost.empty()) normalize_tensor(t_cost, t_cost_tensor);
-
-        return fit<Error>(optimizer, input_tensor, output_tensor, batch_size,
-                          epoch, on_batch_enumerate, on_epoch_enumerate,
-                          reset_weights, n_threads, t_cost_tensor);
-    }
-
-    /**
-    * trains the network for a fixed number of epochs to generate desired output.
-    *
-    * This method execute fixed number of training steps and invoke callbacks for each mini-batch/epochs.
-    * The network is trained to minimize given loss function(specified by template parameter).
-    *
-    * Shape of inputs and desired_outputs must be same to network inputs. For example, if your network
-    * has 2 input layers that takes N dimensional array, for each element of inputs must be [2xN]
-    * array.
-    *
-    * @code
-    * network<sequential> net;
-    * adagrad opt;
-    *
-    * net << layers::fc<tan_h>(2,3) << layers::fc<relu>(3,1);
-    *
-    * // 2training data, each data is float_t[2]
-    * std::vector<vec_t> data { { 1, 0 }, { 0, 2 } };
-    * std::vector<vec_t> out  {    { 2 },    { 1 } };
-    *
-    * net.fit<mse>(opt, data, out, 1, 1);
-    *
-    * // 2training data, each data is float_t[1][2]
-    * // this form is also valid
-    * std::vector<tensor_t> data2{ { { 1, 0 } }, { { 0, 2 } } };
-    * std::vector<tensor_t> out2 { {    { 2 } }, {    { 1 } } };
-    *
-    * net.fit<mse>(opt, data2, out2, 1, 1);
-    * @endcode
-    *
-    *
-    * @param optimizer          optimizing algorithm for training
-    * @param inputs             array of input data
-    * @param desired_outputs    array of desired output
-    * @param batch_size         number of samples per parameter update
-    * @param epoch              number of training epochs
-    * @param on_batch_enumerate callback for each mini-batch enumerate
-    * @param on_epoch_enumerate callback for each epoch
-    * @param reset_weights      set true if reset current network weights
-    * @param n_threads          number of tasks
-    * @param t_cost             target costs (leave to nullptr in order to assume equal cost for every target)
-    */
-    template <typename Error, typename Optimizer,
-              typename OnBatchEnumerate, typename OnEpochEnumerate,
-              typename T, typename U>
-    bool fit(Optimizer&            optimizer,
-             const std::vector<T>& inputs,
-             const std::vector<U>& desired_outputs,
-             size_t                batch_size,
-             int                   epoch,
-             OnBatchEnumerate      on_batch_enumerate,
-             OnEpochEnumerate      on_epoch_enumerate,
-             const bool            reset_weights = false,
-             const int             n_threads = CNN_TASK_SIZE,
-             const std::vector<U>& t_cost = std::vector<U>()) {
-        std::vector<tensor_t> input_tensor, output_tensor, t_cost_tensor;
-        normalize_tensor(inputs, input_tensor);
-        normalize_tensor(desired_outputs, output_tensor);
-        if (!t_cost.empty()) normalize_tensor(t_cost, t_cost_tensor);
-
-        return fit<Error>(optimizer, input_tensor, output_tensor, batch_size,
-                          epoch, on_batch_enumerate, on_epoch_enumerate,
-                          reset_weights, n_threads, t_cost_tensor);
-    }
-
-    /**
-     * @param optimizer          optimizing algorithm for training
-     * @param inputs             array of input data
-     * @param desired_outputs    array of desired output
-     * @param batch_size         number of samples per parameter update
-     * @param epoch              number of training epochs
-     **/
-    template<typename Error, typename Optimizer, typename T, typename U>
-    bool fit(Optimizer&            optimizer,
-             const std::vector<T>& inputs,
-             const std::vector<U>& desired_outputs,
-             size_t                batch_size = 1,
-             int                   epoch = 1) {
-        return fit<Error>(optimizer, inputs, desired_outputs,
-                          batch_size, epoch, nop, nop);
-    }
-
-    /**
-     * @param optimizer          optimizing algorithm for training
-     * @param inputs             array of input data
-     * @param class_labels       array of label-id for each input data(0-origin)
-     * @param batch_size         number of samples per parameter update
-     * @param epoch              number of training epochs
-     **/
-    template<typename Error, typename Optimizer>
-    bool train(Optimizer&                  optimizer,
-               const std::vector<vec_t>&   inputs,
-               const std::vector<label_t>& class_labels,
-               size_t                      batch_size = 1,
-               int                         epoch = 1) {
-        return train<Error>(optimizer, inputs, class_labels,
-                            batch_size, epoch, nop, nop);
-    }
-
-    /**
-     * @deprecated use fit instead for regression task
-     **/
-    template<typename Error, typename Optimizer>
-    bool train(Optimizer&                optimizer,
-               const std::vector<vec_t>& in,
-               const std::vector<vec_t>& t,
-               size_t                    batch_size = 1,
-               int                       epoch = 1) {
-        return fit<Error>(optimizer, in, t, batch_size, epoch, nop, nop);
-    }
-
-    /**
-     * set the netphase to train or test
-     * @param phase phase of network, could be train or test
-     */
-    void set_netphase(net_phase phase) {
-        for (auto n : net_) {
-            n->set_context(phase);
-        }
-    }
-
-    /**
-     * test and generate confusion-matrix for classification task
-     **/
-    result test(const std::vector<vec_t>& in, const std::vector<label_t>& t) {
-        result test_result;
-        set_netphase(net_phase::test);
-        for (size_t i = 0; i < in.size(); i++) {
-            const label_t predicted = fprop_max_index(in[i]);
-            const label_t actual = t[i];
-
-            if (predicted == actual) test_result.num_success++;
-            test_result.num_total++;
-            test_result.confusion_matrix[predicted][actual]++;
-        }
-        return test_result;
-    }
-
-    /**
-     * generate output for each input
-     **/
-    std::vector<vec_t> test(const std::vector<vec_t>& in) {
-        std::vector<vec_t> test_result(in.size());
-        set_netphase(net_phase::test);
-        for (size_t i = 0; i < in.size(); i++) {
-            test_result[i] = predict(in[i]);
-        }
-        return test_result;
-    }
-
-    /**
-     * calculate loss value (the smaller, the better) for regression task
-     **/
-    template <typename E>
-    float_t get_loss(const std::vector<vec_t>& in,
-                     const std::vector<vec_t>& t) {
-        float_t sum_loss = float_t(0);
-
-        for (size_t i = 0; i < in.size(); i++) {
-            const vec_t predicted = predict(in[i]);
-            sum_loss += E::f(predicted, t[i]);
-        }
-        return sum_loss;
-    }
-
-    /**
-     * calculate loss value (the smaller, the better) for regression task
-     **/
-    template <typename E, typename T>
-    float_t get_loss(const std::vector<T>& in, const std::vector<tensor_t>& t) {
-        float_t sum_loss = float_t(0);
-        std::vector<tensor_t> in_tensor;
-        normalize_tensor(in, in_tensor);
-
-        for (size_t i = 0; i < in.size(); i++) {
-            const tensor_t predicted = predict(in_tensor[i]);
-            for (size_t j = 0; j < predicted.size(); j++) {
-                sum_loss += E::f(predicted[j], t[i][j]);
+      switch (mode) {
+        case GRAD_CHECK_ALL:
+          for (int i = 0; i < static_cast<int>(w.size()); i++)
+            if (!calc_delta<E>(in, v, w, dw, i, eps)) {
+              return false;
             }
-        }
-        return sum_loss;
-    }
-
-    /**
-    * checking gradients calculated by bprop
-    * detail information:
-    * http://ufldl.stanford.edu/wiki/index.php/Gradient_checking_and_advanced_optimization
-    **/
-    template <typename E>
-    bool gradient_check(const std::vector<tensor_t>& in,
-                        const std::vector<std::vector<label_t>>& t,
-                        float_t eps, grad_check_mode mode) {
-        assert(in.size() == t.size());
-
-        std::vector<tensor_t> v(t.size());
-        const cnn_size_t sample_count = t.size();
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            net_.label2vec(&t[sample][0], t[sample].size(), &v[sample]);
-        }
-
-        for (auto current : net_) {  // ignore first input layer
-            if (current->weights().size() < 2) {
-                continue;
+          for (int i = 0; i < static_cast<int>(b.size()); i++)
+            if (!calc_delta<E>(in, v, b, db, i, eps)) {
+              return false;
             }
-            vec_t& w = *current->weights()[0];
-            vec_t& b = *current->weights()[1];
-            tensor_t& dw = (*current->weights_grads()[0]);
-            tensor_t& db = (*current->weights_grads()[1]);
-
-            if (w.empty()) continue;
-
-            switch (mode) {
-            case GRAD_CHECK_ALL:
-                for (int i = 0; i < static_cast<int>(w.size()); i++)
-                    if (!calc_delta<E>(in, v, w, dw, i, eps)) {
-                        return false;
-                    }
-                for (int i = 0; i < static_cast<int>(b.size()); i++)
-                    if (!calc_delta<E>(in, v, b, db, i, eps)) {
-                        return false;
-                    }
-                break;
-            case GRAD_CHECK_RANDOM:
-                for (int i = 0; i < 10; i++)
-                    if (!calc_delta<E>(in, v, w, dw, uniform_idx(w), eps)) {
-                        return false;
-                    }
-                for (int i = 0; i < 10; i++)
-                    if (!calc_delta<E>(in, v, b, db, uniform_idx(b), eps)) {
-                        return false;
-                    }
-                break;
-            default:
-                throw nn_error("unknown grad-check type");
+          break;
+        case GRAD_CHECK_RANDOM:
+          for (int i = 0; i < 10; i++)
+            if (!calc_delta<E>(in, v, w, dw, uniform_idx(w), eps)) {
+              return false;
             }
-        }
-        return true;
-    }
-
-    /**
-     * return number of layers
-     **/
-    size_t layer_size() const {
-        return net_.size();
-    }
-
-    /**
-     * @deprecated use layer_size() instread.
-     **/
-    size_t depth() const {
-        return layer_size();
-    }
-
-    /**
-     * return raw pointer of index-th layer
-     **/
-    const layer* operator[] (size_t index) const {
-        return net_[index];
-    }
-
-    /**
-     * return raw pointer of index-th layer
-     **/
-    layer* operator[] (size_t index) {
-        return net_[index];
-    }
-
-    /**
-     * return index-th layer as <T>
-     * throw nn_error if index-th layer cannot be converted to T
-     **/
-    template <typename T>
-    const T& at(size_t index) const {
-        return net_.template at<T>(index);
-    }
-
-    template <typename T>
-    T& at(size_t index) {
-        return net_.template at<T>(index);
-    }
-
-    /**
-     * return total number of elements of output data
-     **/
-    cnn_size_t out_data_size() const {
-        return net_.out_data_size();
-    }
-
-    /**
-     * return total number of elements of input data
-     */
-    cnn_size_t in_data_size() const {
-        return net_.in_data_size();
-    }
-
-    /**
-    * set weight initializer to all layers
-    **/
-    template <typename WeightInit>
-    network& weight_init(const WeightInit& f) {
-        auto ptr = std::make_shared<WeightInit>(f);
-        for (auto& l : net_)
-            l->weight_init(ptr);
-        return *this;
-    }
-
-    /**
-    * set bias initializer to all layers
-    **/
-    template <typename BiasInit>
-    network& bias_init(const BiasInit& f) {
-        auto ptr = std::make_shared<BiasInit>(f);
-        for (auto& l : net_)
-            l->bias_init(ptr);
-        return *this;
-    }
-
-    /**
-     * returns if 2 networks have almost(<eps) the same weights
-     **/
-    template <typename T>
-    bool has_same_weights(const network<T>& rhs, float_t eps) const {
-        auto first1 = net_.begin();
-        auto first2 = rhs.net_.begin();
-        auto last1 = net_.end();
-        auto last2 = rhs.net_.end();
-
-        for (; first1 != last1 && first2 != last2; ++first1, ++first2)
-            if (!(*first1)->has_same_weights(**first2, eps)) return false;
-        return true;
-    }
-
-    iterator begin() { return net_.begin(); }
-    iterator end() { return net_.end(); }
-    const_iterator begin() const { return net_.begin(); }
-    const_iterator end() const { return net_.end(); }
-
-    void load(const std::string& filename,
-              content_type       what     = content_type::weights_and_model,
-              file_format        format   = file_format::binary) {
-        std::ifstream ifs(filename.c_str(), std::ios::binary | std::ios::in);
-        if (ifs.fail() || ifs.bad())
-            throw nn_error("failed to open:" + filename);
-
-        switch (format) {
-            case file_format::binary:
-            {
-                cereal::BinaryInputArchive bi(ifs);
-                from_archive(bi, what);
+          for (int i = 0; i < 10; i++)
+            if (!calc_delta<E>(in, v, b, db, uniform_idx(b), eps)) {
+              return false;
             }
-            break;
-            case file_format::json:
-            {
-                cereal::JSONInputArchive ji(ifs);
-                from_archive(ji, what);
-            }
-            break;
-            default:
-                throw nn_error("invalid serialization format");
-        }
+          break;
+        default:
+          throw nn_error("unknown grad-check type");
+      }
     }
+    return true;
+  }
 
-    void save(const std::string& filename,
-              content_type       what     = content_type::weights_and_model,
-              file_format        format   = file_format::binary) const {
-        std::ofstream ofs(filename.c_str(), std::ios::binary | std::ios::out);
-        if (ofs.fail() || ofs.bad())
-            throw nn_error("failed to open:" + filename);
+  /**
+   * return number of layers
+   **/
+  size_t layer_size() const { return net_.size(); }
 
-        switch (format) {
-            case file_format::binary:
-            {
-                cereal::BinaryOutputArchive bo(ofs);
-                to_archive(bo, what);
-            }
-            break;
-            case file_format::json:
-            {
-                cereal::JSONOutputArchive jo(ofs);
-                to_archive(jo, what);
-            }
-            break;
-            default:
-                throw nn_error("invalid serialization format");
-        }
+  /**
+   * @deprecated use layer_size() instread.
+   **/
+  size_t depth() const { return layer_size(); }
+
+  /**
+   * return raw pointer of index-th layer
+   **/
+  const layer* operator[](size_t index) const { return net_[index]; }
+
+  /**
+   * return raw pointer of index-th layer
+   **/
+  layer* operator[](size_t index) { return net_[index]; }
+
+  /**
+   * return index-th layer as <T>
+   * throw nn_error if index-th layer cannot be converted to T
+   **/
+  template <typename T>
+  const T& at(size_t index) const {
+    return net_.template at<T>(index);
+  }
+
+  template <typename T>
+  T& at(size_t index) {
+    return net_.template at<T>(index);
+  }
+
+  /**
+   * return total number of elements of output data
+   **/
+  cnn_size_t out_data_size() const { return net_.out_data_size(); }
+
+  /**
+   * return total number of elements of input data
+   */
+  cnn_size_t in_data_size() const { return net_.in_data_size(); }
+
+  /**
+  * set weight initializer to all layers
+  **/
+  template <typename WeightInit>
+  network& weight_init(const WeightInit& f) {
+    auto ptr = std::make_shared<WeightInit>(f);
+    for (auto& l : net_) l->weight_init(ptr);
+    return *this;
+  }
+
+  /**
+  * set bias initializer to all layers
+  **/
+  template <typename BiasInit>
+  network& bias_init(const BiasInit& f) {
+    auto ptr = std::make_shared<BiasInit>(f);
+    for (auto& l : net_) l->bias_init(ptr);
+    return *this;
+  }
+
+  /**
+   * returns if 2 networks have almost(<eps) the same weights
+   **/
+  template <typename T>
+  bool has_same_weights(const network<T>& rhs, float_t eps) const {
+    auto first1 = net_.begin();
+    auto first2 = rhs.net_.begin();
+    auto last1 = net_.end();
+    auto last2 = rhs.net_.end();
+
+    for (; first1 != last1 && first2 != last2; ++first1, ++first2)
+      if (!(*first1)->has_same_weights(**first2, eps)) return false;
+    return true;
+  }
+
+  iterator begin() { return net_.begin(); }
+  iterator end() { return net_.end(); }
+  const_iterator begin() const { return net_.begin(); }
+  const_iterator end() const { return net_.end(); }
+
+  void load(const std::string& filename,
+            content_type what = content_type::weights_and_model,
+            file_format format = file_format::binary) {
+    std::ifstream ifs(filename.c_str(), std::ios::binary | std::ios::in);
+    if (ifs.fail() || ifs.bad()) throw nn_error("failed to open:" + filename);
+
+    switch (format) {
+      case file_format::binary: {
+        cereal::BinaryInputArchive bi(ifs);
+        from_archive(bi, what);
+      } break;
+      case file_format::json: {
+        cereal::JSONInputArchive ji(ifs);
+        from_archive(ji, what);
+      } break;
+      default:
+        throw nn_error("invalid serialization format");
     }
+  }
 
-    /**
-     * save the network architecture as json string
-     **/
-    std::string to_json() const {
-        std::stringstream ss;
-        {
-            cereal::JSONOutputArchive oa(ss);
-            to_archive(oa, content_type::model);
-        }
-        return ss.str();
+  void save(const std::string& filename,
+            content_type what = content_type::weights_and_model,
+            file_format format = file_format::binary) const {
+    std::ofstream ofs(filename.c_str(), std::ios::binary | std::ios::out);
+    if (ofs.fail() || ofs.bad()) throw nn_error("failed to open:" + filename);
+
+    switch (format) {
+      case file_format::binary: {
+        cereal::BinaryOutputArchive bo(ofs);
+        to_archive(bo, what);
+      } break;
+      case file_format::json: {
+        cereal::JSONOutputArchive jo(ofs);
+        to_archive(jo, what);
+      } break;
+      default:
+        throw nn_error("invalid serialization format");
     }
+  }
 
-    /**
-     * load the network architecture from json string
-     **/
-    void from_json(const std::string& json_string) {
-        std::stringstream ss;
-        ss << json_string;
-        cereal::JSONInputArchive ia(ss);
-        from_archive(ia, content_type::model);
+  /**
+   * save the network architecture as json string
+   **/
+  std::string to_json() const {
+    std::stringstream ss;
+    {
+      cereal::JSONOutputArchive oa(ss);
+      to_archive(oa, content_type::model);
     }
+    return ss.str();
+  }
 
-    ///< @deprecated use save(filename,target,format) instead.
-    void save(std::ostream& os) const {
-        os.precision(std::numeric_limits<tiny_dnn::float_t>::digits10);
-        net_.save(os);
+  /**
+   * load the network architecture from json string
+   **/
+  void from_json(const std::string& json_string) {
+    std::stringstream ss;
+    ss << json_string;
+    cereal::JSONInputArchive ia(ss);
+    from_archive(ia, content_type::model);
+  }
+
+  ///< @deprecated use save(filename,target,format) instead.
+  void save(std::ostream& os) const {
+    os.precision(std::numeric_limits<tiny_dnn::float_t>::digits10);
+    net_.save(os);
+  }
+
+  ///< @deprecated use load(filename,target,format) instead.
+  void load(std::istream& is) {
+    is.precision(std::numeric_limits<tiny_dnn::float_t>::digits10);
+    net_.load(is);
+  }
+
+  /**
+  * load network weights from filepath, 30 times faster than stream reading
+  * @deprecated use load_weights instead.
+  **/
+  void fast_load(const char* filepath) {
+    FILE* stream = fopen(filepath, "r");
+    std::vector<float_t> data;
+    double temp;
+    while (fscanf(stream, "%lf", &temp) > 0) data.push_back(float_t(temp));
+    fclose(stream);
+
+    net_.load(data);
+  }
+
+  template <typename OutputArchive>
+  void to_archive(OutputArchive& ar,
+                  content_type what = content_type::weights_and_model) const {
+    if (what == content_type::model ||
+        what == content_type::weights_and_model) {
+      net_.save_model(ar);
     }
-
-    ///< @deprecated use load(filename,target,format) instead.
-    void load(std::istream& is) {
-        is.precision(std::numeric_limits<tiny_dnn::float_t>::digits10);
-        net_.load(is);
+    if (what == content_type::weights ||
+        what == content_type::weights_and_model) {
+      net_.save_weights(ar);
     }
+  }
 
-    /**
-    * load network weights from filepath, 30 times faster than stream reading
-    * @deprecated use load_weights instead.
-    **/
-    void fast_load(const char* filepath) {
-        FILE* stream = fopen(filepath, "r");
-        std::vector<float_t> data;
-        double temp;
-        while (fscanf(stream, "%lf", &temp) > 0)
-            data.push_back(float_t(temp));
-        fclose(stream);
-
-        net_.load(data);
+  template <typename InputArchive>
+  void from_archive(InputArchive& ar,
+                    content_type what = content_type::weights_and_model) {
+    if (what == content_type::model ||
+        what == content_type::weights_and_model) {
+      net_.load_model(ar);
     }
-
-    template <typename OutputArchive>
-    void to_archive(OutputArchive& ar,
-                    content_type what = content_type::weights_and_model) const {
-        if (what == content_type::model ||
-            what == content_type::weights_and_model) {
-            net_.save_model(ar);
-        }
-        if (what == content_type::weights ||
-            what == content_type::weights_and_model) {
-            net_.save_weights(ar);
-        }
+    if (what == content_type::weights ||
+        what == content_type::weights_and_model) {
+      net_.load_weights(ar);
     }
-
-    template <typename InputArchive>
-    void from_archive(InputArchive& ar,
-                      content_type what = content_type::weights_and_model) {
-        if (what == content_type::model ||
-            what == content_type::weights_and_model) {
-            net_.load_model(ar);
-        }
-        if (what == content_type::weights ||
-            what == content_type::weights_and_model) {
-            net_.load_weights(ar);
-        }
-    }
+  }
 
  protected:
-    float_t fprop_max(const vec_t& in, int idx = 0) {
-        const vec_t& prediction = fprop(in, idx);
-        return *std::max_element(std::begin(prediction), std::end(prediction));
-    }
+  float_t fprop_max(const vec_t& in, int idx = 0) {
+    const vec_t& prediction = fprop(in, idx);
+    return *std::max_element(std::begin(prediction), std::end(prediction));
+  }
 
-    label_t fprop_max_index(const vec_t& in) {
-        return label_t(max_index(fprop(in)));
-    }
+  label_t fprop_max_index(const vec_t& in) {
+    return label_t(max_index(fprop(in)));
+  }
 
  private:
-    template <typename Layer>
-    friend network<sequential>& operator << (network<sequential>& n, Layer&& l);
+  template <typename Layer>
+  friend network<sequential>& operator<<(network<sequential>& n, Layer&& l);
 
-    friend void construct_graph(network<graph>& graph,
-        const std::vector<std::shared_ptr<layer>>& inputs,
-        const std::vector<std::shared_ptr<layer>>& outputs);
+  friend void construct_graph(
+      network<graph>& graph, const std::vector<std::shared_ptr<layer>>& inputs,
+      const std::vector<std::shared_ptr<layer>>& outputs);
 
-    friend void construct_graph(network<graph>& graph,
-        const std::vector<layer*>& inputs,
-        const std::vector<layer*>& outputs);
+  friend void construct_graph(network<graph>& graph,
+                              const std::vector<layer*>& inputs,
+                              const std::vector<layer*>& outputs);
 
-    template <typename Error, typename Optimizer,
-              typename OnBatchEnumerate, typename OnEpochEnumerate>
-    bool fit(Optimizer&                   optimizer,
-        const std::vector<tensor_t>& inputs,
-        const std::vector<tensor_t>& desired_outputs,
-        size_t                       batch_size,
-        int                          epoch,
-        OnBatchEnumerate             on_batch_enumerate,
-        OnEpochEnumerate             on_epoch_enumerate,
-        const bool                   reset_weights = false,
-        const int                    n_threads = CNN_TASK_SIZE,
-        const std::vector<tensor_t>& t_cost = std::vector<tensor_t>()) {
-        // check_training_data(in, t);
-        check_target_cost_matrix(desired_outputs, t_cost);
-        set_netphase(net_phase::train);
-        net_.setup(reset_weights);
+  template <typename Error, typename Optimizer, typename OnBatchEnumerate,
+            typename OnEpochEnumerate>
+  bool fit(Optimizer& optimizer, const std::vector<tensor_t>& inputs,
+           const std::vector<tensor_t>& desired_outputs, size_t batch_size,
+           int epoch, OnBatchEnumerate on_batch_enumerate,
+           OnEpochEnumerate on_epoch_enumerate,
+           const bool reset_weights = false,
+           const int n_threads = CNN_TASK_SIZE,
+           const std::vector<tensor_t>& t_cost = std::vector<tensor_t>()) {
+    // check_training_data(in, t);
+    check_target_cost_matrix(desired_outputs, t_cost);
+    set_netphase(net_phase::train);
+    net_.setup(reset_weights);
 
-        for (auto n : net_)
-            n->set_parallelize(true);
-        optimizer.reset();
-        for (int iter = 0; iter < epoch; iter++) {
-            for (size_t i = 0; i < inputs.size(); i += batch_size) {
-                train_once<Error>(optimizer, &inputs[i], &desired_outputs[i],
-                    static_cast<int>(std::min(batch_size, inputs.size() - i)),
-                    n_threads,
-                    get_target_cost_sample_pointer(t_cost, i));
-                on_batch_enumerate();
+    for (auto n : net_) n->set_parallelize(true);
+    optimizer.reset();
+    for (int iter = 0; iter < epoch; iter++) {
+      for (size_t i = 0; i < inputs.size(); i += batch_size) {
+        train_once<Error>(
+            optimizer, &inputs[i], &desired_outputs[i],
+            static_cast<int>(std::min(batch_size, inputs.size() - i)),
+            n_threads, get_target_cost_sample_pointer(t_cost, i));
+        on_batch_enumerate();
 
-                /* if (i % 100 == 0 && layers_.is_exploded()) {
-                  std::cout << "[Warning]Detected infinite value in weight. stop learning." << std::endl;
-                    return false;
-                } */
-            }
-            on_epoch_enumerate();
-        }
-        set_netphase(net_phase::test);
-        return true;
+        /* if (i % 100 == 0 && layers_.is_exploded()) {
+          std::cout << "[Warning]Detected infinite value in weight. stop
+        learning." << std::endl;
+            return false;
+        } */
+      }
+      on_epoch_enumerate();
+    }
+    set_netphase(net_phase::test);
+    return true;
+  }
+
+  /**
+   * train on one minibatch
+   *
+   * @param size is the number of data points to use in this batch
+   */
+  template <typename E, typename Optimizer>
+  void train_once(Optimizer& optimizer, const tensor_t* in, const tensor_t* t,
+                  int size, const int nbThreads, const tensor_t* t_cost) {
+    if (size == 1) {
+      bprop<E>(fprop(in[0]), t[0], t_cost ? t_cost[0] : tensor_t());
+      net_.update_weights(&optimizer, 1);
+    } else {
+      train_onebatch<E>(optimizer, in, t, size, nbThreads, t_cost);
+    }
+  }
+
+  /**
+   * trains on one minibatch, i.e. runs forward and backward propagation to
+   * calculate
+   * the gradient of the loss function with respect to the network parameters
+   * (weights),
+   * then calls the optimizer algorithm to update the weights
+   *
+   * @param batch_size the number of data points to use in this batch
+   */
+  template <typename E, typename Optimizer>
+  void train_onebatch(Optimizer& optimizer, const tensor_t* in,
+                      const tensor_t* t, int batch_size, const int num_tasks,
+                      const tensor_t* t_cost) {
+    std::vector<tensor_t> in_batch(&in[0], &in[0] + batch_size);
+    std::vector<tensor_t> t_batch(&t[0], &t[0] + batch_size);
+    std::vector<tensor_t> t_cost_batch =
+        t_cost ? std::vector<tensor_t>(&t_cost[0], &t_cost[0] + batch_size)
+               : std::vector<tensor_t>();
+
+    bprop<E>(fprop(in_batch), t_batch, t_cost_batch);
+    net_.update_weights(&optimizer, batch_size);
+  }
+
+  vec_t fprop(const vec_t& in) {
+    if (in.size() != (size_t)in_data_size()) data_mismatch(**net_.begin(), in);
+
+    return fprop(std::vector<vec_t>{in})[0];
+  }
+
+  // convenience wrapper for the function below
+  std::vector<vec_t> fprop(const std::vector<vec_t>& in) {
+    return fprop(std::vector<tensor_t>{in})[0];
+  }
+
+  std::vector<tensor_t> fprop(const std::vector<tensor_t>& in) {
+    return net_.forward(in);
+  }
+
+  //    template <typename E>
+  //    float_t get_loss(const vec_t& out, const vec_t& t) {
+  //        assert(out.size() == t.size());
+  //        return E::f(out, t);
+  //    }
+
+  template <typename E>
+  bool calc_delta(const std::vector<tensor_t>& in,
+                  const std::vector<tensor_t>& v, vec_t& w, tensor_t& dw,
+                  int check_index, double eps) {
+    static const float_t delta =
+        std::sqrt(std::numeric_limits<float_t>::epsilon());
+
+    assert(in.size() == v.size());
+
+    const cnn_size_t sample_count = in.size();
+
+    assert(sample_count > 0);
+
+    // at the moment, channel count must be 1
+    assert(in[0].size() == 1);
+    assert(v[0].size() == 1);
+
+    // clear previous results, if any
+    for (vec_t& dw_sample : dw) {
+      std::fill(dw_sample.begin(), dw_sample.end(), float_t(0));
     }
 
-    /**
-     * train on one minibatch
-     *
-     * @param size is the number of data points to use in this batch
-     */
-    template <typename E, typename Optimizer>
-    void train_once(Optimizer& optimizer,
-                    const tensor_t* in,
-                    const tensor_t* t,
-                    int size,
-                    const int nbThreads,
-                    const tensor_t* t_cost) {
-        if (size == 1) {
-            bprop<E>(fprop(in[0]), t[0], t_cost ? t_cost[0] : tensor_t());
-            net_.update_weights(&optimizer, 1);
-        } else {
-            train_onebatch<E>(optimizer, in, t, size, nbThreads, t_cost);
-        }
+    // calculate dw/dE by numeric
+    float_t prev_w = w[check_index];
+
+    float_t f_p = float_t(0);
+    w[check_index] = prev_w + delta;
+    for (cnn_size_t i = 0; i < sample_count; i++) {
+      f_p += get_loss<E>(in[i], v[i]);
     }
 
-    /**
-     * trains on one minibatch, i.e. runs forward and backward propagation to calculate
-     * the gradient of the loss function with respect to the network parameters (weights),
-     * then calls the optimizer algorithm to update the weights
-     *
-     * @param batch_size the number of data points to use in this batch
-     */
-    template <typename E, typename Optimizer>
-    void train_onebatch(Optimizer&      optimizer,
-                        const tensor_t* in,
-                        const tensor_t* t,
-                        int             batch_size,
-                        const int       num_tasks,
-                        const tensor_t* t_cost) {
-        std::vector<tensor_t> in_batch(&in[0], &in[0] + batch_size);
-        std::vector<tensor_t> t_batch(&t[0], &t[0] + batch_size);
-        std::vector<tensor_t> t_cost_batch = t_cost
-            ? std::vector<tensor_t>(&t_cost[0], &t_cost[0] + batch_size)
-            : std::vector<tensor_t>();
-
-        bprop<E>(fprop(in_batch), t_batch, t_cost_batch);
-        net_.update_weights(&optimizer, batch_size);
+    float_t f_m = float_t(0);
+    w[check_index] = prev_w - delta;
+    for (cnn_size_t i = 0; i < sample_count; i++) {
+      f_m += get_loss<E>(in[i], v[i]);
     }
 
-    vec_t fprop(const vec_t& in) {
-        if (in.size() != (size_t)in_data_size())
-            data_mismatch(**net_.begin(), in);
+    float_t delta_by_numerical = (f_p - f_m) / (float_t(2) * delta);
+    w[check_index] = prev_w;
 
-        return fprop(std::vector<vec_t>{ in })[0];
+    // calculate dw/dE by bprop
+    bprop<E>(fprop(in), v, std::vector<tensor_t>());
+
+    float_t delta_by_bprop = 0;
+    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+      delta_by_bprop += dw[sample][check_index];
+    }
+    net_.clear_grads();
+
+    return std::abs(delta_by_bprop - delta_by_numerical) <= eps;
+  }
+
+  // convenience wrapper for the function below
+  template <typename E>
+  void bprop(const std::vector<vec_t>& out, const std::vector<vec_t>& t,
+             const std::vector<vec_t>& t_cost) {
+    bprop<E>(std::vector<tensor_t>{out}, std::vector<tensor_t>{t},
+             std::vector<tensor_t>{t_cost});
+  }
+
+  template <typename E>
+  void bprop(const std::vector<tensor_t>& out, const std::vector<tensor_t>& t,
+             const std::vector<tensor_t>& t_cost) {
+    std::vector<tensor_t> delta = gradient<E>(out, t, t_cost);
+    net_.backward(delta);
+  }
+
+  void check_t(size_t i, label_t t, cnn_size_t dim_out) {
+    if (t >= dim_out) {
+      std::ostringstream os;
+      os << format_str("t[%u]=%u, dim(net output)=%u\n", i, t, dim_out);
+      os << "in classification task, dim(net output) ";
+      os << "must be greater than max class id.\n";
+      if (dim_out == 1) {
+        os << "\n(for regression, use vector<vec_t> ";
+        os << "instead of vector<label_t> for training signal)\n";
+      }
+
+      throw nn_error("output dimension mismatch!\n " + os.str());
+    }
+  }
+
+  void check_t(size_t i, const vec_t& t, cnn_size_t dim_out) {
+    if (t.size() != dim_out) {
+      throw nn_error(
+          format_str("output dimension mismatch!\n dim(target[%u])=%u, "
+                     "dim(network output size=%u",
+                     i, t.size(), dim_out));
+    }
+  }
+
+  template <typename T>
+  void check_training_data(const std::vector<vec_t>& in,
+                           const std::vector<T>& t) {
+    cnn_size_t dim_in = in_data_size();
+    cnn_size_t dim_out = out_data_size();
+
+    if (in.size() != t.size()) {
+      throw nn_error("size of training data must be equal to label data");
     }
 
-    // convenience wrapper for the function below
-    std::vector<vec_t> fprop(const std::vector<vec_t>& in) {
-        return fprop(std::vector<tensor_t>{ in })[0];
+    size_t num = in.size();
+
+    for (size_t i = 0; i < num; i++) {
+      if (in[i].size() != dim_in) {
+        throw nn_error(
+            format_str("input dimension mismatch!\n dim(data[%u])=%d, "
+                       "dim(network input)=%u",
+                       i, in[i].size(), dim_in));
+      }
+      check_t(i, t[i], dim_out);
     }
+  }
 
-    std::vector<tensor_t> fprop(const std::vector<tensor_t>& in) {
-        return net_.forward(in);
+  void check_target_cost_matrix(const std::vector<tensor_t>& t,
+                                const std::vector<tensor_t>& t_cost) {
+    if (!t_cost.empty()) {
+      if (t.size() != t_cost.size()) {
+        throw nn_error(
+            "if target cost is supplied, "
+            "its length must equal that of target data");
+      }
+
+      for (size_t i = 0, end = t.size(); i < end; i++) {
+        check_target_cost_element(t[i], t_cost[i]);
+      }
     }
+  }
 
-//    template <typename E>
-//    float_t get_loss(const vec_t& out, const vec_t& t) {
-//        assert(out.size() == t.size());
-//        return E::f(out, t);
-//    }
-
-    template <typename E>
-    bool calc_delta(const std::vector<tensor_t>& in,
-                    const std::vector<tensor_t>& v,
-                    vec_t& w, tensor_t& dw, int check_index, double eps) {
-        static const float_t delta = std::sqrt(
-            std::numeric_limits<float_t>::epsilon());
-
-        assert(in.size() == v.size());
-
-        const cnn_size_t sample_count = in.size();
-
-        assert(sample_count > 0);
-
-        // at the moment, channel count must be 1
-        assert(in[0].size() == 1);
-        assert(v[0].size() == 1);
-
-        // clear previous results, if any
-        for (vec_t& dw_sample : dw) {
-            std::fill(dw_sample.begin(), dw_sample.end(), float_t(0));
-        }
-
-        // calculate dw/dE by numeric
-        float_t prev_w = w[check_index];
-
-        float_t f_p = float_t(0);
-        w[check_index] = prev_w + delta;
-        for (cnn_size_t i = 0; i < sample_count; i++) {
-            f_p += get_loss<E>(in[i], v[i]);
-        }
-
-        float_t f_m = float_t(0);
-        w[check_index] = prev_w - delta;
-        for (cnn_size_t i = 0; i < sample_count; i++) {
-            f_m += get_loss<E>(in[i], v[i]);
-        }
-
-        float_t delta_by_numerical = (f_p - f_m) / (float_t(2) * delta);
-        w[check_index] = prev_w;
-
-        // calculate dw/dE by bprop
-        bprop<E>(fprop(in), v, std::vector<tensor_t>());
-
-        float_t delta_by_bprop = 0;
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            delta_by_bprop += dw[sample][check_index];
-        }
-        net_.clear_grads();
-
-        return std::abs(delta_by_bprop - delta_by_numerical) <= eps;
+  // regression
+  void check_target_cost_element(const vec_t& t, const vec_t& t_cost) {
+    if (t.size() != t_cost.size()) {
+      throw nn_error(
+          "if target cost is supplied for a regression task, "
+          "its shape must be identical to the target data");
     }
-
-    // convenience wrapper for the function below
-    template <typename E>
-    void bprop(const std::vector<vec_t>& out,
-               const std::vector<vec_t>& t, const std::vector<vec_t>& t_cost) {
-        bprop<E>(std::vector<tensor_t>{out},
-                 std::vector<tensor_t>{t}, std::vector<tensor_t>{t_cost});
+  }
+  void check_target_cost_element(const tensor_t& t, const tensor_t& t_cost) {
+    if (t.size() != t_cost.size()) {
+      throw nn_error(
+          "if target cost is supplied for a regression task, "
+          "its shape must be identical to the target data");
     }
+    for (size_t i = 0; i < t.size(); i++)
+      check_target_cost_element(t[i], t_cost[i]);
+  }
 
-    template <typename E>
-    void bprop(const std::vector<tensor_t>& out,
-               const std::vector<tensor_t>& t,
-               const std::vector<tensor_t>& t_cost) {
-        std::vector<tensor_t> delta = gradient<E>(out, t, t_cost);
-        net_.backward(delta);
+  const tensor_t* get_target_cost_sample_pointer(
+      const std::vector<tensor_t>& t_cost, size_t i) {
+    if (!t_cost.empty()) {
+      assert(i < t_cost.size());
+      return &(t_cost[i]);
+    } else {
+      return nullptr;
     }
+  }
 
-    void check_t(size_t i, label_t t, cnn_size_t dim_out) {
-        if (t >= dim_out) {
-            std::ostringstream os;
-            os << format_str("t[%u]=%u, dim(net output)=%u\n", i, t, dim_out);
-            os << "in classification task, dim(net output) ";
-            os << "must be greater than max class id.\n";
-            if (dim_out == 1) {
-                os << "\n(for regression, use vector<vec_t> ";
-                os << "instead of vector<label_t> for training signal)\n";
-            }
+  void normalize_tensor(const std::vector<tensor_t>& inputs,
+                        std::vector<tensor_t>& normalized) {
+    normalized = inputs;
+  }
 
-            throw nn_error("output dimension mismatch!\n " + os.str());
-        }
-    }
+  void normalize_tensor(const std::vector<vec_t>& inputs,
+                        std::vector<tensor_t>& normalized) {
+    normalized.reserve(inputs.size());
+    for (size_t i = 0; i < inputs.size(); i++)
+      normalized.emplace_back(tensor_t{inputs[i]});
+  }
 
-    void check_t(size_t i, const vec_t& t, cnn_size_t dim_out) {
-        if (t.size() != dim_out) {
-            throw nn_error(format_str(
-                "output dimension mismatch!\n dim(target[%u])=%u, "
-                "dim(network output size=%u", i, t.size(), dim_out));
-        }
-    }
+  void normalize_tensor(const std::vector<label_t>& inputs,
+                        std::vector<tensor_t>& normalized) {
+    std::vector<vec_t> vec;
+    normalized.reserve(inputs.size());
+    net_.label2vec(&inputs[0], inputs.size(), &vec);
+    normalize_tensor(vec, normalized);
+  }
 
-    template <typename T>
-    void check_training_data(const std::vector<vec_t>& in,
-                             const std::vector<T>& t) {
-        cnn_size_t dim_in = in_data_size();
-        cnn_size_t dim_out = out_data_size();
-
-        if (in.size() != t.size()) {
-            throw nn_error("size of training data must be equal to label data");
-        }
-
-        size_t num = in.size();
-
-        for (size_t i = 0; i < num; i++) {
-            if (in[i].size() != dim_in) {
-                throw nn_error(format_str(
-                    "input dimension mismatch!\n dim(data[%u])=%d, "
-                    "dim(network input)=%u", i, in[i].size(), dim_in));
-            }
-            check_t(i, t[i], dim_out);
-        }
-    }
-
-    void check_target_cost_matrix(const std::vector<tensor_t>& t,
-                                  const std::vector<tensor_t>& t_cost) {
-        if (!t_cost.empty()) {
-            if (t.size() != t_cost.size()) {
-                throw nn_error("if target cost is supplied, "
-                               "its length must equal that of target data");
-            }
-
-            for (size_t i = 0, end = t.size(); i < end; i++) {
-                check_target_cost_element(t[i], t_cost[i]);
-            }
-        }
-    }
-
-    // regression
-    void check_target_cost_element(const vec_t& t, const vec_t& t_cost) {
-        if (t.size() != t_cost.size()) {
-            throw nn_error("if target cost is supplied for a regression task, "
-                           "its shape must be identical to the target data");
-        }
-    }
-    void check_target_cost_element(const tensor_t& t, const tensor_t& t_cost) {
-        if (t.size() != t_cost.size()) {
-            throw nn_error("if target cost is supplied for a regression task, "
-                           "its shape must be identical to the target data");
-        }
-        for (size_t i = 0; i < t.size(); i++)
-            check_target_cost_element(t[i], t_cost[i]);
-    }
-
-    const tensor_t* get_target_cost_sample_pointer(
-        const std::vector<tensor_t>& t_cost, size_t i) {
-        if (!t_cost.empty()) {
-            assert(i < t_cost.size());
-            return &(t_cost[i]);
-        } else {
-            return nullptr;
-        }
-    }
-
-    void normalize_tensor(const std::vector<tensor_t>& inputs,
-                          std::vector<tensor_t>& normalized) {
-        normalized = inputs;
-    }
-
-    void normalize_tensor(const std::vector<vec_t>& inputs,
-                          std::vector<tensor_t>& normalized) {
-        normalized.reserve(inputs.size());
-        for (size_t i = 0; i < inputs.size(); i++)
-            normalized.emplace_back(tensor_t{ inputs[i] });
-    }
-
-    void normalize_tensor(const std::vector<label_t>& inputs,
-                          std::vector<tensor_t>& normalized) {
-        std::vector<vec_t> vec;
-        normalized.reserve(inputs.size());
-        net_.label2vec(&inputs[0], inputs.size(), &vec);
-        normalize_tensor(vec, normalized);
-    }
-
-    std::string name_;
-    NetType net_;
+  std::string name_;
+  NetType net_;
 };
 
 /**
@@ -1000,76 +955,77 @@ class network {
  * @param data [pointer to the data]
  * @param rows [self explained]
  * @param cols [self explained]
- * @param sizepatch [size of the patch, such as the total number of pixel in the patch is sizepatch*sizepatch ]
+ * @param sizepatch [size of the patch, such as the total number of pixel in the
+ * patch is sizepatch*sizepatch ]
  * @return [vector of vec_c (sample) to be passed to test function]
  */
 inline std::vector<vec_t> image2vec(const float_t* data,
-                                    const unsigned int  rows,
+                                    const unsigned int rows,
                                     const unsigned int cols,
                                     const unsigned int sizepatch,
                                     const unsigned int step = 1) {
-    assert(step > 0);
-    std::vector<vec_t> res((cols-sizepatch) * (rows-sizepatch) / (step*step),
-                           vec_t(sizepatch*sizepatch));
-        for_i((cols-sizepatch)*(rows-sizepatch)/(step*step), [&](int count) {
-            const int j = step*(count / ((cols-sizepatch)/step));
-            const int i = step*(count % ((cols-sizepatch)/step));
+  assert(step > 0);
+  std::vector<vec_t> res(
+      (cols - sizepatch) * (rows - sizepatch) / (step * step),
+      vec_t(sizepatch * sizepatch));
+  for_i((cols - sizepatch) * (rows - sizepatch) / (step * step),
+        [&](int count) {
+          const int j = step * (count / ((cols - sizepatch) / step));
+          const int i = step * (count % ((cols - sizepatch) / step));
 
-            // vec_t sample(sizepatch*sizepatch);
+          // vec_t sample(sizepatch*sizepatch);
 
-            if (i+sizepatch < cols && j+sizepatch < rows) {
-                for (unsigned int k = 0; k < sizepatch*sizepatch; k++) {
-                // for_i(sizepatch*sizepatch, [&](int k) {
-                    unsigned int y = k / sizepatch + j;
-                    unsigned int x = k % sizepatch + i;
-                    res[count][k] = data[x+y*cols];
-                }
-                //});
-                // res[count] = (sample);
+          if (i + sizepatch < cols && j + sizepatch < rows) {
+            for (unsigned int k = 0; k < sizepatch * sizepatch; k++) {
+              // for_i(sizepatch*sizepatch, [&](int k) {
+              unsigned int y = k / sizepatch + j;
+              unsigned int x = k % sizepatch + i;
+              res[count][k] = data[x + y * cols];
             }
+            //});
+            // res[count] = (sample);
+          }
         });
-    return res;
+  return res;
 }
 
 template <typename Layer>
-network<sequential>& operator << (network<sequential>& n, Layer&& l) {
-    n.net_.add(std::forward<Layer>(l));
-    return n;
+network<sequential>& operator<<(network<sequential>& n, Layer&& l) {
+  n.net_.add(std::forward<Layer>(l));
+  return n;
 }
 
 template <typename NetType, typename Char, typename CharTraits>
-std::basic_ostream<Char, CharTraits>& operator << (std::basic_ostream<Char,
-                                                   CharTraits>& os,
-                                                   const network<NetType>& n) {
-    n.save(os);
-    return os;
+std::basic_ostream<Char, CharTraits>& operator<<(
+    std::basic_ostream<Char, CharTraits>& os, const network<NetType>& n) {
+  n.save(os);
+  return os;
 }
 
 template <typename NetType, typename Char, typename CharTraits>
-std::basic_istream<Char, CharTraits>& operator >> (std::basic_istream<Char,
-                                                   CharTraits>& os,
-                                                   network<NetType>& n) {
-    n.load(os);
-    return os;
+std::basic_istream<Char, CharTraits>& operator>>(
+    std::basic_istream<Char, CharTraits>& os, network<NetType>& n) {
+  n.load(os);
+  return os;
 }
 
 inline void construct_graph(network<graph>& graph,
                             const std::vector<layer*>& inputs,
                             const std::vector<layer*>& outputs) {
-    graph.net_.construct(inputs, outputs);
+  graph.net_.construct(inputs, outputs);
 }
 
-inline void construct_graph(network<graph>& graph,
-    const std::vector<std::shared_ptr<layer>>& inputs,
+inline void construct_graph(
+    network<graph>& graph, const std::vector<std::shared_ptr<layer>>& inputs,
     const std::vector<std::shared_ptr<layer>>& outputs) {
-    std::vector<layer*> in_ptr, out_ptr;
-    auto shared2ptr = [](std::shared_ptr<layer> l) { return l.get(); };
+  std::vector<layer*> in_ptr, out_ptr;
+  auto shared2ptr = [](std::shared_ptr<layer> l) { return l.get(); };
 
-    std::transform(inputs.begin(), inputs.end(),
-                   std::back_inserter(in_ptr), shared2ptr);
-    std::transform(outputs.begin(), outputs.end(),
-                   std::back_inserter(out_ptr), shared2ptr);
+  std::transform(inputs.begin(), inputs.end(), std::back_inserter(in_ptr),
+                 shared2ptr);
+  std::transform(outputs.begin(), outputs.end(), std::back_inserter(out_ptr),
+                 shared2ptr);
 
-    graph.net_.construct(in_ptr, out_ptr);
+  graph.net_.construct(in_ptr, out_ptr);
 }
 }  // namespace tiny_dnn

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <iostream>
 #include <stdexcept>

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -3,20 +3,20 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <sstream>
 #include <iomanip>
 #include <memory>
 #include <numeric>
-#include <vector>
-#include <set>
 #include <queue>
+#include <set>
+#include <sstream>
 #include <unordered_set>
+#include <vector>
 
-#include "tiny_dnn/util/util.h"
-#include "tiny_dnn/util/product.h"
-#include "tiny_dnn/util/image.h"
-#include "tiny_dnn/util/weight_init.h"
 #include "tiny_dnn/optimizers/optimizer.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/product.h"
+#include "tiny_dnn/util/util.h"
+#include "tiny_dnn/util/weight_init.h"
 
 #include "tiny_dnn/activations/activation_function.h"
 
@@ -35,36 +35,38 @@ typedef layer* layerptr_t;
  * base class of all kind of tinny-cnn data
  **/
 class node : public std::enable_shared_from_this<node> {
-public:
-    node(cnn_size_t in_size, cnn_size_t out_size)
-        : prev_(in_size), next_(out_size) {}
-    virtual ~node() {}
+ public:
+  node(cnn_size_t in_size, cnn_size_t out_size)
+      : prev_(in_size), next_(out_size) {}
+  virtual ~node() {}
 
-    const std::vector<edgeptr_t>& prev() const { return prev_; }
-    const std::vector<edgeptr_t>& next() const { return next_; }
+  const std::vector<edgeptr_t>& prev() const { return prev_; }
+  const std::vector<edgeptr_t>& next() const { return next_; }
 
-    cnn_size_t prev_port(const edge& e) const {
-        auto it = std::find_if(prev_.begin(), prev_.end(),
-                               [&](edgeptr_t ep) { return ep.get() == &e; });
-        return (cnn_size_t)std::distance(prev_.begin(), it);
-    }
+  cnn_size_t prev_port(const edge& e) const {
+    auto it = std::find_if(prev_.begin(), prev_.end(),
+                           [&](edgeptr_t ep) { return ep.get() == &e; });
+    return (cnn_size_t)std::distance(prev_.begin(), it);
+  }
 
-    cnn_size_t next_port(const edge& e) const {
-        auto it = std::find_if(next_.begin(), next_.end(),
-                               [&](edgeptr_t ep) { return ep.get() == &e; });
-        return (cnn_size_t)std::distance(next_.begin(), it);
-    }
+  cnn_size_t next_port(const edge& e) const {
+    auto it = std::find_if(next_.begin(), next_.end(),
+                           [&](edgeptr_t ep) { return ep.get() == &e; });
+    return (cnn_size_t)std::distance(next_.begin(), it);
+  }
 
-    std::vector<node*> prev_nodes() const; // @todo refactor and remove this method
-    std::vector<node*> next_nodes() const; // @todo refactor and remove this method
+  std::vector<node*> prev_nodes()
+      const;  // @todo refactor and remove this method
+  std::vector<node*> next_nodes()
+      const;  // @todo refactor and remove this method
  protected:
-    node() = delete;
+  node() = delete;
 
-    friend void connect(layerptr_t head, layerptr_t tail,
-                        cnn_size_t head_index, cnn_size_t tail_index);
+  friend void connect(layerptr_t head, layerptr_t tail, cnn_size_t head_index,
+                      cnn_size_t tail_index);
 
-    mutable std::vector<edgeptr_t> prev_;
-    mutable std::vector<edgeptr_t> next_;
+  mutable std::vector<edgeptr_t> prev_;
+  mutable std::vector<edgeptr_t> next_;
 };
 
 /**
@@ -72,149 +74,145 @@ public:
  **/
 class edge {
  public:
-    edge(node* prev, const shape3d& shape, vector_type vtype)
-        : shape_(shape),
-          vtype_(vtype),
-          data_({vec_t(shape.size())}),
-          grad_({vec_t(shape.size())}),
-          prev_(prev) {}
+  edge(node* prev, const shape3d& shape, vector_type vtype)
+      : shape_(shape),
+        vtype_(vtype),
+        data_({vec_t(shape.size())}),
+        grad_({vec_t(shape.size())}),
+        prev_(prev) {}
 
-    void merge_grads(vec_t *dst) {
-        dst->resize(grad_[0].size());
-        std::fill(dst->begin(), dst->end(), static_cast<float_t>(0));
+  void merge_grads(vec_t* dst) {
+    dst->resize(grad_[0].size());
+    std::fill(dst->begin(), dst->end(), static_cast<float_t>(0));
 
-        // @todo consider adding parallelism
-		for (cnn_size_t sample = 0, sample_count = grad_.size(); sample < sample_count; ++sample) {
-			vectorize::reduce<float_t>(&grad_[sample][0], dst->size(), &(*dst)[0]);
-		}
+    // @todo consider adding parallelism
+    for (cnn_size_t sample = 0, sample_count = grad_.size();
+         sample < sample_count; ++sample) {
+      vectorize::reduce<float_t>(&grad_[sample][0], dst->size(), &(*dst)[0]);
     }
+  }
 
-    void clear_grads() {
-		for (cnn_size_t sample = 0, sample_count = grad_.size(); sample < sample_count; ++sample) {
-			std::fill(grad_[sample].begin(), grad_[sample].end(), (float_t)0);
-		}
+  void clear_grads() {
+    for (cnn_size_t sample = 0, sample_count = grad_.size();
+         sample < sample_count; ++sample) {
+      std::fill(grad_[sample].begin(), grad_[sample].end(), (float_t)0);
     }
+  }
 
-    tensor_t* get_data() {
-        return &data_;
-    }
+  tensor_t* get_data() { return &data_; }
 
-    const tensor_t* get_data() const {
-        return &data_;
-    }
+  const tensor_t* get_data() const { return &data_; }
 
-    tensor_t* get_gradient() {
-        return &grad_;
-    }
+  tensor_t* get_gradient() { return &grad_; }
 
-    const tensor_t* get_gradient() const {
-        return &grad_;
-    }
+  const tensor_t* get_gradient() const { return &grad_; }
 
-    const std::vector<node*>& next() const { return next_; }
-    node* prev() { return prev_; }
-    const node* prev() const { return prev_; }
+  const std::vector<node*>& next() const { return next_; }
+  node* prev() { return prev_; }
+  const node* prev() const { return prev_; }
 
-    const shape3d& shape() const { return shape_; }
-    vector_type vtype() const { return vtype_; }
-    void add_next_node(node* next) { next_.push_back(next); }
+  const shape3d& shape() const { return shape_; }
+  vector_type vtype() const { return vtype_; }
+  void add_next_node(node* next) { next_.push_back(next); }
 
  private:
-    shape3d shape_;
-    vector_type vtype_;
-    tensor_t data_;
-    tensor_t grad_;
-    node* prev_;               // previous node, "producer" of this tensor
-    std::vector<node*> next_;  // next nodes, "consumers" of this tensor
+  shape3d shape_;
+  vector_type vtype_;
+  tensor_t data_;
+  tensor_t grad_;
+  node* prev_;               // previous node, "producer" of this tensor
+  std::vector<node*> next_;  // next nodes, "consumers" of this tensor
 };
 
 inline std::vector<node*> node::prev_nodes() const {
-    std::set<node*> sets;
-    for (auto& e : prev_) {
-        if (e && e->prev()) sets.insert(e->prev());
-    }
-    return std::vector<node*>(sets.begin(), sets.end());
+  std::set<node*> sets;
+  for (auto& e : prev_) {
+    if (e && e->prev()) sets.insert(e->prev());
+  }
+  return std::vector<node*>(sets.begin(), sets.end());
 }
 
 inline std::vector<node*> node::next_nodes() const {
-    std::set<node*> sets;
-    for (auto& e : next_) {
-        if (e) {
-            auto n = e->next();
-            sets.insert(n.begin(), n.end());
-        }
+  std::set<node*> sets;
+  for (auto& e : next_) {
+    if (e) {
+      auto n = e->next();
+      sets.insert(n.begin(), n.end());
     }
-    return std::vector<node*>(sets.begin(), sets.end());
+  }
+  return std::vector<node*>(sets.begin(), sets.end());
 }
 
 template <typename T>
 struct node_tuple {
-    node_tuple(T l1, T l2) {
-        nodes_.push_back(l1); nodes_.push_back(l2);
-    }
-    std::vector<T> nodes_;
+  node_tuple(T l1, T l2) {
+    nodes_.push_back(l1);
+    nodes_.push_back(l2);
+  }
+  std::vector<T> nodes_;
 };
 
 template <typename T>
-node_tuple<T*> operator , (T& l1, T& l2) {
-    return node_tuple<T*>(&l1, &l2);
+node_tuple<T*> operator,(T& l1, T& l2) {
+  return node_tuple<T*>(&l1, &l2);
 }
 
 template <typename T>
-node_tuple<std::shared_ptr<T>> operator , (std::shared_ptr<T> l1, std::shared_ptr<T> l2) {
-    return node_tuple<std::shared_ptr<T>>(l1, l2);
+node_tuple<std::shared_ptr<T>> operator,(std::shared_ptr<T> l1,
+                                         std::shared_ptr<T> l2) {
+  return node_tuple<std::shared_ptr<T>>(l1, l2);
 }
 
 template <typename T>
-node_tuple<std::shared_ptr<T>> operator , (node_tuple<std::shared_ptr<T>> lhs, std::shared_ptr<T>& rhs) {
-    lhs.nodes_.push_back(rhs);
-    return lhs;
+node_tuple<std::shared_ptr<T>> operator,(node_tuple<std::shared_ptr<T>> lhs,
+                                         std::shared_ptr<T>& rhs) {
+  lhs.nodes_.push_back(rhs);
+  return lhs;
 }
 
 template <typename T>
-node_tuple<T*> operator , (node_tuple<T*> lhs, T& rhs) {
-    lhs.nodes_.push_back(&rhs);
-    return lhs;
+node_tuple<T*> operator,(node_tuple<T*> lhs, T& rhs) {
+  lhs.nodes_.push_back(&rhs);
+  return lhs;
 }
 
 template <typename T, typename U>
-inline std::shared_ptr<U>& operator << (std::shared_ptr<T>& lhs,
-                                        std::shared_ptr<U>& rhs) {
-    connect(lhs.get(), rhs.get());
-    return rhs;
+inline std::shared_ptr<U>& operator<<(std::shared_ptr<T>& lhs,
+                                      std::shared_ptr<U>& rhs) {
+  connect(lhs.get(), rhs.get());
+  return rhs;
 }
 
 template <typename T, typename U>
-inline U& operator << (const node_tuple<T>& lhs, U& rhs) {
-    for (size_t i = 0; i < lhs.nodes_.size(); i++) {
-        connect(&*lhs.nodes_[i], &*rhs, 0, i);
-    }
-    return rhs;
+inline U& operator<<(const node_tuple<T>& lhs, U& rhs) {
+  for (size_t i = 0; i < lhs.nodes_.size(); i++) {
+    connect(&*lhs.nodes_[i], &*rhs, 0, i);
+  }
+  return rhs;
 }
 
 template <typename T, typename U>
-inline node_tuple<T>& operator << (U& lhs, const node_tuple<T>& rhs) {
-    for (size_t i = 0; i < rhs.nodes_.size(); i++) {
-        connect(&*lhs, &*rhs.nodes_[i], i, 0);
-    }
-    return rhs;
+inline node_tuple<T>& operator<<(U& lhs, const node_tuple<T>& rhs) {
+  for (size_t i = 0; i < rhs.nodes_.size(); i++) {
+    connect(&*lhs, &*rhs.nodes_[i], i, 0);
+  }
+  return rhs;
 }
 
 template <typename T, typename U>
-inline U& operator << (const node_tuple<T*>& lhs, U& rhs) {
-    for (size_t i = 0; i < lhs.nodes_.size(); i++) {
-        connect(lhs.nodes_[i], &rhs, 0, i);
-    }
-    return rhs;
+inline U& operator<<(const node_tuple<T*>& lhs, U& rhs) {
+  for (size_t i = 0; i < lhs.nodes_.size(); i++) {
+    connect(lhs.nodes_[i], &rhs, 0, i);
+  }
+  return rhs;
 }
 
 template <typename T, typename U>
-inline node_tuple<T*>& operator << (U& lhs, const node_tuple<T*>& rhs) {
-    for (size_t i = 0; i < rhs.nodes_.size(); i++) {
-        connect(&lhs, rhs.nodes_[i], i, 0);
-    }
-    return rhs;
+inline node_tuple<T*>& operator<<(U& lhs, const node_tuple<T*>& rhs) {
+  for (size_t i = 0; i < rhs.nodes_.size(); i++) {
+    connect(&lhs, rhs.nodes_[i], i, 0);
+  }
+  return rhs;
 }
 
-
-}   // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <sstream>
 #include <iomanip>

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include <vector>

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -4,37 +4,35 @@
 
 #pragma once
 
-#include <vector>
+#include <cereal/types/tuple.hpp>
+#include <cereal/types/utility.hpp>
 #include <tuple>
 #include <unordered_map>
-#include <cereal/types/utility.hpp>
-#include <cereal/types/tuple.hpp>
+#include <vector>
 
-#include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/optimizers/optimizer.h"
+#include "tiny_dnn/util/util.h"
 
 namespace cereal {
 
 template <typename Archive>
-void save(Archive & ar, const std::vector<tiny_dnn::layerptr_t>& v) {
-    ar(cereal::make_size_tag((cereal::size_type)v.size()));
-    for (auto n : v) {
-        tiny_dnn::layer::save_layer(ar, *n);
-    }
+void save(Archive& ar, const std::vector<tiny_dnn::layerptr_t>& v) {
+  ar(cereal::make_size_tag((cereal::size_type)v.size()));
+  for (auto n : v) {
+    tiny_dnn::layer::save_layer(ar, *n);
+  }
 }
-
 
 template <typename Archive>
-void load(Archive & ar, std::vector<std::shared_ptr<tiny_dnn::layer>>& v) {
-    cereal::size_type size;
-    ar(cereal::make_size_tag(size));
+void load(Archive& ar, std::vector<std::shared_ptr<tiny_dnn::layer>>& v) {
+  cereal::size_type size;
+  ar(cereal::make_size_tag(size));
 
-    for (size_t i = 0; i < size; i++) {
-        v.emplace_back(tiny_dnn::layer::load_layer(ar));
-    }
+  for (size_t i = 0; i < size; i++) {
+    v.emplace_back(tiny_dnn::layer::load_layer(ar));
+  }
 }
-
 }
 
 namespace tiny_dnn {
@@ -54,194 +52,198 @@ namespace tiny_dnn {
  *     sequential s;
  *     s.add(fc<tan_h>(100, 200));                   // rvalue, moved into nodes
  *
- *     s.add(std::make_shared<fc<tan_h>>(200, 100)); // shared_ptr, shared by nodes
+ *     s.add(std::make_shared<fc<tan_h>>(200, 100)); // shared_ptr, shared by
+ *nodes
  *
  *     fc<softmax> out(100, 10);
- *     s.add(out);                                   // lvalue, hold raw-pointer only
+ *     s.add(out);                                   // lvalue, hold raw-pointer
+ *only
  *
  **/
 class nodes {
  public:
-     typedef std::vector<layerptr_t>::iterator iterator;
-     typedef std::vector<layerptr_t>::const_iterator const_iterator;
+  typedef std::vector<layerptr_t>::iterator iterator;
+  typedef std::vector<layerptr_t>::const_iterator const_iterator;
 
-    /**
-     * propagate gradient
-     * @param first        : gradient of cost function(dE/dy)
-     * @param worker_index : id of worker-task
-     **/
-    virtual
-    void backward(const std::vector<tensor_t>& first) = 0;
+  /**
+   * propagate gradient
+   * @param first        : gradient of cost function(dE/dy)
+   * @param worker_index : id of worker-task
+   **/
+  virtual void backward(const std::vector<tensor_t>& first) = 0;
 
-    /**
-     * @param first input  : data vectors
-     * @param worker_index : id of worker-task
-     **/
-    virtual
-    std::vector<tensor_t> forward(const std::vector<tensor_t>& first) = 0; // NOLINT
+  /**
+   * @param first input  : data vectors
+   * @param worker_index : id of worker-task
+   **/
+  virtual std::vector<tensor_t> forward(
+      const std::vector<tensor_t>& first) = 0;  // NOLINT
 
-    /**
-     * update weights and clear all gradients
-     **/
-    virtual
-    void update_weights(optimizer *opt, int batch_size) {
-        for (auto l : nodes_) {
-            l->update_weight(opt, batch_size);
-        }
+  /**
+   * update weights and clear all gradients
+   **/
+  virtual void update_weights(optimizer* opt, int batch_size) {
+    for (auto l : nodes_) {
+      l->update_weight(opt, batch_size);
     }
+  }
 
-    /**
-     * setup all weights, must be called before forward/backward
-     **/
-    virtual void setup(bool reset_weight) {
-        for (auto l : nodes_) {
-            l->setup(reset_weight);
-        }
+  /**
+   * setup all weights, must be called before forward/backward
+   **/
+  virtual void setup(bool reset_weight) {
+    for (auto l : nodes_) {
+      l->setup(reset_weight);
     }
+  }
 
-    void clear_grads() {
-        for (auto l : nodes_) {
-            l->clear_grads();
-        }
+  void clear_grads() {
+    for (auto l : nodes_) {
+      l->clear_grads();
     }
+  }
 
-    size_t size() const { return nodes_.size(); }
-    iterator begin() { return nodes_.begin(); }
-    iterator end() { return nodes_.end(); }
-    const_iterator begin() const { return nodes_.begin(); }
-    const_iterator end() const { return nodes_.end(); }
-    layer* operator[] (size_t index) { return nodes_[index]; }
-    const layer* operator[] (size_t index) const { return nodes_[index]; }
-    cnn_size_t in_data_size() const { return nodes_.front()->in_data_size(); }
-    cnn_size_t out_data_size() const { return nodes_.back()->out_data_size(); }
+  size_t size() const { return nodes_.size(); }
+  iterator begin() { return nodes_.begin(); }
+  iterator end() { return nodes_.end(); }
+  const_iterator begin() const { return nodes_.begin(); }
+  const_iterator end() const { return nodes_.end(); }
+  layer* operator[](size_t index) { return nodes_[index]; }
+  const layer* operator[](size_t index) const { return nodes_[index]; }
+  cnn_size_t in_data_size() const { return nodes_.front()->in_data_size(); }
+  cnn_size_t out_data_size() const { return nodes_.back()->out_data_size(); }
 
-    template <typename T>
-    const T& at(size_t index) const {
-        const T* v = dynamic_cast<const T*>(nodes_[index]);
-        if (v) return *v;
-        throw nn_error("failed to cast");
+  template <typename T>
+  const T& at(size_t index) const {
+    const T* v = dynamic_cast<const T*>(nodes_[index]);
+    if (v) return *v;
+    throw nn_error("failed to cast");
+  }
+
+  template <typename T>
+  T& at(size_t index) {
+    T* v = dynamic_cast<T*>(nodes_[index]);
+    if (v) return *v;
+    throw nn_error("failed to cast");
+  }
+
+  // @todo: multiple output
+  virtual float_t target_value_min(int out_channel = 0) const {
+    CNN_UNREFERENCED_PARAMETER(out_channel);
+    return nodes_.back()->out_value_range().first;
+  }
+
+  virtual float_t target_value_max(int out_channel = 0) const {
+    CNN_UNREFERENCED_PARAMETER(out_channel);
+    return nodes_.back()->out_value_range().second;
+  }
+
+  void save(std::ostream& os) const {  // NOLINT
+    for (auto& l : nodes_) {
+      l->save(os);
     }
+  }
 
-    template <typename T>
-    T& at(size_t index) {
-        T* v = dynamic_cast<T*>(nodes_[index]);
-        if (v) return *v;
-        throw nn_error("failed to cast");
+  void load(std::istream& is) {  // NOLINT
+    setup(false);
+    for (auto& l : nodes_) {
+      l->load(is);
     }
+  }
 
-    // @todo: multiple output
-    virtual float_t target_value_min(int out_channel = 0) const {
-        CNN_UNREFERENCED_PARAMETER(out_channel);
-        return nodes_.back()->out_value_range().first;
+  virtual void load(const std::vector<float_t>& vec) {
+    int idx = 0;
+    setup(false);
+    for (auto& l : nodes_) {
+      l->load(vec, idx);
     }
+  }
 
-    virtual float_t target_value_max(int out_channel = 0) const {
-        CNN_UNREFERENCED_PARAMETER(out_channel);
-        return nodes_.back()->out_value_range().second;
+  void label2vec(const label_t* t, cnn_size_t num,
+                 std::vector<vec_t>* vec) const {
+    cnn_size_t outdim = out_data_size();
+
+    vec->reserve(num);
+    for (cnn_size_t i = 0; i < num; i++) {
+      assert(t[i] < outdim);
+      vec->emplace_back(outdim, target_value_min());
+      vec->back()[t[i]] = target_value_max();
     }
+  }
 
-    void save(std::ostream& os) const { // NOLINT
-        for (auto& l : nodes_) {
-            l->save(os);
-        }
+  template <typename OutputArchive>
+  void save_model(OutputArchive& oa) const;
+
+  template <typename InputArchive>
+  void load_model(InputArchive& ia);
+
+  template <typename OutputArchive>
+  void save_weights(OutputArchive& oa) const {
+    for (auto n : nodes_) {
+      oa(*n);
     }
+  }
 
-    void load(std::istream& is) { // NOLINT
-        setup(false);
-        for (auto& l : nodes_) {
-            l->load(is);
-        }
+  template <typename InputArchive>
+  void load_weights(InputArchive& ia) {
+    for (auto n : nodes_) {
+      ia(*n);
     }
-
-    virtual void load(const std::vector<float_t>& vec) {
-        int idx = 0;
-        setup(false);
-        for (auto& l : nodes_) {
-            l->load(vec, idx);
-        }
-    }
-
-    void label2vec(const label_t* t, cnn_size_t num, std::vector<vec_t> *vec) const {
-        cnn_size_t outdim = out_data_size();
-
-        vec->reserve(num);
-        for (cnn_size_t i = 0; i < num; i++) {
-            assert(t[i] < outdim);
-            vec->emplace_back(outdim, target_value_min());
-            vec->back()[t[i]] = target_value_max();
-        }
-    }
-
-    template <typename OutputArchive>
-    void save_model(OutputArchive & oa) const;
-
-    template <typename InputArchive>
-    void load_model(InputArchive & ia);
-
-
-    template <typename OutputArchive>
-    void save_weights(OutputArchive & oa) const {
-        for (auto n : nodes_) {
-            oa(*n);
-        }
-    }
-
-    template <typename InputArchive>
-    void load_weights(InputArchive & ia) {
-        for (auto n : nodes_) {
-            ia(*n);
-        }
-    }
+  }
 
  protected:
-    template <typename T>
-    void push_back(T&& node) {
-        push_back_impl(std::forward<T>(node),
-                       typename std::is_rvalue_reference<decltype(node)>::type()); // NOLINT
+  template <typename T>
+  void push_back(T&& node) {
+    push_back_impl(
+        std::forward<T>(node),
+        typename std::is_rvalue_reference<decltype(node)>::type());  // NOLINT
+  }
+
+  template <typename T>
+  void push_back(std::shared_ptr<T> node) {
+    own_nodes_.push_back(node);
+    nodes_.push_back(own_nodes_.back().get());
+  }
+
+  // transform indexing so that it's more suitable for per-layer operations
+  // input:  [sample][channel][feature]
+  // output: [channel][sample][feature]
+  std::vector<tensor_t> reorder_for_layerwise_processing(
+      const std::vector<tensor_t>& input) {
+    const cnn_size_t sample_count = input.size();
+    const cnn_size_t channel_count = input[0].size();
+
+    // @todo we could perhaps pass pointers to underlying vec_t objects, in
+    // order to avoid copying
+    std::vector<tensor_t> output(channel_count, tensor_t(sample_count));
+
+    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+      assert(input[sample].size() == channel_count);
+      for (cnn_size_t channel = 0; channel < channel_count; ++channel) {
+        output[channel][sample] = input[sample][channel];
+      }
     }
 
-    template <typename T>
-    void push_back(std::shared_ptr<T> node) {
-        own_nodes_.push_back(node);
-        nodes_.push_back(own_nodes_.back().get());
-    }
+    return output;
+  }
 
-    // transform indexing so that it's more suitable for per-layer operations
-    // input:  [sample][channel][feature]
-    // output: [channel][sample][feature]
-    std::vector<tensor_t> reorder_for_layerwise_processing(const std::vector<tensor_t>& input) {
-        const cnn_size_t sample_count = input.size();
-        const cnn_size_t channel_count = input[0].size();
+  template <typename T>
+  void push_back_impl(T&& node, std::true_type) {  // is_rvalue_reference
+    own_nodes_.push_back(
+        std::make_shared<typename std::remove_reference<T>::type>(
+            std::forward<T>(node)));
+    nodes_.push_back(own_nodes_.back().get());
+  }
 
-        // @todo we could perhaps pass pointers to underlying vec_t objects, in order to avoid copying
-        std::vector<tensor_t> output(channel_count, tensor_t(sample_count));
+  template <typename T>
+  void push_back_impl(T&& node, std::false_type) {
+    nodes_.push_back(&node);
+  }
 
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            assert(input[sample].size() == channel_count);
-            for (cnn_size_t channel = 0; channel < channel_count; ++channel) {
-                output[channel][sample] = input[sample][channel];
-            }
-        }
-
-        return output;
-    }
-
-    template <typename T>
-    void push_back_impl(T&& node, std::true_type) {  // is_rvalue_reference
-        own_nodes_.push_back(std::make_shared<
-            typename std::remove_reference<T>::type>(std::forward<T>(node)));
-        nodes_.push_back(own_nodes_.back().get());
-    }
-
-    template <typename T>
-    void push_back_impl(T&& node, std::false_type) {
-        nodes_.push_back(&node);
-    }
-
-    /* Nodes which this class has ownership */
-    std::vector<std::shared_ptr<layer>> own_nodes_;
-    /* List of all nodes which includes own_nodes */
-    std::vector<layerptr_t> nodes_;
+  /* Nodes which this class has ownership */
+  std::vector<std::shared_ptr<layer>> own_nodes_;
+  /* List of all nodes which includes own_nodes */
+  std::vector<layerptr_t> nodes_;
 };
 
 /**
@@ -249,88 +251,87 @@ class nodes {
  **/
 class sequential : public nodes {
  public:
-    void backward(const std::vector<tensor_t>& first) override {
+  void backward(const std::vector<tensor_t>& first) override {
+    const std::vector<tensor_t> reordered_grad =
+        reorder_for_layerwise_processing(first);
+    assert(reordered_grad.size() == 1);
 
-        const std::vector<tensor_t> reordered_grad = reorder_for_layerwise_processing(first);
-        assert(reordered_grad.size() == 1);
+    nodes_.back()->set_out_grads({reordered_grad[0]});
 
-        nodes_.back()->set_out_grads({ reordered_grad[0] });
+    for (auto l = nodes_.rbegin(); l != nodes_.rend(); l++) {
+      (*l)->backward();
+    }
+  }
 
-        for (auto l = nodes_.rbegin(); l != nodes_.rend(); l++) {
-            (*l)->backward();
-        }
+  std::vector<tensor_t> forward(const std::vector<tensor_t>& first) override {
+    const std::vector<tensor_t> reordered_data =
+        reorder_for_layerwise_processing(first);
+    assert(reordered_data.size() == 1);
+
+    nodes_.front()->set_in_data({reordered_data[0]});
+
+    for (auto l : nodes_) {
+      l->forward();
     }
 
-    std::vector<tensor_t> forward(const std::vector<tensor_t>& first) override {
+    const std::vector<tensor_t> out = nodes_.back()->output();
 
-        const std::vector<tensor_t> reordered_data = reorder_for_layerwise_processing(first);
-        assert(reordered_data.size() == 1);
+    return normalize_out(out);
+  }
 
-        nodes_.front()->set_in_data({ reordered_data[0] });
+  template <typename T>
+  void add(T&& layer) {
+    push_back(std::forward<T>(layer));
 
-        for (auto l : nodes_) {
-            l->forward();
-        }
+    if (nodes_.size() != 1) {
+      auto head = nodes_[nodes_.size() - 2];
+      auto tail = nodes_[nodes_.size() - 1];
+      connect(head, tail, 0, 0);
+      auto out = head->outputs();
+      auto in = tail->inputs();
+    }
+    check_connectivity();
+  }
 
-        const std::vector<tensor_t> out = nodes_.back()->output();
+  void check_connectivity() {
+    for (cnn_size_t i = 0; i < nodes_.size() - 1; i++) {
+      auto out = nodes_[i]->outputs();
+      auto in = nodes_[i + 1]->inputs();
 
-        return normalize_out(out);
+      if (out[0] != in[0]) {
+        throw nn_error("");
+      }
+    }
+  }
+
+  template <typename InputArchive>
+  void load_connections(InputArchive& ia) {
+    for (cnn_size_t i = 0; i < nodes_.size() - 1; i++) {
+      auto head = nodes_[i];
+      auto tail = nodes_[i + 1];
+      connect(head, tail, 0, 0);
+    }
+  }
+
+  template <typename OutputArchive>
+  void save_connections(OutputArchive&) const {}
+
+ private:
+  friend class nodes;
+
+  std::vector<tensor_t> normalize_out(const std::vector<tensor_t>& out) {
+    // normalize indexing back to [sample][layer][feature]
+    std::vector<tensor_t> normalized_output;
+
+    const cnn_size_t sample_count = out[0].size();
+    normalized_output.resize(sample_count, tensor_t(1));
+
+    for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+      normalized_output[sample][0] = out[0][sample];
     }
 
-    template <typename T>
-    void add(T&& layer) {
-        push_back(std::forward<T>(layer));
-
-        if (nodes_.size() != 1) {
-            auto head = nodes_[nodes_.size()-2];
-            auto tail = nodes_[nodes_.size()-1];
-            connect(head, tail, 0, 0);
-            auto out = head->outputs();
-            auto in = tail->inputs();
-        }
-        check_connectivity();
-    }
-
-    void check_connectivity() {
-        for (cnn_size_t i = 0; i < nodes_.size() - 1; i++) {
-            auto out = nodes_[i]->outputs();
-            auto in = nodes_[i+1]->inputs();
-
-            if (out[0] != in[0]) {
-                throw nn_error("");
-            }
-        }
-    }
-
-    template <typename InputArchive>
-    void load_connections(InputArchive& ia) {
-        for (cnn_size_t i = 0; i < nodes_.size() - 1; i++) {
-            auto head = nodes_[i];
-            auto tail = nodes_[i + 1];
-            connect(head, tail, 0, 0);
-        }
-    }
-
-    template <typename OutputArchive>
-    void save_connections(OutputArchive& ) const { }
-
-private:
-    friend class nodes;
-
-    std::vector<tensor_t> normalize_out(const std::vector<tensor_t>& out)
-    {
-        // normalize indexing back to [sample][layer][feature]
-        std::vector<tensor_t> normalized_output;
-
-        const cnn_size_t sample_count = out[0].size();
-        normalized_output.resize(sample_count, tensor_t(1));
-
-        for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            normalized_output[sample][0] = out[0][sample];
-        }
-
-        return normalized_output;
-    }
+    return normalized_output;
+  }
 };
 
 /**
@@ -339,229 +340,229 @@ private:
  **/
 class graph : public nodes {
  public:
-    void backward(const std::vector<tensor_t>& out_grad) override {
+  void backward(const std::vector<tensor_t>& out_grad) override {
+    cnn_size_t output_channel_count = out_grad[0].size();
 
-        cnn_size_t output_channel_count = out_grad[0].size();
-
-        if (output_channel_count != output_layers_.size()) {
-            throw nn_error("input size mismatch");
-        }
-
-        const std::vector<tensor_t> reordered_grad = reorder_for_layerwise_processing(out_grad);
-        assert(reordered_grad.size() == output_channel_count);
-
-        for (cnn_size_t i = 0; i < output_channel_count; i++) {
-            output_layers_[i]->set_out_grads({ reordered_grad[i] });
-        }
-
-        for (auto l = nodes_.rbegin(); l != nodes_.rend(); l++) {
-            (*l)->backward();
-        }
+    if (output_channel_count != output_layers_.size()) {
+      throw nn_error("input size mismatch");
     }
 
-    std::vector<tensor_t> forward(const std::vector<tensor_t>& in_data) override {
+    const std::vector<tensor_t> reordered_grad =
+        reorder_for_layerwise_processing(out_grad);
+    assert(reordered_grad.size() == output_channel_count);
 
-        cnn_size_t input_data_channel_count = in_data[0].size();
-
-        if (input_data_channel_count != input_layers_.size()) {
-            throw nn_error("input size mismatch");
-        }
-
-        const std::vector<tensor_t> reordered_data = reorder_for_layerwise_processing(in_data);
-        assert(reordered_data.size() == input_data_channel_count);
-
-        for (cnn_size_t channel_index = 0; channel_index < input_data_channel_count; channel_index++) {
-            input_layers_[channel_index]->set_in_data({ reordered_data[channel_index] });
-        }
-
-        for (auto l : nodes_) {
-            l->forward();
-        }
-        return merge_outs();
+    for (cnn_size_t i = 0; i < output_channel_count; i++) {
+      output_layers_[i]->set_out_grads({reordered_grad[i]});
     }
 
-    void construct(const std::vector<layerptr_t>& input,
-                   const std::vector<layerptr_t>& output) {
-        std::vector<layerptr_t> sorted;
-        std::vector<nodeptr_t> input_nodes(input.begin(), input.end());
-        std::unordered_map<node*, std::vector<uint8_t>> removed_edge;
+    for (auto l = nodes_.rbegin(); l != nodes_.rend(); l++) {
+      (*l)->backward();
+    }
+  }
 
-        // topological-sorting
-        while (!input_nodes.empty()) {
-            sorted.push_back(dynamic_cast<layerptr_t>(input_nodes.back()));
-            input_nodes.pop_back();
+  std::vector<tensor_t> forward(const std::vector<tensor_t>& in_data) override {
+    cnn_size_t input_data_channel_count = in_data[0].size();
 
-            layerptr_t curr = sorted.back();
-            std::vector<node*> next = curr->next_nodes();
-
-            for (size_t i = 0; i < next.size(); i++) {
-                if (!next[i]) continue;
-                // remove edge between next[i] and current
-                if (removed_edge.find(next[i]) == removed_edge.end()) {
-                    removed_edge[next[i]] =
-                        std::vector<uint8_t>(next[i]->prev_nodes().size(), 0);
-                }
-
-                std::vector<uint8_t>& removed = removed_edge[next[i]];
-                removed[find_index(next[i]->prev_nodes(), curr)] = 1;
-
-                if (std::all_of(removed.begin(), removed.end(), [](uint8_t x) {
-                        return x == 1; })) {
-                    input_nodes.push_back(next[i]);
-                }
-            }
-        }
-
-        for (auto& n : sorted) {
-            nodes_.push_back(n);
-        }
-
-        input_layers_ = input;
-        output_layers_ = output;
-
-        setup(false);
+    if (input_data_channel_count != input_layers_.size()) {
+      throw nn_error("input size mismatch");
     }
 
-private:
-    friend class nodes;
+    const std::vector<tensor_t> reordered_data =
+        reorder_for_layerwise_processing(in_data);
+    assert(reordered_data.size() == input_data_channel_count);
 
-    struct _graph_connection {
-        void add_connection(size_t head, size_t tail, size_t head_index, size_t tail_index) {
-            if (!is_connected(head, tail, head_index, tail_index)) {
-                connections.emplace_back(head, tail, head_index, tail_index);
-            }
-        }
-
-        bool is_connected(size_t head, size_t tail, size_t head_index, size_t tail_index) const {
-            return std::find(connections.begin(),
-                             connections.end(),
-                             std::make_tuple(head, tail, head_index, tail_index)) != connections.end();
-        }
-
-        template <typename Archive>
-        void serialize(Archive & ar) {
-            ar(CEREAL_NVP(connections), CEREAL_NVP(in_nodes), CEREAL_NVP(out_nodes));
-        }
-
-        std::vector<std::tuple<size_t, size_t, size_t, size_t>> connections;
-        std::vector<size_t> in_nodes, out_nodes;
-    };
-
-    template <typename OutputArchive>
-    void save_connections(OutputArchive& oa) const {
-        _graph_connection gc;
-        std::unordered_map<node*, size_t> node2id;
-        size_t idx = 0;
-
-        for (auto n : nodes_) {
-            node2id[n] = idx++;
-        }
-        for (auto l : input_layers_) {
-            gc.in_nodes.push_back(node2id[l]);
-        }
-        for (auto l : output_layers_) {
-            gc.out_nodes.push_back(node2id[l]);
-        }
-
-        for (auto l : input_layers_) {
-            graph_traverse(l, [=](layer& l) {}, [&](edge& e) {
-                auto next = e.next();
-                cnn_size_t head_index = e.prev()->next_port(e);
-
-                for (auto n : next) {
-                    cnn_size_t tail_index = n->prev_port(e);
-                    gc.add_connection(node2id[e.prev()], node2id[n], head_index, tail_index);
-                }
-            });
-        }
-
-        oa(cereal::make_nvp("graph", gc));
+    for (cnn_size_t channel_index = 0; channel_index < input_data_channel_count;
+         channel_index++) {
+      input_layers_[channel_index]->set_in_data(
+          {reordered_data[channel_index]});
     }
 
-    template <typename InputArchive>
-    void load_connections(InputArchive& ia) {
-        _graph_connection gc;
-        ia(cereal::make_nvp("graph", gc));
+    for (auto l : nodes_) {
+      l->forward();
+    }
+    return merge_outs();
+  }
 
-        for (auto c : gc.connections) {
-            size_t head, tail, head_index, tail_index;
-            std::tie(head, tail, head_index, tail_index) = c;
-            connect(nodes_[head], nodes_[tail], head_index, tail_index);
+  void construct(const std::vector<layerptr_t>& input,
+                 const std::vector<layerptr_t>& output) {
+    std::vector<layerptr_t> sorted;
+    std::vector<nodeptr_t> input_nodes(input.begin(), input.end());
+    std::unordered_map<node*, std::vector<uint8_t>> removed_edge;
+
+    // topological-sorting
+    while (!input_nodes.empty()) {
+      sorted.push_back(dynamic_cast<layerptr_t>(input_nodes.back()));
+      input_nodes.pop_back();
+
+      layerptr_t curr = sorted.back();
+      std::vector<node*> next = curr->next_nodes();
+
+      for (size_t i = 0; i < next.size(); i++) {
+        if (!next[i]) continue;
+        // remove edge between next[i] and current
+        if (removed_edge.find(next[i]) == removed_edge.end()) {
+          removed_edge[next[i]] =
+              std::vector<uint8_t>(next[i]->prev_nodes().size(), 0);
         }
-        for (auto in : gc.in_nodes) {
-            input_layers_.push_back(nodes_[in]);
+
+        std::vector<uint8_t>& removed = removed_edge[next[i]];
+        removed[find_index(next[i]->prev_nodes(), curr)] = 1;
+
+        if (std::all_of(removed.begin(), removed.end(),
+                        [](uint8_t x) { return x == 1; })) {
+          input_nodes.push_back(next[i]);
         }
-        for (auto out : gc.out_nodes) {
-            output_layers_.push_back(nodes_[out]);
-        }
+      }
     }
 
-     // normalize indexing back to [sample][layer][feature]
-     std::vector<tensor_t> merge_outs() {
-         std::vector<tensor_t> merged;
-         cnn_size_t output_channel_count = output_layers_.size();
-         for (cnn_size_t output_channel = 0; output_channel < output_channel_count; ++output_channel) {
-             std::vector<tensor_t> out = output_layers_[output_channel]->output();
-
-             cnn_size_t sample_count = out[0].size();
-             if (output_channel == 0) {
-                 assert(merged.empty());
-                 merged.resize(sample_count, tensor_t(output_channel_count));
-             }
-
-             assert(merged.size() == sample_count);
-
-             for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-                 merged[sample][output_channel] = out[0][sample];
-             }
-         }
-         return merged;
-     }
-
-    cnn_size_t find_index(const std::vector<node*>& nodes,
-                          layerptr_t target) {
-        for (cnn_size_t i = 0; i < nodes.size(); i++) {
-            if (nodes[i] == static_cast<node*>(&*target)) return i;
-        }
-        throw nn_error("invalid connection");
+    for (auto& n : sorted) {
+      nodes_.push_back(n);
     }
-    std::vector<layerptr_t> input_layers_;
-    std::vector<layerptr_t> output_layers_;
+
+    input_layers_ = input;
+    output_layers_ = output;
+
+    setup(false);
+  }
+
+ private:
+  friend class nodes;
+
+  struct _graph_connection {
+    void add_connection(size_t head, size_t tail, size_t head_index,
+                        size_t tail_index) {
+      if (!is_connected(head, tail, head_index, tail_index)) {
+        connections.emplace_back(head, tail, head_index, tail_index);
+      }
+    }
+
+    bool is_connected(size_t head, size_t tail, size_t head_index,
+                      size_t tail_index) const {
+      return std::find(connections.begin(), connections.end(),
+                       std::make_tuple(head, tail, head_index, tail_index)) !=
+             connections.end();
+    }
+
+    template <typename Archive>
+    void serialize(Archive& ar) {
+      ar(CEREAL_NVP(connections), CEREAL_NVP(in_nodes), CEREAL_NVP(out_nodes));
+    }
+
+    std::vector<std::tuple<size_t, size_t, size_t, size_t>> connections;
+    std::vector<size_t> in_nodes, out_nodes;
+  };
+
+  template <typename OutputArchive>
+  void save_connections(OutputArchive& oa) const {
+    _graph_connection gc;
+    std::unordered_map<node*, size_t> node2id;
+    size_t idx = 0;
+
+    for (auto n : nodes_) {
+      node2id[n] = idx++;
+    }
+    for (auto l : input_layers_) {
+      gc.in_nodes.push_back(node2id[l]);
+    }
+    for (auto l : output_layers_) {
+      gc.out_nodes.push_back(node2id[l]);
+    }
+
+    for (auto l : input_layers_) {
+      graph_traverse(l, [=](layer& l) {},
+                     [&](edge& e) {
+                       auto next = e.next();
+                       cnn_size_t head_index = e.prev()->next_port(e);
+
+                       for (auto n : next) {
+                         cnn_size_t tail_index = n->prev_port(e);
+                         gc.add_connection(node2id[e.prev()], node2id[n],
+                                           head_index, tail_index);
+                       }
+                     });
+    }
+
+    oa(cereal::make_nvp("graph", gc));
+  }
+
+  template <typename InputArchive>
+  void load_connections(InputArchive& ia) {
+    _graph_connection gc;
+    ia(cereal::make_nvp("graph", gc));
+
+    for (auto c : gc.connections) {
+      size_t head, tail, head_index, tail_index;
+      std::tie(head, tail, head_index, tail_index) = c;
+      connect(nodes_[head], nodes_[tail], head_index, tail_index);
+    }
+    for (auto in : gc.in_nodes) {
+      input_layers_.push_back(nodes_[in]);
+    }
+    for (auto out : gc.out_nodes) {
+      output_layers_.push_back(nodes_[out]);
+    }
+  }
+
+  // normalize indexing back to [sample][layer][feature]
+  std::vector<tensor_t> merge_outs() {
+    std::vector<tensor_t> merged;
+    cnn_size_t output_channel_count = output_layers_.size();
+    for (cnn_size_t output_channel = 0; output_channel < output_channel_count;
+         ++output_channel) {
+      std::vector<tensor_t> out = output_layers_[output_channel]->output();
+
+      cnn_size_t sample_count = out[0].size();
+      if (output_channel == 0) {
+        assert(merged.empty());
+        merged.resize(sample_count, tensor_t(output_channel_count));
+      }
+
+      assert(merged.size() == sample_count);
+
+      for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
+        merged[sample][output_channel] = out[0][sample];
+      }
+    }
+    return merged;
+  }
+
+  cnn_size_t find_index(const std::vector<node*>& nodes, layerptr_t target) {
+    for (cnn_size_t i = 0; i < nodes.size(); i++) {
+      if (nodes[i] == static_cast<node*>(&*target)) return i;
+    }
+    throw nn_error("invalid connection");
+  }
+  std::vector<layerptr_t> input_layers_;
+  std::vector<layerptr_t> output_layers_;
 };
 
-
-
 template <typename OutputArchive>
-void nodes::save_model(OutputArchive & oa) const {
-    oa(cereal::make_nvp("nodes", nodes_));
+void nodes::save_model(OutputArchive& oa) const {
+  oa(cereal::make_nvp("nodes", nodes_));
 
-    if (typeid(*this) == typeid(sequential)) {
-        dynamic_cast<const sequential*>(this)->save_connections(oa);
-    }
-    else {
-        dynamic_cast<const graph*>(this)->save_connections(oa);
-    }
+  if (typeid(*this) == typeid(sequential)) {
+    dynamic_cast<const sequential*>(this)->save_connections(oa);
+  } else {
+    dynamic_cast<const graph*>(this)->save_connections(oa);
+  }
 }
 
 template <typename InputArchive>
-void nodes::load_model(InputArchive & ia) {
-    own_nodes_.clear();
-    nodes_.clear();
+void nodes::load_model(InputArchive& ia) {
+  own_nodes_.clear();
+  nodes_.clear();
 
-    ia(cereal::make_nvp("nodes", own_nodes_));
+  ia(cereal::make_nvp("nodes", own_nodes_));
 
-    for (auto& n : own_nodes_) {
-        nodes_.push_back(&*n);
-    }
+  for (auto& n : own_nodes_) {
+    nodes_.push_back(&*n);
+  }
 
-    if (typeid(*this) == typeid(sequential)) {
-        dynamic_cast<sequential*>(this)->load_connections(ia);
-    }
-    else {
-        dynamic_cast<graph*>(this)->load_connections(ia);
-    }
+  if (typeid(*this) == typeid(sequential)) {
+    dynamic_cast<sequential*>(this)->load_connections(ia);
+  } else {
+    dynamic_cast<graph*>(this)->load_connections(ia);
+  }
 }
 
-
 }  // namespace tiny_dnn
-

--- a/tiny_dnn/optimizers/optimizer.h
+++ b/tiny_dnn/optimizers/optimizer.h
@@ -3,46 +3,46 @@
 // found in the LICENSE file.
 
 #pragma once
-#include "tiny_dnn/util/util.h"
 #include <unordered_map>
+#include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
 /**
  * base class of optimizer
- * usesHessian : true if an optimizer uses hessian (2nd order derivative of loss function)
+ * usesHessian : true if an optimizer uses hessian (2nd order derivative of loss
+ *function)
  **/
 struct optimizer {
-    optimizer() = default;
-    optimizer(const optimizer &) = default;
+  optimizer() = default;
+  optimizer(const optimizer&) = default;
 #ifndef CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
-    optimizer(optimizer &&) = default;
+  optimizer(optimizer&&) = default;
 #endif
-    optimizer &operator =(const optimizer &) = default;
+  optimizer& operator=(const optimizer&) = default;
 #ifndef CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
-    optimizer &operator =(optimizer &&) = default;
+  optimizer& operator=(optimizer&&) = default;
 #endif
-    virtual ~optimizer() = default;
-    virtual void update(const vec_t& dW, vec_t &W) = 0;
-    virtual void reset() {} // override to implement pre-learning action
+  virtual ~optimizer() = default;
+  virtual void update(const vec_t& dW, vec_t& W) = 0;
+  virtual void reset() {}  // override to implement pre-learning action
 };
 
 // helper class to hold N values for each weight
 template <int N>
 struct stateful_optimizer : public optimizer {
-    void reset() override {
-        for (auto& e : E_) e.clear();
-    }
+  void reset() override {
+    for (auto& e : E_) e.clear();
+  }
 
-protected:
-    template <int Index>
-    vec_t& get(const vec_t& key) {
-        static_assert(Index < N, "index out of range");
-        if (E_[Index][&key].empty())
-            E_[Index][&key].resize(key.size(), float_t());
-        return E_[Index][&key];
-    }
-    std::unordered_map<const vec_t*, vec_t> E_[N];
+ protected:
+  template <int Index>
+  vec_t& get(const vec_t& key) {
+    static_assert(Index < N, "index out of range");
+    if (E_[Index][&key].empty()) E_[Index][&key].resize(key.size(), float_t());
+    return E_[Index][&key];
+  }
+  std::unordered_map<const vec_t*, vec_t> E_[N];
 };
 
 /**
@@ -53,20 +53,20 @@ protected:
  * The Journal of Machine Learning Research, pages 2121-2159, 2011.
  **/
 struct adagrad : public stateful_optimizer<1> {
-    adagrad() : alpha(float_t(0.01)), eps(float_t(1e-8)) {}
+  adagrad() : alpha(float_t(0.01)), eps(float_t(1e-8)) {}
 
-    void update(const vec_t& dW, vec_t &W) {
-        vec_t& g = get<0>(W);
+  void update(const vec_t& dW, vec_t& W) {
+    vec_t& g = get<0>(W);
 
-        for_i(static_cast<int>(W.size()), [&](int i) {
-            g[i] += dW[i] * dW[i];
-            W[i] -= alpha * dW[i] / (std::sqrt(g[i]) + eps);
-        });
-    }
+    for_i(static_cast<int>(W.size()), [&](int i) {
+      g[i] += dW[i] * dW[i];
+      W[i] -= alpha * dW[i] / (std::sqrt(g[i]) + eps);
+    });
+  }
 
-    float_t alpha; // learning rate
-private:
-    float_t eps;
+  float_t alpha;  // learning rate
+ private:
+  float_t eps;
 };
 
 /**
@@ -76,58 +76,62 @@ private:
  * Lecture 6.5 - rmsprop, COURSERA: Neural Networks for Machine Learning (2012)
  **/
 struct RMSprop : public stateful_optimizer<1> {
-    RMSprop() : alpha(float_t(0.0001)), mu(float_t(0.99)), eps(float_t(1e-8)) {}
+  RMSprop() : alpha(float_t(0.0001)), mu(float_t(0.99)), eps(float_t(1e-8)) {}
 
-    void update(const vec_t& dW, vec_t& W) {
-        vec_t& g = get<0>(W);
+  void update(const vec_t& dW, vec_t& W) {
+    vec_t& g = get<0>(W);
 
-        for_i(static_cast<int>(W.size()), [&](int i)
-        {
-            g[i] = mu * g[i] + (1 - mu) * dW[i] * dW[i];
-            W[i] -= alpha * dW[i] / std::sqrt(g[i] + eps);
-        });
-    }
+    for_i(static_cast<int>(W.size()), [&](int i) {
+      g[i] = mu * g[i] + (1 - mu) * dW[i] * dW[i];
+      W[i] -= alpha * dW[i] / std::sqrt(g[i] + eps);
+    });
+  }
 
-    float_t alpha; // learning rate
-    float_t mu; // decay term
-private:
-    float_t eps; // constant value to avoid zero-division
+  float_t alpha;  // learning rate
+  float_t mu;     // decay term
+ private:
+  float_t eps;  // constant value to avoid zero-division
 };
-
 
 /**
  * @brief [a new optimizer (2015)]
  * @details [see Adam: A Method for Stochastic Optimization (Algorithm 1)
  *               http://arxiv.org/abs/1412.6980]
- * 
+ *
  */
 struct adam : public stateful_optimizer<2> {
-    adam() : alpha(float_t(0.001)), b1(float_t(0.9)), b2(float_t(0.999)), b1_t(float_t(0.9)), b2_t(float_t(0.999)), eps(float_t(1e-8)) {}
+  adam()
+      : alpha(float_t(0.001)),
+        b1(float_t(0.9)),
+        b2(float_t(0.999)),
+        b1_t(float_t(0.9)),
+        b2_t(float_t(0.999)),
+        eps(float_t(1e-8)) {}
 
-    void update(const vec_t& dW, vec_t& W) {
-        vec_t& mt = get<0>(W);
-        vec_t& vt = get<1>(W);
+  void update(const vec_t& dW, vec_t& W) {
+    vec_t& mt = get<0>(W);
+    vec_t& vt = get<1>(W);
 
-        b1_t*=b1;b2_t*=b2;
+    b1_t *= b1;
+    b2_t *= b2;
 
-        for_i(static_cast<int>(W.size()), [&](int i){
-            mt[i] = b1 * mt[i] + (float_t(1) - b1) * dW[i];
-            vt[i] = b2 * vt[i] + (float_t(1) - b2) * dW[i] * dW[i];
+    for_i(static_cast<int>(W.size()), [&](int i) {
+      mt[i] = b1 * mt[i] + (float_t(1) - b1) * dW[i];
+      vt[i] = b2 * vt[i] + (float_t(1) - b2) * dW[i] * dW[i];
 
-            W[i] -= alpha * ( mt[i]/(float_t(1) -b1_t) ) / std::sqrt( (vt[i]/(float_t(1)-b2_t)) + eps);
-        });
-    }
+      W[i] -= alpha * (mt[i] / (float_t(1) - b1_t)) /
+              std::sqrt((vt[i] / (float_t(1) - b2_t)) + eps);
+    });
+  }
 
-    float_t alpha; // learning rate
-    float_t b1; // decay term
-    float_t b2; // decay term
-    float_t b1_t; // decay term power t
-    float_t b2_t; // decay term power t   
-private:
-    float_t eps; // constant value to avoid zero-division
+  float_t alpha;  // learning rate
+  float_t b1;     // decay term
+  float_t b2;     // decay term
+  float_t b1_t;   // decay term power t
+  float_t b2_t;   // decay term power t
+ private:
+  float_t eps;  // constant value to avoid zero-division
 };
-
-
 
 /**
  * SGD without momentum
@@ -135,16 +139,15 @@ private:
  * slightly faster than tiny_dnn::momentum
  **/
 struct gradient_descent : public optimizer {
-    gradient_descent() : alpha(float_t(0.01)), lambda(float_t(0)) {}
+  gradient_descent() : alpha(float_t(0.01)), lambda(float_t(0)) {}
 
-    void update(const vec_t& dW, vec_t& W) {
-        for_i(static_cast<int>(W.size()), [&](int i){
-            W[i] = W[i] - alpha * (dW[i] + lambda * W[i]);
-        });
-    }
+  void update(const vec_t& dW, vec_t& W) {
+    for_i(static_cast<int>(W.size()),
+          [&](int i) { W[i] = W[i] - alpha * (dW[i] + lambda * W[i]); });
+  }
 
-    float_t alpha; // learning rate
-    float_t lambda; // weight decay
+  float_t alpha;   // learning rate
+  float_t lambda;  // weight decay
 };
 
 /**
@@ -155,22 +158,22 @@ struct gradient_descent : public optimizer {
  * USSR Computational Mathematics and Mathematical Physics, 4(5):1-17, 1964.
  **/
 struct momentum : public stateful_optimizer<1> {
-public:
-    momentum() : alpha(float_t(0.01)), lambda(float_t(0)), mu(float_t(0.9)) {}
+ public:
+  momentum() : alpha(float_t(0.01)), lambda(float_t(0)), mu(float_t(0.9)) {}
 
-    void update(const vec_t& dW, vec_t& W) {
-        vec_t& dWprev = get<0>(W);
+  void update(const vec_t& dW, vec_t& W) {
+    vec_t& dWprev = get<0>(W);
 
-        for_i(static_cast<int>(W.size()), [&](int i){
-            float_t V = mu * dWprev[i] - alpha * (dW[i] + W[i] * lambda);
-            W[i]      += V;
-            dWprev[i] =  V;
-        });
-    }
+    for_i(static_cast<int>(W.size()), [&](int i) {
+      float_t V = mu * dWprev[i] - alpha * (dW[i] + W[i] * lambda);
+      W[i] += V;
+      dWprev[i] = V;
+    });
+  }
 
-    float_t alpha; // learning rate
-    float_t lambda; // weight decay
-    float_t mu; // momentum
+  float_t alpha;   // learning rate
+  float_t lambda;  // weight decay
+  float_t mu;      // momentum
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/optimizers/optimizer.h
+++ b/tiny_dnn/optimizers/optimizer.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <unordered_map>

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/config.h"

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -11,48 +11,47 @@
 #include "tiny_dnn/core/framework/device.h"
 #include "tiny_dnn/core/framework/program_manager.h"
 
-#include "tiny_dnn/layers/input_layer.h"
-#include "tiny_dnn/layers/feedforward_layer.h"
-#include "tiny_dnn/layers/convolutional_layer.h"
-#include "tiny_dnn/layers/quantized_convolutional_layer.h"
-#include "tiny_dnn/layers/deconvolutional_layer.h"
-#include "tiny_dnn/layers/quantized_deconvolutional_layer.h"
-#include "tiny_dnn/layers/fully_connected_layer.h"
-#include "tiny_dnn/layers/quantized_fully_connected_layer.h"
-#include "tiny_dnn/layers/average_pooling_layer.h"
-#include "tiny_dnn/layers/max_pooling_layer.h"
-#include "tiny_dnn/layers/linear_layer.h"
-#include "tiny_dnn/layers/lrn_layer.h"
-#include "tiny_dnn/layers/dropout_layer.h"
 #include "tiny_dnn/layers/arithmetic_layer.h"
-#include "tiny_dnn/layers/concat_layer.h"
-#include "tiny_dnn/layers/max_unpooling_layer.h"
+#include "tiny_dnn/layers/average_pooling_layer.h"
 #include "tiny_dnn/layers/average_unpooling_layer.h"
 #include "tiny_dnn/layers/batch_normalization_layer.h"
-#include "tiny_dnn/layers/slice_layer.h"
+#include "tiny_dnn/layers/concat_layer.h"
+#include "tiny_dnn/layers/convolutional_layer.h"
+#include "tiny_dnn/layers/deconvolutional_layer.h"
+#include "tiny_dnn/layers/dropout_layer.h"
+#include "tiny_dnn/layers/feedforward_layer.h"
+#include "tiny_dnn/layers/fully_connected_layer.h"
+#include "tiny_dnn/layers/input_layer.h"
+#include "tiny_dnn/layers/linear_layer.h"
+#include "tiny_dnn/layers/lrn_layer.h"
+#include "tiny_dnn/layers/max_pooling_layer.h"
+#include "tiny_dnn/layers/max_unpooling_layer.h"
 #include "tiny_dnn/layers/power_layer.h"
+#include "tiny_dnn/layers/quantized_convolutional_layer.h"
+#include "tiny_dnn/layers/quantized_deconvolutional_layer.h"
+#include "tiny_dnn/layers/quantized_fully_connected_layer.h"
+#include "tiny_dnn/layers/slice_layer.h"
 
 #include "tiny_dnn/activations/activation_function.h"
 #include "tiny_dnn/lossfunctions/loss_function.h"
 #include "tiny_dnn/optimizers/optimizer.h"
 
-#include "tiny_dnn/util/weight_init.h"
-#include "tiny_dnn/util/image.h"
 #include "tiny_dnn/util/deform.h"
-#include "tiny_dnn/util/product.h"
 #include "tiny_dnn/util/graph_visualizer.h"
+#include "tiny_dnn/util/image.h"
+#include "tiny_dnn/util/product.h"
+#include "tiny_dnn/util/weight_init.h"
 
-#include "tiny_dnn/io/mnist_parser.h"
 #include "tiny_dnn/io/cifar10_parser.h"
 #include "tiny_dnn/io/display.h"
 #include "tiny_dnn/io/layer_factory.h"
+#include "tiny_dnn/io/mnist_parser.h"
 #include "tiny_dnn/util/serialization_helper.h"
 
 #ifdef CNN_USE_CAFFE_CONVERTER
 // experimental / require google protobuf
 #include "tiny_dnn/io/caffe/layer_factory.h"
 #endif
-
 
 // shortcut version of layer names
 namespace tiny_dnn {
@@ -97,7 +96,6 @@ using max_unpool = tiny_dnn::max_unpooling_layer<T>;
 
 template <class T>
 using ave_unpool = tiny_dnn::average_unpooling_layer<T>;
-
 }
 
 #include "tiny_dnn/models/alexnet.h"
@@ -113,5 +111,4 @@ using batch_norm = tiny_dnn::batch_normalization_layer;
 using slice = tiny_dnn::slice_layer;
 
 using power = tiny_dnn::power_layer;
-
 }

--- a/tiny_dnn/util/aligned_allocator.h
+++ b/tiny_dnn/util/aligned_allocator.h
@@ -16,112 +16,107 @@ namespace tiny_dnn {
 
 template <typename T, std::size_t alignment>
 class aligned_allocator {
-public:
-    typedef T value_type;
-    typedef T* pointer;
-    typedef std::size_t size_type;
-    typedef std::ptrdiff_t difference_type;
-    typedef T& reference;
-    typedef const T& const_reference;
-    typedef const T* const_pointer;
+ public:
+  typedef T value_type;
+  typedef T* pointer;
+  typedef std::size_t size_type;
+  typedef std::ptrdiff_t difference_type;
+  typedef T& reference;
+  typedef const T& const_reference;
+  typedef const T* const_pointer;
 
-    template <typename U>
-    struct rebind {
-        typedef aligned_allocator<U, alignment> other;
-    };
+  template <typename U>
+  struct rebind {
+    typedef aligned_allocator<U, alignment> other;
+  };
 
-    aligned_allocator() {}
+  aligned_allocator() {}
 
-    template <typename U>
-    aligned_allocator(const aligned_allocator<U, alignment>&) {}
+  template <typename U>
+  aligned_allocator(const aligned_allocator<U, alignment>&) {}
 
-    const_pointer address(const_reference value) const {
-        return std::addressof(value);
-    }
+  const_pointer address(const_reference value) const {
+    return std::addressof(value);
+  }
 
-    pointer address(reference value) const {
-        return std::addressof(value);
-    }
+  pointer address(reference value) const { return std::addressof(value); }
 
-    pointer allocate(size_type size, const void* = nullptr) {
-        void* p = aligned_alloc(alignment, sizeof(T) * size);
-        if (!p && size > 0)
-            throw nn_error("failed to allocate");
-        return static_cast<pointer>(p);
-    }
-    
-    size_type max_size() const {
-        return ~static_cast<std::size_t>(0) / sizeof(T);
-    }
+  pointer allocate(size_type size, const void* = nullptr) {
+    void* p = aligned_alloc(alignment, sizeof(T) * size);
+    if (!p && size > 0) throw nn_error("failed to allocate");
+    return static_cast<pointer>(p);
+  }
 
-    void deallocate(pointer ptr, size_type) {
-        aligned_free(ptr);
-    }
+  size_type max_size() const {
+    return ~static_cast<std::size_t>(0) / sizeof(T);
+  }
 
-    template<class U, class V>
-    void construct(U* ptr, const V& value) {
-        void* p = ptr;
-        ::new(p) U(value);
-    }
+  void deallocate(pointer ptr, size_type) { aligned_free(ptr); }
+
+  template <class U, class V>
+  void construct(U* ptr, const V& value) {
+    void* p = ptr;
+    ::new (p) U(value);
+  }
 
 #if defined(_MSC_VER) && _MSC_VER <= 1800
-    // -vc2013 doesn't support variadic templates
+// -vc2013 doesn't support variadic templates
 #else
-    template<class U, class... Args>
-    void construct(U* ptr, Args&&... args) {
-        void* p = ptr;
-        ::new(p) U(std::forward<Args>(args)...);
-    }
+  template <class U, class... Args>
+  void construct(U* ptr, Args&&... args) {
+    void* p = ptr;
+    ::new (p) U(std::forward<Args>(args)...);
+  }
 #endif
 
-    template<class U>
-    void construct(U* ptr) {
-        void* p = ptr;
-        ::new(p) U();
-    }
+  template <class U>
+  void construct(U* ptr) {
+    void* p = ptr;
+    ::new (p) U();
+  }
 
-    template<class U>
-    void destroy(U* ptr) {
-        ptr->~U();
-    }
+  template <class U>
+  void destroy(U* ptr) {
+    ptr->~U();
+  }
 
-private:
-    void* aligned_alloc(size_type align, size_type size) const {
+ private:
+  void* aligned_alloc(size_type align, size_type size) const {
 #if defined(_MSC_VER)
-        return ::_aligned_malloc(size, align);
-#elif defined (__ANDROID__)
-        return ::memalign(align, size);
-#elif defined (__MINGW32__)
-        return _mm_malloc(size, align);
-#else // posix assumed
-        void* p;
-        if (::posix_memalign(&p, align, size) != 0) {
-            p = 0;
-        }
-        return p;
-#endif
-    }
-
-    void aligned_free(pointer ptr) {
-#if defined(_MSC_VER)
-        ::_aligned_free(ptr);
+    return ::_aligned_malloc(size, align);
+#elif defined(__ANDROID__)
+    return ::memalign(align, size);
 #elif defined(__MINGW32__)
-        ::free(ptr);
-#else
-        ::free(ptr);
-#endif
+    return _mm_malloc(size, align);
+#else  // posix assumed
+    void* p;
+    if (::posix_memalign(&p, align, size) != 0) {
+      p = 0;
     }
+    return p;
+#endif
+  }
+
+  void aligned_free(pointer ptr) {
+#if defined(_MSC_VER)
+    ::_aligned_free(ptr);
+#elif defined(__MINGW32__)
+    ::free(ptr);
+#else
+    ::free(ptr);
+#endif
+  }
 };
 
-template<typename T1, typename T2, std::size_t alignment>
-inline bool operator==(const aligned_allocator<T1, alignment>&, const aligned_allocator<T2, alignment>&)
-{
-    return true;
+template <typename T1, typename T2, std::size_t alignment>
+inline bool operator==(const aligned_allocator<T1, alignment>&,
+                       const aligned_allocator<T2, alignment>&) {
+  return true;
 }
 
-template<typename T1, typename T2, std::size_t alignment>
-inline bool operator!=(const aligned_allocator<T1, alignment>&, const aligned_allocator<T2, alignment>&)
-{
-    return false;
+template <typename T1, typename T2, std::size_t alignment>
+inline bool operator!=(const aligned_allocator<T1, alignment>&,
+                       const aligned_allocator<T2, alignment>&) {
+  return false;
 }
 }

--- a/tiny_dnn/util/aligned_allocator.h
+++ b/tiny_dnn/util/aligned_allocator.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <stdlib.h>
 #ifdef _WIN32

--- a/tiny_dnn/util/colored_print.h
+++ b/tiny_dnn/util/colored_print.h
@@ -8,70 +8,77 @@
 #ifdef CNN_WINDOWS
 #ifndef NOMINMAX
 #define NOMINMAX
-#endif // ifdef NOMINMAX
+#endif  // ifdef NOMINMAX
 #include <Windows.h>
 #endif
 
 namespace tiny_dnn {
 
-enum class Color {
-    RED,
-    GREEN,
-    BLUE,
-    YELLOW
-};
+enum class Color { RED, GREEN, BLUE, YELLOW };
 
 #ifdef CNN_WINDOWS
 inline WORD getColorAttr(Color c) {
-    switch (c) {
-    case Color::RED:    return FOREGROUND_RED;
-    case Color::GREEN:  return FOREGROUND_GREEN;
-    case Color::BLUE:   return FOREGROUND_BLUE;
-    case Color::YELLOW: return FOREGROUND_GREEN|FOREGROUND_RED;
-    default:            assert(0); return 0;
-    }
+  switch (c) {
+    case Color::RED:
+      return FOREGROUND_RED;
+    case Color::GREEN:
+      return FOREGROUND_GREEN;
+    case Color::BLUE:
+      return FOREGROUND_BLUE;
+    case Color::YELLOW:
+      return FOREGROUND_GREEN | FOREGROUND_RED;
+    default:
+      assert(0);
+      return 0;
+  }
 }
 #else
 inline const char* getColorEscape(Color c) {
-    switch (c) {
-    case Color::RED:    return "\033[31m";
-    case Color::GREEN:  return "\033[32m";
-    case Color::BLUE:   return "\033[34m";
-    case Color::YELLOW: return "\033[33m";
-    default:           assert(0); return "";
-    }
+  switch (c) {
+    case Color::RED:
+      return "\033[31m";
+    case Color::GREEN:
+      return "\033[32m";
+    case Color::BLUE:
+      return "\033[34m";
+    case Color::YELLOW:
+      return "\033[33m";
+    default:
+      assert(0);
+      return "";
+  }
 }
 #endif
 
 inline void coloredPrint(Color c, const char* fmt, ...) {
-    va_list args;
-    va_start(args, fmt);
+  va_list args;
+  va_start(args, fmt);
 
 #ifdef CNN_WINDOWS
-    const HANDLE std_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
+  const HANDLE std_handle = ::GetStdHandle(STD_OUTPUT_HANDLE);
 
-    CONSOLE_SCREEN_BUFFER_INFO buffer_info;
-    ::GetConsoleScreenBufferInfo(std_handle, &buffer_info);
-    const WORD old_color = buffer_info.wAttributes;
-    const WORD new_color = getColorAttr(c) | FOREGROUND_INTENSITY;
+  CONSOLE_SCREEN_BUFFER_INFO buffer_info;
+  ::GetConsoleScreenBufferInfo(std_handle, &buffer_info);
+  const WORD old_color = buffer_info.wAttributes;
+  const WORD new_color = getColorAttr(c) | FOREGROUND_INTENSITY;
 
-    fflush(stdout);
-    ::SetConsoleTextAttribute(std_handle, new_color);
+  fflush(stdout);
+  ::SetConsoleTextAttribute(std_handle, new_color);
 
-    vprintf(fmt, args);
+  vprintf(fmt, args);
 
-    fflush(stdout);
-    ::SetConsoleTextAttribute(std_handle, old_color);
+  fflush(stdout);
+  ::SetConsoleTextAttribute(std_handle, old_color);
 #else
-    printf("%s", getColorEscape(c));
-    vprintf(fmt, args);
-    printf("\033[m");
+  printf("%s", getColorEscape(c));
+  vprintf(fmt, args);
+  printf("\033[m");
 #endif
-    va_end(args);
+  va_end(args);
 }
 
 inline void coloredPrint(Color c, const std::string& msg) {
-    coloredPrint(c, msg.c_str());
+  coloredPrint(c, msg.c_str());
 }
 
-} // tiny_dnn
+}  // tiny_dnn

--- a/tiny_dnn/util/colored_print.h
+++ b/tiny_dnn/util/colored_print.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/config.h"
 

--- a/tiny_dnn/util/deform.h
+++ b/tiny_dnn/util/deform.h
@@ -8,11 +8,9 @@
 namespace tiny_dnn {
 
 inline vec_t corrupt(vec_t&& in, float_t corruption_level, float_t min_value) {
-    for (size_t i = 0; i < in.size(); i++)
-        if (bernoulli(corruption_level))
-            in[i] = min_value;
-    return in;
+  for (size_t i = 0; i < in.size(); i++)
+    if (bernoulli(corruption_level)) in[i] = min_value;
+  return in;
 }
 
-
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/deform.h
+++ b/tiny_dnn/util/deform.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 

--- a/tiny_dnn/util/graph_visualizer.h
+++ b/tiny_dnn/util/graph_visualizer.h
@@ -1,29 +1,7 @@
-﻿/*
-Copyright (c) 2016, Taiga Nomi
-All rights reserved.
+﻿// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-* Neither the name of the <organization> nor the
-names of its contributors may be used to endorse or promote products
-derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #include "tiny_dnn/node.h"

--- a/tiny_dnn/util/graph_visualizer.h
+++ b/tiny_dnn/util/graph_visualizer.h
@@ -4,9 +4,9 @@
 
 #pragma once
 
-#include "tiny_dnn/node.h"
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/network.h"
+#include "tiny_dnn/node.h"
 
 namespace tiny_dnn {
 
@@ -14,93 +14,97 @@ namespace tiny_dnn {
  * utility for graph visualization
  **/
 class graph_visualizer {
-public:
-    explicit graph_visualizer(layer *root_node, const std::string& graph_name = "graph")
-    : root_(root_node), name_(graph_name) {}
+ public:
+  explicit graph_visualizer(layer* root_node,
+                            const std::string& graph_name = "graph")
+      : root_(root_node), name_(graph_name) {}
 
-    template <typename N>
-    explicit graph_visualizer(network<N>& network, const std::string& graph_name = "graph")
-        : root_(network[0]), name_(graph_name) {}
+  template <typename N>
+  explicit graph_visualizer(network<N>& network,
+                            const std::string& graph_name = "graph")
+      : root_(network[0]), name_(graph_name) {}
 
-    /**
-     * generate graph structure in dot language format
-     **/
-    void generate(std::ostream& stream) {
-        generate_header(stream);
-        generate_nodes(stream);
-        generate_footer(stream);
+  /**
+   * generate graph structure in dot language format
+   **/
+  void generate(std::ostream& stream) {
+    generate_header(stream);
+    generate_nodes(stream);
+    generate_footer(stream);
+  }
+
+ private:
+  typedef std::unordered_map<const node*, std::string> node2name_t;
+
+  void generate_header(std::ostream& stream) {
+    stream << "digraph \"" << name_ << "\" {" << std::endl;
+    stream << "  node [ shape=record ];" << std::endl;
+  }
+
+  void generate_nodes(std::ostream& stream) {
+    node2name_t node2name;
+    get_layer_names(node2name);
+
+    graph_traverse(
+        root_, [&](const layer& l) { generate_layer(stream, l, node2name); },
+        [&](const edge& e) { generate_edge(stream, e, node2name); });
+  }
+
+  void get_layer_names(node2name_t& node2name) {
+    std::unordered_map<std::string, int> layer_counts;  // [layer_type -> num]
+
+    auto namer = [&](const layer& l) {
+      std::string ltype = l.layer_type();
+
+      // add quote and sequential-id
+      node2name[&l] =
+          "\"" + ltype + to_string(layer_counts[l.layer_type()]++) + "\"";
+    };
+
+    graph_traverse(root_, namer, [&](const edge&) {});
+  }
+
+  void generate_edge(std::ostream& stream, const edge& e,
+                     node2name_t& node2name) {
+    auto next = e.next();
+    auto prev = e.prev();
+
+    for (auto n : next) {
+      cnn_size_t dst_port = n->prev_port(e);
+      cnn_size_t src_port = prev->next_port(e);
+      stream << "  " << node2name[prev] << ":out" << src_port << " -> "
+             << node2name[n] << ":in" << dst_port << ";" << std::endl;
     }
+  }
 
-private:
-    typedef std::unordered_map<const node*, std::string> node2name_t;
+  void generate_layer(std::ostream& stream, const layer& layer,
+                      node2name_t& node2name) {
+    stream << "  " << node2name[&layer] << " [" << std::endl;
+    stream << "    label= \"";
+    stream << layer.layer_type() << "|{{in";
+    generate_layer_channels(stream, layer.in_shape(), layer.in_types(), "in");
+    stream << "}|{out";
+    generate_layer_channels(stream, layer.out_shape(), layer.out_types(),
+                            "out");
+    stream << "}}\"" << std::endl;
+    stream << "  ];" << std::endl;
+  }
 
-    void generate_header(std::ostream& stream) {
-        stream << "digraph \"" << name_ << "\" {" << std::endl;
-        stream << "  node [ shape=record ];" << std::endl;
+  void generate_layer_channels(std::ostream& stream,
+                               const std::vector<shape3d>& shapes,
+                               const std::vector<vector_type>& vtypes,
+                               const std::string& port_prefix) {
+    CNN_UNREFERENCED_PARAMETER(vtypes);
+    for (size_t i = 0; i < shapes.size(); i++) {
+      stream << "|<" << port_prefix << i << ">" << shapes[i] << "(" << vtypes[i]
+             << ")";
     }
+  }
 
-    void generate_nodes(std::ostream& stream) {
-        node2name_t node2name;
-        get_layer_names(node2name);
+  void generate_footer(std::ostream& stream) { stream << "}" << std::endl; }
 
-        graph_traverse(root_,
-            [&](const layer& l) { generate_layer(stream, l, node2name); },
-            [&](const edge& e) { generate_edge(stream, e, node2name); });
-    }
-
-    void get_layer_names(node2name_t& node2name) {
-        std::unordered_map<std::string, int> layer_counts; // [layer_type -> num]
-
-        auto namer = [&](const layer& l) {
-            std::string ltype = l.layer_type();
-
-            // add quote and sequential-id
-            node2name[&l] = "\"" + ltype + to_string(layer_counts[l.layer_type()]++) + "\"";
-        };
-
-        graph_traverse(root_, namer, [&](const edge&){});
-    }
-
-    void generate_edge(std::ostream& stream, const edge& e, node2name_t& node2name) {
-        auto next = e.next();
-        auto prev = e.prev();
-
-        for (auto n : next) {
-            cnn_size_t dst_port = n->prev_port(e);
-            cnn_size_t src_port = prev->next_port(e);
-            stream << "  " << node2name[prev] << ":out" << src_port <<
-                    " -> " << node2name[n] << ":in" << dst_port << ";" << std::endl;
-        }
-    }
-
-    void generate_layer(std::ostream& stream, const layer& layer, node2name_t& node2name) {
-        stream << "  " << node2name[&layer] << " [" << std::endl;
-        stream << "    label= \"";
-        stream << layer.layer_type() << "|{{in";
-        generate_layer_channels(stream, layer.in_shape(), layer.in_types(), "in");
-        stream << "}|{out";
-        generate_layer_channels(stream, layer.out_shape(), layer.out_types(), "out");
-        stream << "}}\""<< std::endl;
-        stream << "  ];" << std::endl;
-    }
-
-    void generate_layer_channels(std::ostream& stream,
-                                 const std::vector<shape3d>& shapes,
-                                 const std::vector<vector_type>& vtypes,
-                                 const std::string& port_prefix) {
-        CNN_UNREFERENCED_PARAMETER(vtypes);
-        for (size_t i = 0; i < shapes.size(); i++) {
-            stream << "|<" << port_prefix << i << ">" << shapes[i] << "(" << vtypes[i] << ")";
-        }
-    }
-
-    void generate_footer(std::ostream& stream) {
-        stream << "}" << std::endl;
-    }
-
-    layer* root_;
-    std::string name_;
+  layer* root_;
+  std::string name_;
 };
 
-
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/image.h
+++ b/tiny_dnn/util/image.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <vector>
 #include <fstream>

--- a/tiny_dnn/util/image.h
+++ b/tiny_dnn/util/image.h
@@ -3,20 +3,20 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <vector>
-#include <fstream>
-#include <cstdint>
 #include <algorithm>
 #include <array>
+#include <cstdint>
+#include <fstream>
+#include <vector>
 #include "tiny_dnn/util/util.h"
 
 #ifdef _MSC_VER
 #pragma warning(push)
-#pragma warning(disable:4996) // suppress warnings about using fopen
+#pragma warning(disable : 4996)  // suppress warnings about using fopen
 #endif
 
 #define STB_IMAGE_IMPLEMENTATION
-#define STB_IMAGE_INLINE // We need this define to avoid multiple definition
+#define STB_IMAGE_INLINE  // We need this define to avoid multiple definition
 #include "third_party/stb/stb_image.h"
 
 #define STB_IMAGE_RESIZE_IMPLEMENTATION
@@ -27,286 +27,289 @@
 #define STB_IMAGE_WRITE_INLINE
 #include "third_party/stb/stb_image_write.h"
 
-
 namespace tiny_dnn {
 
-inline bool ends_with(std::string const & value, std::string const & ending) {
-    if (ending.size() > value.size()) return false;
-    return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
+inline bool ends_with(std::string const& value, std::string const& ending) {
+  if (ending.size() > value.size()) return false;
+  return std::equal(ending.rbegin(), ending.rend(), value.rbegin());
 }
 
 enum class image_type {
-    grayscale,    ///< load image and convert automatically to 8-bit grayscale
-    rgb, ///< load image and keep original color channels
-    bgr
+  grayscale,  ///< load image and convert automatically to 8-bit grayscale
+  rgb,        ///< load image and keep original color channels
+  bgr
 };
 
 /**
  * Simple image utility class
  */
-template<typename T = unsigned char>
+template <typename T = unsigned char>
 class image {
-public:
-    typedef T intensity_t;
-    typedef typename std::vector<intensity_t>::iterator iterator;
-    typedef typename std::vector<intensity_t>::const_iterator const_iterator;
+ public:
+  typedef T intensity_t;
+  typedef typename std::vector<intensity_t>::iterator iterator;
+  typedef typename std::vector<intensity_t>::const_iterator const_iterator;
 
-    image() : width_(0), height_(0), depth_(1) {}
+  image() : width_(0), height_(0), depth_(1) {}
 
-    /**
-     * create image from raw pointer
-     */
-    image(const T* data, size_t width, size_t height, image_type type)
-        : width_(width), height_(height), depth_(type == image_type::grayscale ? 1: 3), type_(type), data_(depth_ * width_ * height_, 0)
-    {
-        std::copy(data, data + width * height * depth_, &data_[0]);
+  /**
+   * create image from raw pointer
+   */
+  image(const T* data, size_t width, size_t height, image_type type)
+      : width_(width),
+        height_(height),
+        depth_(type == image_type::grayscale ? 1 : 3),
+        type_(type),
+        data_(depth_ * width_ * height_, 0) {
+    std::copy(data, data + width * height * depth_, &data_[0]);
+  }
+
+  /**
+   * create WxHxD image filled with 0
+   */
+  image(const shape3d& size, image_type type)
+      : width_(size.width_),
+        height_(size.height_),
+        depth_(size.depth_),
+        type_(type),
+        data_(depth_ * width_ * height_, 0) {
+    if (type == image_type::grayscale && size.depth_ != 1) {
+      throw nn_error("depth must be 1 in grayscale");
+    } else if (type != image_type::grayscale && size.depth_ != 3) {
+      throw nn_error("depth must be 3 in rgb/bgr");
+    }
+  }
+
+  template <typename U>
+  image(const image<U>& rhs)
+      : width_(rhs.width()),
+        height_(rhs.height()),
+        depth_(rhs.depth()),
+        type_(rhs.type()),
+        data_(rhs.shape().size()) {
+    std::transform(rhs.begin(), rhs.end(), data_.begin(),
+                   [](T src) { return static_cast<intensity_t>(src); });
+  }
+
+  /**
+   * create image from file
+   * supported file format: JPEG/PNG/TGA/BMP/PSD/GIF/HDR/PIC/PNM
+   *                        (see detail at the comments in
+   * thrid_party/stb/stb_image.h)
+   */
+  image(const std::string& filename, image_type type) {
+    int w, h, d;
+    stbi_uc* input_pixels = stbi_load(filename.c_str(), &w, &h, &d,
+                                      type == image_type::grayscale ? 1 : 3);
+    if (input_pixels == nullptr) {
+      throw nn_error("failed to open image:" +
+                     std::string(stbi_failure_reason()));
     }
 
-    /**
-     * create WxHxD image filled with 0
-     */
-    image(const shape3d& size, image_type type)
-        : width_(size.width_), height_(size.height_), depth_(size.depth_),
-          type_(type),
-          data_(depth_ * width_ * height_, 0){
-        if (type == image_type::grayscale && size.depth_ != 1) {
-            throw nn_error("depth must be 1 in grayscale");
-        }
-        else if (type != image_type::grayscale && size.depth_ != 3) {
-            throw nn_error("depth must be 3 in rgb/bgr");
-        }
+    width_ = static_cast<size_t>(w);
+    height_ = static_cast<size_t>(h);
+    depth_ = type == image_type::grayscale ? 1 : 3;
+    type_ = type;
+
+    data_.resize(width_ * height_ * depth_);
+
+    // reorder to HxWxD -> DxHxW
+    from_rgb(input_pixels, input_pixels + data_.size());
+
+    stbi_image_free(input_pixels);
+  }
+
+  void save(const std::string& path) const {
+    int ret;
+    std::vector<uint8_t> buf = to_rgb<uint8_t>();
+
+    if (ends_with(path, "png")) {
+      ret = stbi_write_png(path.c_str(), width_, height_, depth_,
+                           (const void*)&buf[0], 0);
+    } else {
+      ret = stbi_write_bmp(path.c_str(), width_, height_, depth_,
+                           (const void*)&buf[0]);
     }
-
-    template <typename U>
-    image(const image<U>& rhs) : width_(rhs.width()), height_(rhs.height()), depth_(rhs.depth()), type_(rhs.type()), data_(rhs.shape().size()) {
-        std::transform(rhs.begin(), rhs.end(), data_.begin(), [](T src) { return static_cast<intensity_t>(src); });
+    if (ret == 0) {
+      throw nn_error("failed to save image:" + path);
     }
+  }
 
-    /**
-     * create image from file
-     * supported file format: JPEG/PNG/TGA/BMP/PSD/GIF/HDR/PIC/PNM
-     *                        (see detail at the comments in thrid_party/stb/stb_image.h)
-     */
-    image(const std::string& filename, image_type type)
-    {
-        int w, h, d;
-        stbi_uc* input_pixels = stbi_load(filename.c_str(), &w, &h, &d, type == image_type::grayscale ? 1 : 3);
-        if (input_pixels == nullptr) {
-            throw nn_error("failed to open image:" + std::string(stbi_failure_reason()));
-        }
+  void write(const std::string& path) const { save(path); }
 
-        width_  = static_cast<size_t>(w);
-        height_ = static_cast<size_t>(h);
-        depth_  = type == image_type::grayscale ? 1 : 3;
-        type_ = type;
+  void resize(size_t width, size_t height) {
+    data_.resize(width * height * depth_);
+    width_ = width;
+    height_ = height;
+    // depth_ = depth;
+  }
 
-        data_.resize(width_*height_*depth_);
+  void fill(intensity_t value) { std::fill(data_.begin(), data_.end(), value); }
 
-        // reorder to HxWxD -> DxHxW
-        from_rgb(input_pixels, input_pixels + data_.size());
-   
-        stbi_image_free(input_pixels);
+  intensity_t& at(size_t x, size_t y, size_t z = 0) {
+    assert(x < width_);
+    assert(y < height_);
+    assert(z < depth_);
+    return data_[z * width_ * height_ + y * width_ + x];
+  }
+
+  const intensity_t& at(size_t x, size_t y, size_t z = 0) const {
+    assert(x < width_);
+    assert(y < height_);
+    assert(z < depth_);
+    return data_[z * width_ * height_ + y * width_ + x];
+  }
+
+  bool empty() const { return data_.empty(); }
+  iterator begin() { return data_.begin(); }
+  iterator end() { return data_.end(); }
+  const_iterator begin() const { return data_.begin(); }
+  const_iterator end() const { return data_.end(); }
+
+  intensity_t& operator[](std::size_t idx) { return data_[idx]; };
+  const intensity_t& operator[](std::size_t idx) const { return data_[idx]; };
+
+  size_t width() const { return width_; }
+  size_t height() const { return height_; }
+  size_t depth() const { return depth_; }
+  image_type type() const { return type_; }
+  shape3d shape() const { return shape3d(width_, height_, depth_); }
+  const std::vector<intensity_t>& data() const { return data_; }
+  vec_t to_vec() const { return vec_t(begin(), end()); }
+
+  template <typename U>
+  std::vector<U> to_rgb() const {
+    if (depth_ == 1) {
+      return std::vector<U>(data_.begin(), data_.end());
+    } else {
+      std::vector<U> buf(shape().size());
+      auto order = depth_order(type_);
+      auto dst = buf.begin();
+
+      for (size_t y = 0; y < height_; y++)
+        for (size_t x = 0; x < width_; x++)
+          for (size_t i = 0; i < depth_; i++)
+            *dst++ = static_cast<U>(at(x, y, order[i]));
+      return buf;
     }
+  }
 
-    void save(const std::string& path) const {
-        int ret;
-        std::vector<uint8_t> buf = to_rgb<uint8_t>();
+  template <typename Iter>
+  void from_rgb(Iter begin, Iter end) {
+    if (depth_ == 1) {
+      std::copy(begin, end, data_.begin());
+    } else {
+      auto order = depth_order(type_);
+      assert(static_cast<cnn_size_t>(std::distance(begin, end)) ==
+             data_.size());
 
-        if (ends_with(path, "png")) {
-            ret = stbi_write_png(path.c_str(), width_, height_, depth_, (const void*)&buf[0], 0);
-        }
-        else {
-            ret = stbi_write_bmp(path.c_str(), width_, height_, depth_, (const void*)&buf[0]);
-        }
-        if (ret == 0) {
-            throw nn_error("failed to save image:" + path);
-        }
+      for (size_t y = 0; y < height_; y++)
+        for (size_t x = 0; x < width_; x++)
+          for (size_t i = 0; i < depth_; i++)
+            at(x, y, order[i]) = static_cast<intensity_t>(*begin++);
     }
+  }
 
-    void write(const std::string& path) const {
-        save(path);
+ private:
+  std::array<size_t, 3> depth_order(image_type img) const {
+    if (img == image_type::rgb) {
+      return {{0, 1, 2}};
+    } else {
+      assert(img == image_type::bgr);
+      return {{2, 1, 0}};
     }
-
-    void resize(size_t width, size_t height) 
-    {
-        data_.resize(width * height * depth_);
-        width_ = width;
-        height_ = height;
-        //depth_ = depth;
-    }
-
-    void fill(intensity_t value) {
-        std::fill(data_.begin(), data_.end(), value);
-    }
-
-    intensity_t& at(size_t x, size_t y, size_t z = 0) {
-        assert(x < width_);
-        assert(y < height_);
-        assert(z < depth_);
-        return data_[z * width_ * height_ + y * width_ + x];
-    }
-
-    const intensity_t& at(size_t x, size_t y, size_t z = 0) const {
-        assert(x < width_);
-        assert(y < height_);
-        assert(z < depth_);
-        return data_[z * width_ * height_ + y * width_ + x];
-    }
-
-    bool empty() const { return data_.empty(); }
-    iterator begin() { return data_.begin(); }
-    iterator end() { return data_.end();  }
-    const_iterator begin() const { return data_.begin(); }
-    const_iterator end() const { return data_.end(); }
-
-    intensity_t& operator[](std::size_t idx)       { return data_[idx]; };
-    const intensity_t& operator[](std::size_t idx) const { return data_[idx]; };
-
-    size_t width() const { return width_; }
-    size_t height() const { return height_; }
-    size_t depth() const {return depth_;}
-    image_type type() const { return type_; }
-    shape3d shape() const { return shape3d(width_, height_, depth_); }
-    const std::vector<intensity_t>& data() const { return data_; }
-    vec_t to_vec() const { return vec_t(begin(), end()); }
-
-    template <typename U>
-    std::vector<U> to_rgb() const {
-        if (depth_ == 1) {
-            return std::vector<U>(data_.begin(), data_.end());
-        }
-        else {
-            std::vector<U> buf(shape().size());
-            auto order = depth_order(type_);
-            auto dst = buf.begin();
-
-            for (size_t y = 0; y < height_; y++)
-                for (size_t x = 0; x < width_; x++)
-                    for (size_t i = 0; i < depth_; i++)
-                        *dst++ = static_cast<U>(at(x, y, order[i]));
-            return buf;
-        }
-    }
-
-    template <typename Iter>
-    void from_rgb(Iter begin, Iter end) { 
-        if (depth_ == 1) {
-            std::copy(begin, end, data_.begin());
-        }
-        else {
-            auto order = depth_order(type_);
-            assert(static_cast<cnn_size_t>(
-                std::distance(begin, end)) == data_.size());
-
-            for (size_t y = 0; y < height_; y++)
-                for (size_t x = 0; x < width_; x++)
-                    for (size_t i = 0; i < depth_; i++)
-                        at(x, y, order[i]) = static_cast<intensity_t>(*begin++);
-        }
-    }
-
-private:
-    std::array<size_t, 3> depth_order(image_type img) const {
-        if (img == image_type::rgb) {
-            return{ {0,1,2} };
-        }
-        else {
-            assert(img == image_type::bgr);
-            return{ {2,1,0 } };
-        }
-    }
-    size_t width_;
-    size_t height_;
-    size_t depth_;
-    image_type type_;
-    std::vector<intensity_t> data_;
+  }
+  size_t width_;
+  size_t height_;
+  size_t depth_;
+  image_type type_;
+  std::vector<intensity_t> data_;
 };
 
 template <typename T>
-image<float_t> mean_image(const image<T>& src)
-{
-    image<float_t> mean(shape3d(1, 1, src.depth()), src.type());
+image<float_t> mean_image(const image<T>& src) {
+  image<float_t> mean(shape3d(1, 1, src.depth()), src.type());
 
-    for (size_t i = 0; i < src.depth(); i++) {
-        float_t sum = 0.0f;
-        for (size_t y = 0; y < src.height(); y++) {
-            for (size_t x = 0; x < src.width(); x++) {
-                sum += src.at(x, y, i);
-            }
-        }
-        mean.at(0, 0, i) = sum / (src.width() * src.height());
+  for (size_t i = 0; i < src.depth(); i++) {
+    float_t sum = 0.0f;
+    for (size_t y = 0; y < src.height(); y++) {
+      for (size_t x = 0; x < src.width(); x++) {
+        sum += src.at(x, y, i);
+      }
     }
+    mean.at(0, 0, i) = sum / (src.width() * src.height());
+  }
 
-    return mean;
+  return mean;
 }
 
-inline void resize_image_core(const uint8_t* src, int srcw, int srch, uint8_t* dst, int dstw, int dsth, int channels)
-{
-    stbir_resize_uint8(src, srcw, srch, 0, dst, dstw, dsth, 0, channels);
+inline void resize_image_core(const uint8_t* src, int srcw, int srch,
+                              uint8_t* dst, int dstw, int dsth, int channels) {
+  stbir_resize_uint8(src, srcw, srch, 0, dst, dstw, dsth, 0, channels);
 }
 
-inline void resize_image_core(const float* src, int srcw, int srch, float* dst, int dstw, int dsth, int channels)
-{
-    stbir_resize_float(src, srcw, srch, 0, dst, dstw, dsth, 0, channels);
+inline void resize_image_core(const float* src, int srcw, int srch, float* dst,
+                              int dstw, int dsth, int channels) {
+  stbir_resize_float(src, srcw, srch, 0, dst, dstw, dsth, 0, channels);
 }
 
 template <typename T>
-inline image<T> resize_image(const image<T>& src, int width, int height)
-{
-    image<T> resized(shape3d(width, height, src.depth()), src.type());
-    std::vector<T> src_rgb = src.template to_rgb<T>();
-    std::vector<T> dst_rgb(resized.shape().size());
+inline image<T> resize_image(const image<T>& src, int width, int height) {
+  image<T> resized(shape3d(width, height, src.depth()), src.type());
+  std::vector<T> src_rgb = src.template to_rgb<T>();
+  std::vector<T> dst_rgb(resized.shape().size());
 
-    resize_image_core(&src_rgb[0], src.width(), src.height(), &dst_rgb[0], width, height, src.depth());
+  resize_image_core(&src_rgb[0], src.width(), src.height(), &dst_rgb[0], width,
+                    height, src.depth());
 
-    resized.from_rgb(dst_rgb.begin(), dst_rgb.end());
+  resized.from_rgb(dst_rgb.begin(), dst_rgb.end());
 
-    return resized;
+  return resized;
 }
 
 // dst[x,y,d] = lhs[x,y,d] - rhs[x,y,d]
 template <typename T>
-image<T> subtract_image(const image<T>& lhs, const image<T>& rhs)
-{
-    if (lhs.shape() != rhs.shape()) {
-        throw nn_error("Shapes of lhs/rhs must be same. lhs:" + to_string(lhs.shape()) + ",rhs:" + to_string(rhs.shape()));
-    }
+image<T> subtract_image(const image<T>& lhs, const image<T>& rhs) {
+  if (lhs.shape() != rhs.shape()) {
+    throw nn_error("Shapes of lhs/rhs must be same. lhs:" +
+                   to_string(lhs.shape()) + ",rhs:" + to_string(rhs.shape()));
+  }
 
-    image<T> dst(lhs.width(), lhs.height(), lhs.depth());
+  image<T> dst(lhs.width(), lhs.height(), lhs.depth());
 
-    auto dstit = dst.begin();
-    auto lhsit = lhs.begin();
-    auto rhsit = rhs.begin();
+  auto dstit = dst.begin();
+  auto lhsit = lhs.begin();
+  auto rhsit = rhs.begin();
 
-    for (; dstit != dst.end(); ++dstit, ++lhsit, ++rhsit) {
-        *dstit = *lhsit - *rhsit;
-    }
-    return dst;
+  for (; dstit != dst.end(); ++dstit, ++lhsit, ++rhsit) {
+    *dstit = *lhsit - *rhsit;
+  }
+  return dst;
 }
 
 template <typename T>
-image<T> subtract_scalar(const image<T>& lhs, const image<T>& rhs)
-{
-    if (lhs.depth() != rhs.depth()) {
-        throw nn_error("Depth of lhs/rhs must be same. lhs:" + to_string(lhs.depth()) + ",rhs:" + to_string(rhs.depth()));
+image<T> subtract_scalar(const image<T>& lhs, const image<T>& rhs) {
+  if (lhs.depth() != rhs.depth()) {
+    throw nn_error("Depth of lhs/rhs must be same. lhs:" +
+                   to_string(lhs.depth()) + ",rhs:" + to_string(rhs.depth()));
+  }
+  if (rhs.width() != 1 || rhs.height() != 1) {
+    throw nn_error("rhs must be 1x1xN");
+  }
+
+  image<T> dst(lhs.shape(), lhs.type());
+
+  auto dstit = dst.begin();
+  auto lhsit = lhs.begin();
+  auto rhsit = rhs.begin();
+
+  for (size_t i = 0; i < lhs.depth(); i++, ++rhsit) {
+    for (size_t j = 0; j < lhs.width() * lhs.height(); j++, ++dstit, ++lhsit) {
+      *dstit = *lhsit - *rhsit;
     }
-    if (rhs.width() != 1 || rhs.height() != 1) {
-        throw nn_error("rhs must be 1x1xN");
-    }
+  }
 
-    image<T> dst(lhs.shape(), lhs.type());
-
-    auto dstit = dst.begin();
-    auto lhsit = lhs.begin();
-    auto rhsit = rhs.begin();
-
-    for (size_t i = 0; i < lhs.depth(); i++, ++rhsit) {
-        for (size_t j = 0; j < lhs.width() * lhs.height(); j++, ++dstit, ++lhsit) {
-            *dstit = *lhsit - *rhsit;
-        }
-    }
-
-    return dst;
+  return dst;
 }
 
 /**
@@ -322,44 +325,44 @@ image<T> subtract_scalar(const image<T>& lhs, const image<T>& rhs)
  *   -11-55-33-
  *   ----------
  **/
-template<typename T>
-inline image<T> vec2image(const vec_t& vec, cnn_size_t block_size = 2, cnn_size_t max_cols = 20)
-{
-    if (vec.empty())
-        throw nn_error("failed to visialize image: vector is empty");
+template <typename T>
+inline image<T> vec2image(const vec_t& vec, cnn_size_t block_size = 2,
+                          cnn_size_t max_cols = 20) {
+  if (vec.empty()) throw nn_error("failed to visialize image: vector is empty");
 
-    image<T> img;
-    const cnn_size_t border_width = 1;
-    const auto cols = vec.size() >= (cnn_size_t)max_cols ? (cnn_size_t)max_cols : vec.size();
-    const auto rows = (vec.size() - 1) / cols + 1;
-    const auto pitch = block_size + border_width;
-    const auto width = pitch * cols + border_width;
-    const auto height = pitch * rows + border_width;
-    const typename image<T>::intensity_t bg_color = 255;
-    cnn_size_t current_idx = 0;
+  image<T> img;
+  const cnn_size_t border_width = 1;
+  const auto cols =
+      vec.size() >= (cnn_size_t)max_cols ? (cnn_size_t)max_cols : vec.size();
+  const auto rows = (vec.size() - 1) / cols + 1;
+  const auto pitch = block_size + border_width;
+  const auto width = pitch * cols + border_width;
+  const auto height = pitch * rows + border_width;
+  const typename image<T>::intensity_t bg_color = 255;
+  cnn_size_t current_idx = 0;
 
-    img.resize(width, height);
-    img.fill(bg_color);
+  img.resize(width, height);
+  img.fill(bg_color);
 
-    auto minmax = std::minmax_element(vec.begin(), vec.end());
+  auto minmax = std::minmax_element(vec.begin(), vec.end());
 
-    for (unsigned int r = 0; r < rows; r++) {
-        cnn_size_t topy = pitch * r + border_width;
+  for (unsigned int r = 0; r < rows; r++) {
+    cnn_size_t topy = pitch * r + border_width;
 
-        for (unsigned int c = 0; c < cols; c++, current_idx++) {
-            cnn_size_t leftx = pitch * c + border_width;
-            const float_t src = vec[current_idx];
-            image<>::intensity_t dst
-                = static_cast<typename image<T>::intensity_t>(rescale(src, *minmax.first, *minmax.second, 0, 255));
+    for (unsigned int c = 0; c < cols; c++, current_idx++) {
+      cnn_size_t leftx = pitch * c + border_width;
+      const float_t src = vec[current_idx];
+      image<>::intensity_t dst = static_cast<typename image<T>::intensity_t>(
+          rescale(src, *minmax.first, *minmax.second, 0, 255));
 
-            for (cnn_size_t y = 0; y < block_size; y++)
-              for (cnn_size_t x = 0; x < block_size; x++)
-                img.at(x + leftx, y + topy) = dst;
+      for (cnn_size_t y = 0; y < block_size; y++)
+        for (cnn_size_t x = 0; x < block_size; x++)
+          img.at(x + leftx, y + topy) = dst;
 
-            if (current_idx == vec.size()) return img;
-        }
+      if (current_idx == vec.size()) return img;
     }
-    return img;
+  }
+  return img;
 }
 
 /**
@@ -376,42 +379,41 @@ inline image<T> vec2image(const vec_t& vec, cnn_size_t block_size = 2, cnn_size_
  *  -63-42-
  *  -------
  **/
-template<typename T>
+template <typename T>
 inline image<T> vec2image(const vec_t& vec, const index3d<cnn_size_t>& maps) {
-    if (vec.empty())
-        throw nn_error("failed to visualize image: vector is empty");
-    if (vec.size() != maps.size())
-        throw nn_error("failed to visualize image: vector size invalid");
+  if (vec.empty()) throw nn_error("failed to visualize image: vector is empty");
+  if (vec.size() != maps.size())
+    throw nn_error("failed to visualize image: vector size invalid");
 
-    const cnn_size_t border_width = 1;
-    const auto pitch = maps.width_ + border_width;
-    const auto width = maps.depth_ * pitch + border_width;
-    const auto height = maps.height_ + 2 * border_width;
-    const typename image<T>::intensity_t bg_color = 255;
-    image<T> img;
+  const cnn_size_t border_width = 1;
+  const auto pitch = maps.width_ + border_width;
+  const auto width = maps.depth_ * pitch + border_width;
+  const auto height = maps.height_ + 2 * border_width;
+  const typename image<T>::intensity_t bg_color = 255;
+  image<T> img;
 
-    img.resize(width, height);
-    img.fill(bg_color);
+  img.resize(width, height);
+  img.fill(bg_color);
 
-    auto minmax = std::minmax_element(vec.begin(), vec.end());
+  auto minmax = std::minmax_element(vec.begin(), vec.end());
 
-    for (cnn_size_t c = 0; c < maps.depth_; ++c) {
-        const auto top = border_width;
-        const auto left = c * pitch + border_width;
+  for (cnn_size_t c = 0; c < maps.depth_; ++c) {
+    const auto top = border_width;
+    const auto left = c * pitch + border_width;
 
-        for (cnn_size_t y = 0; y < maps.height_; ++y) {
-            for (cnn_size_t x = 0; x < maps.width_; ++x) {
-                const float_t val = vec[maps.get_index(x, y, c)];
+    for (cnn_size_t y = 0; y < maps.height_; ++y) {
+      for (cnn_size_t x = 0; x < maps.width_; ++x) {
+        const float_t val = vec[maps.get_index(x, y, c)];
 
-                img.at(left + x, top + y)
-                    = static_cast<typename image<T>::intensity_t>(rescale(val, *minmax.first, *minmax.second, 0, 255));
-            }
-        }
+        img.at(left + x, top + y) = static_cast<typename image<T>::intensity_t>(
+            rescale(val, *minmax.first, *minmax.second, 0, 255));
+      }
     }
-    return img;
+  }
+  return img;
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn
 
 #ifdef _MSC_VER
 #pragma warning(pop)

--- a/tiny_dnn/util/macro.h
+++ b/tiny_dnn/util/macro.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the tiny-dnn nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 
 #define CNN_UNREFERENCED_PARAMETER(x) (void)(x)

--- a/tiny_dnn/util/macro.h
+++ b/tiny_dnn/util/macro.h
@@ -19,11 +19,12 @@
 #define CNN_ALIGNOF(x) alignof(x)
 #endif
 
-#if !defined(_MSC_VER) || (_MSC_VER >= 1900) // default generation of move constructor is unsupported in VS2013
+#if !defined(_MSC_VER) || \
+    (_MSC_VER >=          \
+     1900)  // default generation of move constructor is unsupported in VS2013
 #define CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
 #endif
 
 #if defined _WIN32
 #define CNN_WINDOWS
 #endif
-

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -11,55 +11,56 @@ namespace tiny_dnn {
 
 // x = x / denom
 inline void vector_div(vec_t& x, float_t denom) {
-    std::transform(x.begin(), x.end(), x.begin(), [=](float_t x) { return x / denom; });
+  std::transform(x.begin(), x.end(), x.begin(),
+                 [=](float_t x) { return x / denom; });
 }
 
-/** 
+/**
  * calculate mean/variance across channels
  */
-inline void moments(const tensor_t& in, cnn_size_t spatial_dim, cnn_size_t channels, vec_t *mean, vec_t *variance) {
-    cnn_size_t num_examples = in.size();
+inline void moments(const tensor_t& in, cnn_size_t spatial_dim,
+                    cnn_size_t channels, vec_t* mean, vec_t* variance) {
+  cnn_size_t num_examples = in.size();
 
-    assert(in[0].size() == spatial_dim * channels);
+  assert(in[0].size() == spatial_dim * channels);
 
-    mean->resize(channels);
-    std::fill(mean->begin(), mean->end(), (float_t)0.0);
+  mean->resize(channels);
+  std::fill(mean->begin(), mean->end(), (float_t)0.0);
 
-    if (variance != nullptr) {
-        variance->resize(channels);
-        std::fill(variance->begin(), variance->end(), (float_t)0.0);
+  if (variance != nullptr) {
+    variance->resize(channels);
+    std::fill(variance->begin(), variance->end(), (float_t)0.0);
+  }
+
+  // calculate mean
+  for (cnn_size_t i = 0; i < num_examples; i++) {
+    for (cnn_size_t j = 0; j < channels; j++) {
+      float_t* pmean = &mean->at(j);
+      const float_t* X = &in[i][j * spatial_dim];
+
+      for (cnn_size_t k = 0; k < spatial_dim; k++) {
+        *pmean += *X++;
+      }
     }
+  }
 
-    // calculate mean
+  vector_div(*mean, (float_t)num_examples * spatial_dim);
+
+  // calculate variance
+  if (variance != nullptr) {
     for (cnn_size_t i = 0; i < num_examples; i++) {
-        for (cnn_size_t j = 0; j < channels; j++) {
-            float_t*       pmean = &mean->at(j);
-            const float_t* X = &in[i][j*spatial_dim];
+      for (cnn_size_t j = 0; j < channels; j++) {
+        float_t* pvar = &variance->at(j);
+        const float_t* X = &in[i][j * spatial_dim];
+        float_t EX = (*mean)[j];
 
-            for (cnn_size_t k = 0; k < spatial_dim; k++) {
-                *pmean += *X++;
-            }
+        for (cnn_size_t k = 0; k < spatial_dim; k++) {
+          *pvar += pow(*X++ - EX, (float_t)2.0);
         }
+      }
     }
 
-    vector_div(*mean, (float_t)num_examples*spatial_dim);
-
-    // calculate variance
-    if (variance != nullptr) {
-        for (cnn_size_t i = 0; i < num_examples; i++) {
-            for (cnn_size_t j = 0; j < channels; j++) {
-                float_t* pvar = &variance->at(j);
-                const float_t* X = &in[i][j*spatial_dim];
-                float_t        EX = (*mean)[j];
-
-                for (cnn_size_t k = 0; k < spatial_dim; k++) {
-                    *pvar += pow(*X++ - EX, (float_t)2.0);
-                }
-            }
-        }
-
-        vector_div(*variance, std::max(1.0f, num_examples*spatial_dim-1.0f));
-    }
+    vector_div(*variance, std::max(1.0f, num_examples * spatial_dim - 1.0f));
+  }
 }
-
 }

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -1,29 +1,7 @@
-/*
-Copyright (c) 2016, Taiga Nomi
-All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-* Redistributions of source code must retain the above copyright
-notice, this list of conditions and the following disclaimer.
-* Redistributions in binary form must reproduce the above copyright
-notice, this list of conditions and the following disclaimer in the
-documentation and/or other materials provided with the distribution.
-* Neither the name of the <organization> nor the
-names of its contributors may be used to endorse or promote products
-derived from this software without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <algorithm>
 

--- a/tiny_dnn/util/nn_error.h
+++ b/tiny_dnn/util/nn_error.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <exception>
 #include <string>

--- a/tiny_dnn/util/nn_error.h
+++ b/tiny_dnn/util/nn_error.h
@@ -13,54 +13,50 @@ namespace tiny_dnn {
  * error exception class for tiny-dnn
  **/
 class nn_error : public std::exception {
-public:
-    explicit nn_error(const std::string& msg) : msg_(msg) {}
-    const char* what() const throw() override {
-        return msg_.c_str();
-    }
+ public:
+  explicit nn_error(const std::string& msg) : msg_(msg) {}
+  const char* what() const throw() override { return msg_.c_str(); }
 
-private:
-    std::string msg_;
+ private:
+  std::string msg_;
 };
-
 
 /**
  * warning class for tiny-dnn (for debug)
  **/
 class nn_warn {
-public:
-    explicit nn_warn(const std::string& msg) : msg_(msg) {
+ public:
+  explicit nn_warn(const std::string& msg) : msg_(msg) {
 #ifdef CNN_USE_STDOUT
-        coloredPrint(Color::YELLOW, msg_h_ + msg_);
+    coloredPrint(Color::YELLOW, msg_h_ + msg_);
 #endif
-    }
+  }
 
-private:
-    std::string msg_;
-    std::string msg_h_ = std::string("[WARNING] ");
+ private:
+  std::string msg_;
+  std::string msg_h_ = std::string("[WARNING] ");
 };
-
 
 /**
  * info class for tiny-dnn (for debug)
  **/
 class nn_info {
-public:
-    nn_info(const std::string& msg) : msg_(msg) {
+ public:
+  nn_info(const std::string& msg) : msg_(msg) {
 #ifdef CNN_USE_STDOUT
-        std::cout << msg_h + msg_ << std::endl;
+    std::cout << msg_h + msg_ << std::endl;
 #endif
-    }
+  }
 
-private:
-    std::string msg_;
-    std::string msg_h = std::string("[INFO] ");
+ private:
+  std::string msg_;
+  std::string msg_h = std::string("[INFO] ");
 };
-
 
 class nn_not_implemented_error : public nn_error {
-public:
-    explicit nn_not_implemented_error(const std::string& msg = "not implemented") : nn_error(msg) {}
+ public:
+  explicit nn_not_implemented_error(const std::string& msg = "not implemented")
+      : nn_error(msg) {}
 };
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/parallel_for.h
+++ b/tiny_dnn/util/parallel_for.h
@@ -3,158 +3,163 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <vector>
-#include <type_traits>
-#include <limits>
 #include <cassert>
 #include <cstdio>
+#include <limits>
 #include <string>
+#include <type_traits>
+#include <vector>
 #include "aligned_allocator.h"
 #include "nn_error.h"
 #include "tiny_dnn/config.h"
 
 #ifdef CNN_USE_TBB
 #ifndef NOMINMAX
-#define NOMINMAX // tbb includes windows.h in tbb/machine/windows_api.h
+#define NOMINMAX  // tbb includes windows.h in tbb/machine/windows_api.h
 #endif
-#include <tbb/tbb.h>
 #include <tbb/task_group.h>
+#include <tbb/tbb.h>
 #endif
 
 #ifndef CNN_USE_OMP
-#include <thread>
 #include <future>
+#include <thread>
 #endif
 
 namespace tiny_dnn {
 
 #ifdef CNN_USE_TBB
 
-static tbb::task_scheduler_init tbbScheduler(tbb::task_scheduler_init::automatic);//tbb::task_scheduler_init::deferred);
+static tbb::task_scheduler_init tbbScheduler(
+    tbb::task_scheduler_init::
+        automatic);  // tbb::task_scheduler_init::deferred);
 
 typedef tbb::blocked_range<int> blocked_range;
 
-template<typename Func>
+template <typename Func>
 void parallel_for(int begin, int end, const Func& f, int grainsize) {
-    tbb::parallel_for(blocked_range(begin, end, end - begin > grainsize ? grainsize : 1), f);
+  tbb::parallel_for(
+      blocked_range(begin, end, end - begin > grainsize ? grainsize : 1), f);
 }
-template<typename Func>
+template <typename Func>
 void xparallel_for(int begin, int end, const Func& f) {
-    f(blocked_range(begin, end, 100));
+  f(blocked_range(begin, end, 100));
 }
 
 #else
 
 struct blocked_range {
-    typedef int const_iterator;
+  typedef int const_iterator;
 
-    blocked_range(int begin, int end) : begin_(begin), end_(end) {}
-    blocked_range(size_t begin, size_t end) : begin_(static_cast<int>(begin)), end_(static_cast<int>(end)) {}
+  blocked_range(int begin, int end) : begin_(begin), end_(end) {}
+  blocked_range(size_t begin, size_t end)
+      : begin_(static_cast<int>(begin)), end_(static_cast<int>(end)) {}
 
-    const_iterator begin() const { return begin_; }
-    const_iterator end() const { return end_; }
-private:
-    int begin_;
-    int end_;
+  const_iterator begin() const { return begin_; }
+  const_iterator end() const { return end_; }
+
+ private:
+  int begin_;
+  int end_;
 };
 
-template<typename Func>
+template <typename Func>
 void xparallel_for(size_t begin, size_t end, const Func& f) {
-    blocked_range r(begin, end);
-    f(r);
+  blocked_range r(begin, end);
+  f(r);
 }
 
 #if defined(CNN_USE_OMP)
 
-template<typename Func>
+template <typename Func>
 void parallel_for(int begin, int end, const Func& f, int /*grainsize*/) {
-    #pragma omp parallel for
-    for (int i=begin; i<end; ++i)
-        f(blocked_range(i,i+1));
+#pragma omp parallel for
+  for (int i = begin; i < end; ++i) f(blocked_range(i, i + 1));
 }
 
 #elif defined(CNN_SINGLE_THREAD)
 
-template<typename Func>
+template <typename Func>
 void parallel_for(int begin, int end, const Func& f, int /*grainsize*/) {
-    xparallel_for(static_cast<size_t>(begin), static_cast<size_t>(end), f);
+  xparallel_for(static_cast<size_t>(begin), static_cast<size_t>(end), f);
 }
 
 #else
 
-template<typename Func>
+template <typename Func>
 void parallel_for(int start, int end, const Func &f, int /*grainsize*/) {
-    int nthreads = std::thread::hardware_concurrency();
-    int blockSize = (end - start) / nthreads;
-    if (blockSize*nthreads < end - start)
-        blockSize++;
+  int nthreads = std::thread::hardware_concurrency();
+  int blockSize = (end - start) / nthreads;
+  if (blockSize * nthreads < end - start) blockSize++;
 
-    std::vector<std::future<void>> futures;
+  std::vector<std::future<void> > futures;
 
-    int blockStart = start;
-    int blockEnd = blockStart + blockSize;
-    if (blockEnd > end) blockEnd = end;
+  int blockStart = start;
+  int blockEnd = blockStart + blockSize;
+  if (blockEnd > end) blockEnd = end;
 
-    for (int i = 0; i < nthreads; i++) {
-        futures.push_back(std::move(std::async(std::launch::async, [blockStart, blockEnd, &f] {
-            f(blocked_range(blockStart, blockEnd));
+  for (int i = 0; i < nthreads; i++) {
+    futures.push_back(
+        std::move(std::async(std::launch::async, [blockStart, blockEnd, &f] {
+          f(blocked_range(blockStart, blockEnd));
         })));
 
-        blockStart += blockSize;
-        blockEnd = blockStart + blockSize;
-        if (blockStart >= end) break;
-        if (blockEnd > end) blockEnd = end;
-    }
+    blockStart += blockSize;
+    blockEnd = blockStart + blockSize;
+    if (blockStart >= end) break;
+    if (blockEnd > end) blockEnd = end;
+  }
 
-    for (auto &future : futures)
-        future.wait();
+  for (auto &future : futures) future.wait();
 }
 
 #endif
 
-#endif // CNN_USE_TBB
+#endif  // CNN_USE_TBB
 
-template<typename T, typename U>
-bool value_representation(U const &value) {
-    return static_cast<U>(static_cast<T>(value)) == value;
-}
-
-template<typename T, typename Func>
-inline
-void for_(std::true_type, bool parallelize, int begin, T end, Func f, int grainsize = 100){
-    parallelize = parallelize && value_representation<int>(end);
-    parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize) :
-                  xparallel_for(begin, static_cast<int>(end), f);
-}
-
-template<typename T, typename Func>
-inline
-void for_(std::false_type, bool parallelize, int begin, T end, Func f, int grainsize = 100){
-    parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize) : xparallel_for(begin, end, f);
-}
-
-template<typename T, typename Func>
-inline
-void for_(bool parallelize, int begin, T end, Func f, int grainsize = 100) {
-    static_assert(std::is_integral<T>::value, "end must be integral type");
-    for_(typename std::is_unsigned<T>::type(), parallelize, begin, end, f, grainsize);
+template <typename T, typename U>
+bool value_representation(U const& value) {
+  return static_cast<U>(static_cast<T>(value)) == value;
 }
 
 template <typename T, typename Func>
-void for_i(bool parallelize, T size, Func f, int grainsize = 100)
-{
-    for_(parallelize, 0, size, [&](const blocked_range& r) {
+inline void for_(std::true_type, bool parallelize, int begin, T end, Func f,
+                 int grainsize = 100) {
+  parallelize = parallelize && value_representation<int>(end);
+  parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize)
+              : xparallel_for(begin, static_cast<int>(end), f);
+}
+
+template <typename T, typename Func>
+inline void for_(std::false_type, bool parallelize, int begin, T end, Func f,
+                 int grainsize = 100) {
+  parallelize ? parallel_for(begin, static_cast<int>(end), f, grainsize)
+              : xparallel_for(begin, end, f);
+}
+
+template <typename T, typename Func>
+inline void for_(bool parallelize, int begin, T end, Func f,
+                 int grainsize = 100) {
+  static_assert(std::is_integral<T>::value, "end must be integral type");
+  for_(typename std::is_unsigned<T>::type(), parallelize, begin, end, f,
+       grainsize);
+}
+
+template <typename T, typename Func>
+void for_i(bool parallelize, T size, Func f, int grainsize = 100) {
+  for_(parallelize, 0, size,
+       [&](const blocked_range& r) {
 #ifdef CNN_USE_OMP
 #pragma omp parallel for
 #endif
-        for (int i = r.begin(); i < r.end(); i++)
-            f(i);
-    }, grainsize);
+         for (int i = r.begin(); i < r.end(); i++) f(i);
+       },
+       grainsize);
 }
 
 template <typename T, typename Func>
 void for_i(T size, Func f, int grainsize = 100) {
-    for_i(true, size, f, grainsize);
+  for_i(true, size, f, grainsize);
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/parallel_for.h
+++ b/tiny_dnn/util/parallel_for.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <vector>
 #include <type_traits>

--- a/tiny_dnn/util/product.h
+++ b/tiny_dnn/util/product.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #if defined(CNN_USE_SSE) || defined(CNN_USE_AVX)
 #include <immintrin.h>

--- a/tiny_dnn/util/product.h
+++ b/tiny_dnn/util/product.h
@@ -6,8 +6,8 @@
 #if defined(CNN_USE_SSE) || defined(CNN_USE_AVX)
 #include <immintrin.h>
 #endif
-#include <cstdint>
 #include <cassert>
+#include <cstdint>
 #include <numeric>
 
 #if defined(_MSC_VER)
@@ -21,242 +21,295 @@
 namespace vectorize {
 namespace detail {
 
-
-template<typename T>
+template <typename T>
 inline bool is_aligned(T, const typename T::value_type* /*p*/) {
-    return true;
+  return true;
 }
 
-template<typename T>
-inline bool is_aligned(T, const typename T::value_type* p1, const typename T::value_type* p2) {
-    return is_aligned(T(), p1) && is_aligned(T(), p2);
+template <typename T>
+inline bool is_aligned(T, const typename T::value_type* p1,
+                       const typename T::value_type* p2) {
+  return is_aligned(T(), p1) && is_aligned(T(), p2);
 }
 
 // traits
 
 template <typename T>
 struct generic_vec_type {
-    typedef T register_type;
-    typedef T value_type;
-    enum {
-        unroll_size = 1
-    };
-    static register_type set1(const value_type& x) { return x; }
-    static register_type zero() { return register_type(0); }
-    static register_type mul(const register_type& v1, const register_type& v2) { return v1 * v2; }
-    static register_type add(const register_type& v1, const register_type& v2) { return v1 + v2; }
-    static register_type load(const value_type* px) { return *px; }
-    static register_type loadu(const value_type* px) { return *px; }
-    static void store(value_type* px, const register_type& v) { *px = v; }
-    static void storeu(value_type* px, const register_type& v) { *px = v; }
-    static value_type resemble(const register_type& x) { return x; }
+  typedef T register_type;
+  typedef T value_type;
+  enum { unroll_size = 1 };
+  static register_type set1(const value_type& x) { return x; }
+  static register_type zero() { return register_type(0); }
+  static register_type mul(const register_type& v1, const register_type& v2) {
+    return v1 * v2;
+  }
+  static register_type add(const register_type& v1, const register_type& v2) {
+    return v1 + v2;
+  }
+  static register_type load(const value_type* px) { return *px; }
+  static register_type loadu(const value_type* px) { return *px; }
+  static void store(value_type* px, const register_type& v) { *px = v; }
+  static void storeu(value_type* px, const register_type& v) { *px = v; }
+  static value_type resemble(const register_type& x) { return x; }
 };
 
 #ifdef CNN_USE_SSE
 
 struct float_sse {
-    typedef __m128 register_type;
-    typedef float value_type;
-    enum {
-        unroll_size = 4
-    };
-    static register_type set1(const value_type& x) { return _mm_set1_ps(x); }
-    static register_type zero() { register_type v = {}; return v; }
-    static register_type mul(const register_type& v1, const register_type& v2) { return _mm_mul_ps(v1, v2); }
-    static register_type add(const register_type& v1, const register_type& v2) { return _mm_add_ps(v1, v2); }
-    static register_type load(const value_type* px) { return _mm_load_ps(px); }
-    static register_type loadu(const value_type* px) { return _mm_loadu_ps(px); }
-    static void store(value_type* px, const register_type& v) { _mm_store_ps(px, v); }
-    static void storeu(value_type* px, const register_type& v) { _mm_storeu_ps(px, v); }
-    static value_type resemble(const register_type& x) {
-        VECTORIZE_ALIGN(16) float tmp[4];
-        _mm_store_ps(tmp, x);
-        return tmp[0] + tmp[1] + tmp[2] + tmp[3];
-    }
+  typedef __m128 register_type;
+  typedef float value_type;
+  enum { unroll_size = 4 };
+  static register_type set1(const value_type& x) { return _mm_set1_ps(x); }
+  static register_type zero() {
+    register_type v = {};
+    return v;
+  }
+  static register_type mul(const register_type& v1, const register_type& v2) {
+    return _mm_mul_ps(v1, v2);
+  }
+  static register_type add(const register_type& v1, const register_type& v2) {
+    return _mm_add_ps(v1, v2);
+  }
+  static register_type load(const value_type* px) { return _mm_load_ps(px); }
+  static register_type loadu(const value_type* px) { return _mm_loadu_ps(px); }
+  static void store(value_type* px, const register_type& v) {
+    _mm_store_ps(px, v);
+  }
+  static void storeu(value_type* px, const register_type& v) {
+    _mm_storeu_ps(px, v);
+  }
+  static value_type resemble(const register_type& x) {
+    VECTORIZE_ALIGN(16) float tmp[4];
+    _mm_store_ps(tmp, x);
+    return tmp[0] + tmp[1] + tmp[2] + tmp[3];
+  }
 };
 
 struct double_sse {
-    typedef __m128d register_type;
-    typedef double value_type;
-    enum {
-        unroll_size = 2
-    };
-    static register_type set1(const value_type& x) { return _mm_set1_pd(x); }
-    static register_type zero() { register_type v = {}; return v; }
-    static register_type mul(const register_type& v1, const register_type& v2) { return _mm_mul_pd(v1, v2); }
-    static register_type add(const register_type& v1, const register_type& v2) { return _mm_add_pd(v1, v2); }
-    static register_type load(const value_type* px) { return _mm_load_pd(px); }
-    static register_type loadu(const value_type* px) { return _mm_loadu_pd(px); }
-    static void store(value_type* px, const register_type& v) { _mm_store_pd(px, v); }
-    static void storeu(value_type* px, const register_type& v) { _mm_storeu_pd(px, v); }
-    static value_type resemble(const register_type& x) {
-        VECTORIZE_ALIGN(16) double tmp[2];
-        _mm_store_pd(tmp, x);
-        return tmp[0] + tmp[1];
-    }
+  typedef __m128d register_type;
+  typedef double value_type;
+  enum { unroll_size = 2 };
+  static register_type set1(const value_type& x) { return _mm_set1_pd(x); }
+  static register_type zero() {
+    register_type v = {};
+    return v;
+  }
+  static register_type mul(const register_type& v1, const register_type& v2) {
+    return _mm_mul_pd(v1, v2);
+  }
+  static register_type add(const register_type& v1, const register_type& v2) {
+    return _mm_add_pd(v1, v2);
+  }
+  static register_type load(const value_type* px) { return _mm_load_pd(px); }
+  static register_type loadu(const value_type* px) { return _mm_loadu_pd(px); }
+  static void store(value_type* px, const register_type& v) {
+    _mm_store_pd(px, v);
+  }
+  static void storeu(value_type* px, const register_type& v) {
+    _mm_storeu_pd(px, v);
+  }
+  static value_type resemble(const register_type& x) {
+    VECTORIZE_ALIGN(16) double tmp[2];
+    _mm_store_pd(tmp, x);
+    return tmp[0] + tmp[1];
+  }
 };
 
-template<typename T>
+template <typename T>
 struct sse {};
-template<>
+template <>
 struct sse<float> : public float_sse {};
-template<>
+template <>
 struct sse<double> : public double_sse {};
 
-template<typename T>
+template <typename T>
 inline bool is_aligned(sse<T>, const typename sse<T>::value_type* p) {
-    return reinterpret_cast<std::size_t>(p) % 16 == 0;
+  return reinterpret_cast<std::size_t>(p) % 16 == 0;
 }
 
-#endif // CNN_USE_SSE
+#endif  // CNN_USE_SSE
 
 #ifdef CNN_USE_AVX
 
 struct float_avx {
-    typedef __m256 register_type;
-    typedef float value_type;
-    enum {
-        unroll_size = 8
-    };
-    static register_type set1(const value_type& x) { return _mm256_set1_ps(x); }
-    static register_type zero() { register_type v = {}; return v; }
-    static register_type mul(const register_type& v1, const register_type& v2) { return _mm256_mul_ps(v1, v2); }
-    static register_type add(const register_type& v1, const register_type& v2) { return _mm256_add_ps(v1, v2); }
-    static register_type load(const value_type* px) { return _mm256_load_ps(px); }
-    static register_type loadu(const value_type* px) { return _mm256_loadu_ps(px); }
-    static void store(value_type* px, const register_type& v) { _mm256_store_ps(px, v); }
-    static void storeu(value_type* px, const register_type& v) { _mm256_storeu_ps(px, v); }
-    static value_type resemble(const register_type& x) { 
-        VECTORIZE_ALIGN(32) float tmp[8];
-        _mm256_store_ps(tmp, x);
-        return std::accumulate(tmp, tmp + 8, 0.0f);
-    }
+  typedef __m256 register_type;
+  typedef float value_type;
+  enum { unroll_size = 8 };
+  static register_type set1(const value_type& x) { return _mm256_set1_ps(x); }
+  static register_type zero() {
+    register_type v = {};
+    return v;
+  }
+  static register_type mul(const register_type& v1, const register_type& v2) {
+    return _mm256_mul_ps(v1, v2);
+  }
+  static register_type add(const register_type& v1, const register_type& v2) {
+    return _mm256_add_ps(v1, v2);
+  }
+  static register_type load(const value_type* px) { return _mm256_load_ps(px); }
+  static register_type loadu(const value_type* px) {
+    return _mm256_loadu_ps(px);
+  }
+  static void store(value_type* px, const register_type& v) {
+    _mm256_store_ps(px, v);
+  }
+  static void storeu(value_type* px, const register_type& v) {
+    _mm256_storeu_ps(px, v);
+  }
+  static value_type resemble(const register_type& x) {
+    VECTORIZE_ALIGN(32) float tmp[8];
+    _mm256_store_ps(tmp, x);
+    return std::accumulate(tmp, tmp + 8, 0.0f);
+  }
 };
 
 struct double_avx {
-    typedef __m256d register_type;
-    typedef double value_type;
-    enum {
-        unroll_size = 4
-    };
-    static register_type set1(const value_type& x) { return _mm256_set1_pd(x); }
-    static register_type zero() { register_type v = {}; return v; }
-    static register_type mul(const register_type& v1, const register_type& v2) { return _mm256_mul_pd(v1, v2); }
-    static register_type add(const register_type& v1, const register_type& v2) { return _mm256_add_pd(v1, v2); }
-    static register_type load(const value_type* px) { return _mm256_load_pd(px); }
-    static register_type loadu(const value_type* px) { return _mm256_loadu_pd(px); }
-    static void store(value_type* px, const register_type& v) { _mm256_store_pd(px, v); }
-    static void storeu(value_type* px, const register_type& v) { _mm256_storeu_pd(px, v); }
-    static value_type resemble(const register_type& x) {
-        VECTORIZE_ALIGN(32) double tmp[4];
-        _mm256_store_pd(tmp, x);
-        return std::accumulate(tmp, tmp + 4, 0.0);  
-    }
+  typedef __m256d register_type;
+  typedef double value_type;
+  enum { unroll_size = 4 };
+  static register_type set1(const value_type& x) { return _mm256_set1_pd(x); }
+  static register_type zero() {
+    register_type v = {};
+    return v;
+  }
+  static register_type mul(const register_type& v1, const register_type& v2) {
+    return _mm256_mul_pd(v1, v2);
+  }
+  static register_type add(const register_type& v1, const register_type& v2) {
+    return _mm256_add_pd(v1, v2);
+  }
+  static register_type load(const value_type* px) { return _mm256_load_pd(px); }
+  static register_type loadu(const value_type* px) {
+    return _mm256_loadu_pd(px);
+  }
+  static void store(value_type* px, const register_type& v) {
+    _mm256_store_pd(px, v);
+  }
+  static void storeu(value_type* px, const register_type& v) {
+    _mm256_storeu_pd(px, v);
+  }
+  static value_type resemble(const register_type& x) {
+    VECTORIZE_ALIGN(32) double tmp[4];
+    _mm256_store_pd(tmp, x);
+    return std::accumulate(tmp, tmp + 4, 0.0);
+  }
 };
 
-template<typename T>
+template <typename T>
 struct avx {};
-template<>
+template <>
 struct avx<float> : public float_avx {};
-template<>
+template <>
 struct avx<double> : public double_avx {};
 
-template<typename T>
+template <typename T>
 inline bool is_aligned(avx<T>, const typename avx<T>::value_type* p) {
-    return reinterpret_cast<std::size_t>(p) % 32 == 0;
+  return reinterpret_cast<std::size_t>(p) % 32 == 0;
 }
 
-#endif // CNN_USE_AVX
+#endif  // CNN_USE_AVX
 
 // generic dot-product
-template<typename T>
-inline typename T::value_type dot_product_nonaligned(const typename T::value_type* f1, const typename T::value_type* f2, std::size_t  size) {
-    typename T::register_type result = T::zero();
+template <typename T>
+inline typename T::value_type dot_product_nonaligned(
+    const typename T::value_type* f1, const typename T::value_type* f2,
+    std::size_t size) {
+  typename T::register_type result = T::zero();
 
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) 
-        result = T::add(result, T::mul(T::loadu(&f1[i*T::unroll_size]), T::loadu(&f2[i*T::unroll_size])));  
+  for (std::size_t i = 0; i < size / T::unroll_size; i++)
+    result = T::add(result, T::mul(T::loadu(&f1[i * T::unroll_size]),
+                                   T::loadu(&f2[i * T::unroll_size])));
 
-    typename T::value_type sum = T::resemble(result);
+  typename T::value_type sum = T::resemble(result);
 
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        sum += f1[i] * f2[i];
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    sum += f1[i] * f2[i];
 
-    return sum;
+  return sum;
 }
 
 // generic dot-product(aligned)
-template<typename T>
-inline typename T::value_type dot_product_aligned(const typename T::value_type* f1, const typename T::value_type* f2, std::size_t  size) {
-    typename T::register_type result = T::zero();
+template <typename T>
+inline typename T::value_type dot_product_aligned(
+    const typename T::value_type* f1, const typename T::value_type* f2,
+    std::size_t size) {
+  typename T::register_type result = T::zero();
 
-    assert(is_aligned(T(), f1));
-    assert(is_aligned(T(), f2));
+  assert(is_aligned(T(), f1));
+  assert(is_aligned(T(), f2));
 
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) 
-        result = T::add(result, T::mul(T::load(&f1[i*T::unroll_size]), T::load(&f2[i*T::unroll_size])));  
-    
-    typename T::value_type sum = T::resemble(result);
+  for (std::size_t i = 0; i < size / T::unroll_size; i++)
+    result = T::add(result, T::mul(T::load(&f1[i * T::unroll_size]),
+                                   T::load(&f2[i * T::unroll_size])));
 
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        sum += f1[i] * f2[i];
+  typename T::value_type sum = T::resemble(result);
 
-    return sum;
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    sum += f1[i] * f2[i];
+
+  return sum;
 }
 
-template<typename T>
-inline void muladd_aligned(const typename T::value_type* src, typename T::value_type c, std::size_t  size, typename T::value_type* dst) {
-    typename T::register_type factor = T::set1(c);
+template <typename T>
+inline void muladd_aligned(const typename T::value_type* src,
+                           typename T::value_type c, std::size_t size,
+                           typename T::value_type* dst) {
+  typename T::register_type factor = T::set1(c);
 
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) {
-        typename T::register_type d = T::load(&dst[i*T::unroll_size]);
-        typename T::register_type s = T::load(&src[i*T::unroll_size]);
-        T::store(&dst[i*T::unroll_size], T::add(d, T::mul(s, factor)));
-    }
+  for (std::size_t i = 0; i < size / T::unroll_size; i++) {
+    typename T::register_type d = T::load(&dst[i * T::unroll_size]);
+    typename T::register_type s = T::load(&src[i * T::unroll_size]);
+    T::store(&dst[i * T::unroll_size], T::add(d, T::mul(s, factor)));
+  }
 
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        dst[i] += src[i] * c;
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    dst[i] += src[i] * c;
 }
 
+template <typename T>
+inline void muladd_nonaligned(const typename T::value_type* src,
+                              typename T::value_type c, std::size_t size,
+                              typename T::value_type* dst) {
+  typename T::register_type factor = T::set1(c);
 
-template<typename T>
-inline void muladd_nonaligned(const typename T::value_type* src, typename T::value_type c, std::size_t  size, typename T::value_type* dst) {
-    typename T::register_type factor = T::set1(c);
+  for (std::size_t i = 0; i < size / T::unroll_size; i++) {
+    typename T::register_type d = T::loadu(&dst[i * T::unroll_size]);
+    typename T::register_type s = T::loadu(&src[i * T::unroll_size]);
+    T::storeu(&dst[i * T::unroll_size], T::add(d, T::mul(s, factor)));
+  }
 
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) {
-        typename T::register_type d = T::loadu(&dst[i*T::unroll_size]);
-        typename T::register_type s = T::loadu(&src[i*T::unroll_size]);
-        T::storeu(&dst[i*T::unroll_size], T::add(d, T::mul(s, factor)));
-    }
-
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        dst[i] += src[i] * c;
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    dst[i] += src[i] * c;
 }
 
-template<typename T>
-inline void reduce_nonaligned(const typename T::value_type* src, std::size_t  size, typename T::value_type* dst) {
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) {
-        typename T::register_type d = T::loadu(&dst[i*T::unroll_size]);
-        typename T::register_type s = T::loadu(&src[i*T::unroll_size]);
-        T::storeu(&dst[i*T::unroll_size], T::add(d, s));
-    }
+template <typename T>
+inline void reduce_nonaligned(const typename T::value_type* src,
+                              std::size_t size, typename T::value_type* dst) {
+  for (std::size_t i = 0; i < size / T::unroll_size; i++) {
+    typename T::register_type d = T::loadu(&dst[i * T::unroll_size]);
+    typename T::register_type s = T::loadu(&src[i * T::unroll_size]);
+    T::storeu(&dst[i * T::unroll_size], T::add(d, s));
+  }
 
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        dst[i] += src[i];
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    dst[i] += src[i];
 }
 
-template<typename T>
-inline void reduce_aligned(const typename T::value_type* src, std::size_t  size, typename T::value_type* dst) {
-    for (std::size_t i = 0; i < size/T::unroll_size; i++) {
-        typename T::register_type d = T::loadu(&dst[i*T::unroll_size]);
-        typename T::register_type s = T::loadu(&src[i*T::unroll_size]);
-        T::storeu(&dst[i*T::unroll_size], T::add(d, s));
-    }
+template <typename T>
+inline void reduce_aligned(const typename T::value_type* src, std::size_t size,
+                           typename T::value_type* dst) {
+  for (std::size_t i = 0; i < size / T::unroll_size; i++) {
+    typename T::register_type d = T::loadu(&dst[i * T::unroll_size]);
+    typename T::register_type s = T::loadu(&src[i * T::unroll_size]);
+    T::storeu(&dst[i * T::unroll_size], T::add(d, s));
+  }
 
-    for (std::size_t i = (size/T::unroll_size)*T::unroll_size; i < size; i++)
-        dst[i] += src[i];
+  for (std::size_t i = (size / T::unroll_size) * T::unroll_size; i < size; i++)
+    dst[i] += src[i];
 }
 
-} // namespace detail
+}  // namespace detail
 
 #if defined(CNN_USE_AVX)
 #define VECTORIZE_TYPE(T) detail::avx<T>
@@ -267,30 +320,30 @@ inline void reduce_aligned(const typename T::value_type* src, std::size_t  size,
 #endif
 
 // dst[i] += c * src[i]
-template<typename T>
-void muladd(const T* src, T c, std::size_t  size, T* dst) {
-    if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
-        detail::muladd_aligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
-    else
-        detail::muladd_nonaligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
+template <typename T>
+void muladd(const T* src, T c, std::size_t size, T* dst) {
+  if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
+    detail::muladd_aligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
+  else
+    detail::muladd_nonaligned<VECTORIZE_TYPE(T)>(src, c, size, dst);
 }
 
 // sum(s1[i] * s2[i])
-template<typename T>
-T dot(const T* s1, const T* s2, std::size_t  size) {
-    if (detail::is_aligned(VECTORIZE_TYPE(T)(), s1, s2))
-        return detail::dot_product_aligned<VECTORIZE_TYPE(T)>(s1, s2, size);
-    else
-        return detail::dot_product_nonaligned<VECTORIZE_TYPE(T)>(s1, s2, size);
+template <typename T>
+T dot(const T* s1, const T* s2, std::size_t size) {
+  if (detail::is_aligned(VECTORIZE_TYPE(T)(), s1, s2))
+    return detail::dot_product_aligned<VECTORIZE_TYPE(T)>(s1, s2, size);
+  else
+    return detail::dot_product_nonaligned<VECTORIZE_TYPE(T)>(s1, s2, size);
 }
 
 /// dst[i] += src[i]
-template<typename T>
-void reduce(const T* src, std::size_t  size, T* dst) {
-    if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
-        return detail::reduce_aligned<VECTORIZE_TYPE(T)>(src, size, dst);
-    else
-        return detail::reduce_nonaligned<VECTORIZE_TYPE(T)>(src, size, dst);
+template <typename T>
+void reduce(const T* src, std::size_t size, T* dst) {
+  if (detail::is_aligned(VECTORIZE_TYPE(T)(), src, dst))
+    return detail::reduce_aligned<VECTORIZE_TYPE(T)>(src, size, dst);
+  else
+    return detail::reduce_nonaligned<VECTORIZE_TYPE(T)>(src, size, dst);
 }
 
-} // namespace vectorize
+}  // namespace vectorize

--- a/tiny_dnn/util/random.h
+++ b/tiny_dnn/util/random.h
@@ -3,79 +3,74 @@
 // found in the LICENSE file.
 
 #pragma once
+#include <limits>
 #include <random>
 #include <type_traits>
-#include <limits>
 #include "nn_error.h"
 #include "tiny_dnn/config.h"
 
 namespace tiny_dnn {
 
 class random_generator {
-public:
-    static random_generator& get_instance() {
-        static random_generator instance;
-        return instance;
-    }
+ public:
+  static random_generator& get_instance() {
+    static random_generator instance;
+    return instance;
+  }
 
-    std::mt19937& operator()() {
-        return gen_;
-    }
+  std::mt19937& operator()() { return gen_; }
 
-    void set_seed(unsigned int seed) {
-        gen_.seed(seed);
-    }
-private:
-    // avoid gen_(0) for MSVC known issue
-    // https://connect.microsoft.com/VisualStudio/feedback/details/776456
-    random_generator() : gen_(1) {}
-    std::mt19937 gen_;
+  void set_seed(unsigned int seed) { gen_.seed(seed); }
+
+ private:
+  // avoid gen_(0) for MSVC known issue
+  // https://connect.microsoft.com/VisualStudio/feedback/details/776456
+  random_generator() : gen_(1) {}
+  std::mt19937 gen_;
 };
 
-template<typename T> inline
-typename std::enable_if<std::is_integral<T>::value, T>::type
+template <typename T>
+inline typename std::enable_if<std::is_integral<T>::value, T>::type
 uniform_rand(T min, T max) {
-    std::uniform_int_distribution<T> dst(min, max);
-    return dst(random_generator::get_instance()());
+  std::uniform_int_distribution<T> dst(min, max);
+  return dst(random_generator::get_instance()());
 }
 
-template<typename T> inline
-typename std::enable_if<std::is_floating_point<T>::value, T>::type
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 uniform_rand(T min, T max) {
-    std::uniform_real_distribution<T> dst(min, max);
-    return dst(random_generator::get_instance()());
+  std::uniform_real_distribution<T> dst(min, max);
+  return dst(random_generator::get_instance()());
 }
 
-template<typename T> inline
-typename std::enable_if<std::is_floating_point<T>::value, T>::type
+template <typename T>
+inline typename std::enable_if<std::is_floating_point<T>::value, T>::type
 gaussian_rand(T mean, T sigma) {
-    std::normal_distribution<T> dst(mean, sigma);
-    return dst(random_generator::get_instance()());
+  std::normal_distribution<T> dst(mean, sigma);
+  return dst(random_generator::get_instance()());
 }
 
 inline void set_random_seed(unsigned int seed) {
-    random_generator::get_instance().set_seed(seed);
+  random_generator::get_instance().set_seed(seed);
 }
 
-template<typename Container>
+template <typename Container>
 inline int uniform_idx(const Container& t) {
-    return uniform_rand(0, int(t.size() - 1));
+  return uniform_rand(0, int(t.size() - 1));
 }
 
 inline bool bernoulli(float_t p) {
-    return uniform_rand(float_t(0), float_t(1)) <= p;
+  return uniform_rand(float_t(0), float_t(1)) <= p;
 }
 
-template<typename Iter>
+template <typename Iter>
 void uniform_rand(Iter begin, Iter end, float_t min, float_t max) {
-    for (Iter it = begin; it != end; ++it)
-        *it = uniform_rand(min, max);
+  for (Iter it = begin; it != end; ++it) *it = uniform_rand(min, max);
 }
 
-template<typename Iter>
+template <typename Iter>
 void gaussian_rand(Iter begin, Iter end, float_t mean, float_t sigma) {
-    for (Iter it = begin; it != end; ++it)
-        *it = gaussian_rand(mean, sigma);
+  for (Iter it = begin; it != end; ++it) *it = gaussian_rand(mean, sigma);
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/random.h
+++ b/tiny_dnn/util/random.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <random>
 #include <type_traits>

--- a/tiny_dnn/util/serialization_helper.h
+++ b/tiny_dnn/util/serialization_helper.h
@@ -3,223 +3,259 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <typeindex>
-#include <map>
-#include <functional>
-#include <memory>
-#include <string>
 #include <cereal/archives/json.hpp>
 #include <cereal/types/memory.hpp>
-#include "tiny_dnn/util/nn_error.h"
-#include "tiny_dnn/util/macro.h"
+#include <functional>
+#include <map>
+#include <memory>
+#include <string>
+#include <typeindex>
 #include "tiny_dnn/layers/layers.h"
+#include "tiny_dnn/util/macro.h"
+#include "tiny_dnn/util/nn_error.h"
 
 namespace tiny_dnn {
 
 template <typename InputArchive, typename OutputArchive>
 class serialization_helper {
-public:
-    void register_loader(const std::string& name, std::function<std::shared_ptr<layer>(InputArchive&)> func) {
-        loaders_[name] = [=](void* ar) {
-            return func(*reinterpret_cast<InputArchive*>(ar));
-        };
+ public:
+  void register_loader(
+      const std::string& name,
+      std::function<std::shared_ptr<layer>(InputArchive&)> func) {
+    loaders_[name] = [=](void* ar) {
+      return func(*reinterpret_cast<InputArchive*>(ar));
+    };
+  }
+
+  void register_saver(const std::string& name,
+                      std::function<void(OutputArchive&, const layer*)> func) {
+    savers_[name] = [=](void* ar, const layer* l) {
+      return func(*reinterpret_cast<OutputArchive*>(ar), l);
+    };
+  }
+
+  template <typename T>
+  void register_type(const std::string& name) {
+    type_names_[typeid(T)] = name;
+  }
+
+  std::shared_ptr<layer> load(const std::string& layer_name, InputArchive& ar) {
+    check_if_serialization_enabled();
+
+    if (loaders_.find(layer_name) == loaders_.end()) {
+      throw nn_error("Failed to generate layer. Generator for " + layer_name +
+                     " is not found.\n"
+                     "Please use CNN_REGISTER_LAYER_DESERIALIZER macro to "
+                     "register appropriate generator");
     }
 
-    void register_saver(const std::string& name, std::function<void(OutputArchive&, const layer*)> func) {
-        savers_[name] = [=](void* ar, const layer* l) {
-            return func(*reinterpret_cast<OutputArchive*>(ar), l);
-        };
+    return loaders_[layer_name](reinterpret_cast<void*>(&ar));
+  }
+
+  void save(const std::string& layer_name, OutputArchive& ar, const layer* l) {
+    check_if_serialization_enabled();
+
+    if (savers_.find(layer_name) == savers_.end()) {
+      throw nn_error("Failed to generate layer. Generator for " + layer_name +
+                     " is not found.\n"
+                     "Please use CNN_REGISTER_LAYER_DESERIALIZER macro to "
+                     "register appropriate generator");
     }
 
-    template <typename T>
-    void register_type(const std::string& name) {
-        type_names_[typeid(T)] = name;
+    savers_[layer_name](reinterpret_cast<void*>(&ar), l);
+  }
+
+  std::string serialization_name(std::type_index index) const {
+    if (type_names_.find(index) == type_names_.end()) {
+      throw nn_error("Typename is not registered");
     }
+    return type_names_.at(index);
+  }
 
-    std::shared_ptr<layer> load(const std::string& layer_name, InputArchive& ar) {
-        check_if_serialization_enabled();
+  static serialization_helper& get_instance() {
+    static serialization_helper instance;
+    return instance;
+  }
 
-        if (loaders_.find(layer_name) == loaders_.end()) {
-            throw nn_error("Failed to generate layer. Generator for " + layer_name + " is not found.\n"
-                           "Please use CNN_REGISTER_LAYER_DESERIALIZER macro to register appropriate generator");
-        }
-
-        return loaders_[layer_name](reinterpret_cast<void*>(&ar));
-    }
-
-    void save(const std::string& layer_name, OutputArchive & ar, const layer *l) {
-        check_if_serialization_enabled();
-
-        if (savers_.find(layer_name) == savers_.end()) {
-            throw nn_error("Failed to generate layer. Generator for " + layer_name + " is not found.\n"
-                "Please use CNN_REGISTER_LAYER_DESERIALIZER macro to register appropriate generator");
-        }
-
-        savers_[layer_name](reinterpret_cast<void*>(&ar), l);
-    }
-
-    std::string serialization_name(std::type_index index) const {
-        if (type_names_.find(index) == type_names_.end()) {
-            throw nn_error("Typename is not registered");
-        }
-        return type_names_.at(index);
-    }
-
-    static serialization_helper& get_instance() {
-        static serialization_helper instance;
-        return instance;
-    }
-
-private:
-    void check_if_serialization_enabled() const {
+ private:
+  void check_if_serialization_enabled() const {
 #ifdef CNN_NO_SERIALIZATION
-        static_assert(sizeof(InputArchive)==0,
-                             "You are using save/load functions, but serialization function is disabled in current configuration.\n\n"
-                             "You need to undef CNN_NO_SERIALIZATION to enable these functions.\n"
-                             "If you are using cmake, you can use -DUSE_SERIALIZER=ON option.\n\n");
+    static_assert(
+        sizeof(InputArchive) == 0,
+        "You are using save/load functions, but serialization function is "
+        "disabled in current configuration.\n\n"
+        "You need to undef CNN_NO_SERIALIZATION to enable these functions.\n"
+        "If you are using cmake, you can use -DUSE_SERIALIZER=ON option.\n\n");
 #endif
-    }
+  }
 
-    /** layer-type -> generator  */
-    std::map<std::string, std::function<std::shared_ptr<layer>(void*)>> loaders_;
+  /** layer-type -> generator  */
+  std::map<std::string, std::function<std::shared_ptr<layer>(void*)>> loaders_;
 
-    std::map<std::string, std::function<void(void*, const layer*)>> savers_;
+  std::map<std::string, std::function<void(void*, const layer*)>> savers_;
 
-    std::map<std::type_index, std::string> type_names_;
+  std::map<std::type_index, std::string> type_names_;
 
-#define CNN_REGISTER_LAYER_BODY(layer_type, layer_name) \
-    register_loader(layer_name, detail::load_layer_impl<InputArchive, layer_type>);\
-    register_type<layer_type>(layer_name);\
-    register_saver(layer_name, detail::save_layer_impl<OutputArchive, layer_type>)
+#define CNN_REGISTER_LAYER_BODY(layer_type, layer_name)               \
+  register_loader(layer_name,                                         \
+                  detail::load_layer_impl<InputArchive, layer_type>); \
+  register_type<layer_type>(layer_name);                              \
+  register_saver(layer_name, detail::save_layer_impl<OutputArchive, layer_type>)
 
-#define CNN_REGISTER_LAYER(layer_type, layer_name) CNN_REGISTER_LAYER_BODY(layer_type, #layer_name)
+#define CNN_REGISTER_LAYER(layer_type, layer_name) \
+  CNN_REGISTER_LAYER_BODY(layer_type, #layer_name)
 
-#define CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, activation_type, layer_name) \
-CNN_REGISTER_LAYER_BODY(layer_type<activation::activation_type>, #layer_name "<" #activation_type ">")
+#define CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, activation_type, \
+                                           layer_name)                  \
+  CNN_REGISTER_LAYER_BODY(layer_type<activation::activation_type>,      \
+                          #layer_name "<" #activation_type ">")
 
-#define CNN_REGISTER_LAYER_WITH_ACTIVATIONS(layer_type, layer_name) \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, tan_h, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, softmax, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, identity, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, sigmoid, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, relu, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, leaky_relu, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, elu, layer_name); \
-CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, tan_hp1m2, layer_name)
+#define CNN_REGISTER_LAYER_WITH_ACTIVATIONS(layer_type, layer_name)       \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, tan_h, layer_name);      \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, softmax, layer_name);    \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, identity, layer_name);   \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, sigmoid, layer_name);    \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, relu, layer_name);       \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, leaky_relu, layer_name); \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, elu, layer_name);        \
+  CNN_REGISTER_LAYER_WITH_ACTIVATION(layer_type, tan_hp1m2, layer_name)
 
-    serialization_helper();
+  serialization_helper();
 };
 
 namespace detail {
 
 template <typename InputArchive, typename T>
 std::shared_ptr<layer> load_layer_impl(InputArchive& ia) {
+  using ST = typename std::aligned_storage<sizeof(T), CNN_ALIGNOF(T)>::type;
 
-    using ST = typename std::aligned_storage<sizeof(T), CNN_ALIGNOF(T)>::type;
+  std::unique_ptr<ST> bn(new ST());
 
-    std::unique_ptr<ST> bn(new ST());
+  cereal::memory_detail::LoadAndConstructLoadWrapper<InputArchive, T> wrapper(
+      reinterpret_cast<T*>(bn.get()));
 
-    cereal::memory_detail::LoadAndConstructLoadWrapper<InputArchive, T> wrapper(reinterpret_cast<T*>(bn.get()));
+  wrapper.CEREAL_SERIALIZE_FUNCTION_NAME(ia);
 
-    wrapper.CEREAL_SERIALIZE_FUNCTION_NAME(ia);
+  std::shared_ptr<layer> t;
+  t.reset(reinterpret_cast<T*>(bn.get()));
+  bn.release();
 
-    std::shared_ptr<layer> t;
-    t.reset(reinterpret_cast<T*>(bn.get()));
-    bn.release();
-
-    return t;
+  return t;
 }
 
 template <typename OutputArchive, typename T>
-void save_layer_impl(OutputArchive& oa, const layer *layer) {
-    typedef typename cereal::traits::detail::get_input_from_output<OutputArchive>::type InputArchive;
+void save_layer_impl(OutputArchive& oa, const layer* layer) {
+  typedef typename cereal::traits::detail::get_input_from_output<
+      OutputArchive>::type InputArchive;
 
-    oa (cereal::make_nvp(serialization_helper<InputArchive, OutputArchive>::get_instance().serialization_name(typeid(T)),
-                         *dynamic_cast<const T*>(layer)));
+  oa(cereal::make_nvp(
+      serialization_helper<InputArchive, OutputArchive>::get_instance()
+          .serialization_name(typeid(T)),
+      *dynamic_cast<const T*>(layer)));
 }
 
 template <typename InputArchive, typename OutputArchive, typename T>
 struct automatic_layer_generator_register {
-    explicit automatic_layer_generator_register(const std::string& s) {
-        serialization_helper<InputArchive, OutputArchive>::get_instance().register_loader(s, load_layer_impl<InputArchive, T>);
-        serialization_helper<InputArchive, OutputArchive>::get_instance().template register_type<T>(s);
-        serialization_helper<InputArchive, OutputArchive>::get_instance().register_saver(s, save_layer_impl<OutputArchive, T>);
-    }
+  explicit automatic_layer_generator_register(const std::string& s) {
+    serialization_helper<InputArchive, OutputArchive>::get_instance()
+        .register_loader(s, load_layer_impl<InputArchive, T>);
+    serialization_helper<InputArchive, OutputArchive>::get_instance()
+        .template register_type<T>(s);
+    serialization_helper<InputArchive, OutputArchive>::get_instance()
+        .register_saver(s, save_layer_impl<OutputArchive, T>);
+  }
 };
 
 template <typename OutputArchive>
 void serialize_prolog(OutputArchive& oa, std::type_index typeindex) {
-    typedef typename cereal::traits::detail::get_input_from_output<OutputArchive>::type InputArchive;
+  typedef typename cereal::traits::detail::get_input_from_output<
+      OutputArchive>::type InputArchive;
 
-    oa(cereal::make_nvp("type",
-        serialization_helper<InputArchive, OutputArchive>::get_instance()
-        .serialization_name(typeindex)));
+  oa(cereal::make_nvp(
+      "type", serialization_helper<InputArchive, OutputArchive>::get_instance()
+                  .serialization_name(typeindex)));
 }
 
-} // namespace detail
+}  // namespace detail
 
 template <typename T>
-void start_loading_layer(T & ar) {}
+void start_loading_layer(T& ar) {}
 
 template <typename T>
-void finish_loading_layer(T & ar) {}
+void finish_loading_layer(T& ar) {}
 
-inline void start_loading_layer(cereal::JSONInputArchive & ia) { ia.startNode(); }
+inline void start_loading_layer(cereal::JSONInputArchive& ia) {
+  ia.startNode();
+}
 
-inline void finish_loading_layer(cereal::JSONInputArchive & ia) { ia.finishNode(); }
-
+inline void finish_loading_layer(cereal::JSONInputArchive& ia) {
+  ia.finishNode();
+}
 
 template <typename InputArchive, typename OutputArchive>
 serialization_helper<InputArchive, OutputArchive>::serialization_helper() {
 #include "serialization_layer_list.h"
 }
 
-
 /**
 * generate layer from cereal's Archive
 **/
 template <typename InputArchive>
-std::shared_ptr<layer> layer::load_layer(InputArchive & ia) {
-    typedef typename cereal::traits::detail::get_output_from_input<InputArchive>::type OutputArchive;
+std::shared_ptr<layer> layer::load_layer(InputArchive& ia) {
+  typedef
+      typename cereal::traits::detail::get_output_from_input<InputArchive>::type
+          OutputArchive;
 
-    start_loading_layer(ia);
+  start_loading_layer(ia);
 
-    std::string p;
-    ia(cereal::make_nvp("type", p));
-    auto l = serialization_helper<InputArchive, OutputArchive>::get_instance().load(p, ia);
+  std::string p;
+  ia(cereal::make_nvp("type", p));
+  auto l =
+      serialization_helper<InputArchive, OutputArchive>::get_instance().load(
+          p, ia);
 
-    finish_loading_layer(ia);
+  finish_loading_layer(ia);
 
-    return l;
+  return l;
 }
 
 template <typename OutputArchive>
-void layer::save_layer(OutputArchive & oa, const layer& l) {
-    typedef typename cereal::traits::detail::get_input_from_output<OutputArchive>::type InputArchive;
+void layer::save_layer(OutputArchive& oa, const layer& l) {
+  typedef typename cereal::traits::detail::get_input_from_output<
+      OutputArchive>::type InputArchive;
 
-    std::string name = serialization_helper<InputArchive, OutputArchive>::get_instance().serialization_name(typeid(l));
-    serialization_helper<InputArchive, OutputArchive>::get_instance().save(name, oa, &l);
+  std::string name =
+      serialization_helper<InputArchive, OutputArchive>::get_instance()
+          .serialization_name(typeid(l));
+  serialization_helper<InputArchive, OutputArchive>::get_instance().save(
+      name, oa, &l);
 }
-
 
 template <class Archive>
-void layer::serialize_prolog(Archive & ar) {
-    detail::serialize_prolog(ar, typeid(*this));
+void layer::serialize_prolog(Archive& ar) {
+  detail::serialize_prolog(ar, typeid(*this));
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn
 
-#define CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type, layer_name, unique_name) \
-static tiny_dnn::detail::automatic_layer_generator_register<cereal::JSONInputArchive, cereal::JSONOutputArchive, layer_type> s_register_##unique_name(layer_name);\
-static tiny_dnn::detail::automatic_layer_generator_register<cereal::BinaryInputArchive, cereal::BinaryOutputArchive, layer_type> s_register_binary_##unique_name(layer_name)
+#define CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type, layer_name,         \
+                                           unique_name)                    \
+  static tiny_dnn::detail::automatic_layer_generator_register<             \
+      cereal::JSONInputArchive, cereal::JSONOutputArchive, layer_type>     \
+      s_register_##unique_name(layer_name);                                \
+  static tiny_dnn::detail::automatic_layer_generator_register<             \
+      cereal::BinaryInputArchive, cereal::BinaryOutputArchive, layer_type> \
+      s_register_binary_##unique_name(layer_name)
 
-#define CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, activation_type, layer_name) \
-CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type<tiny_dnn::activation::activation_type>, #layer_name "<" #activation_type ">", layer_name##_##activation_type)
-
+#define CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(   \
+    layer_type, activation_type, layer_name)             \
+  CNN_REGISTER_LAYER_SERIALIZER_BODY(                    \
+      layer_type<tiny_dnn::activation::activation_type>, \
+      #layer_name "<" #activation_type ">", layer_name##_##activation_type)
 
 #ifdef CNN_NO_SERIALIZATION
 
-  // ignore all serialization functions
+// ignore all serialization functions
 #define CNN_REGISTER_LAYER_SERIALIZER(layer_type, layer_name)
 #define CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATIONS(layer_type, layer_name)
 
@@ -227,24 +263,31 @@ CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type<tiny_dnn::activation::activation_t
 
 /**
  * Register layer serializer
- * Once you define, you can create layer from text via generte_layer(InputArchive)
+ * Once you define, you can create layer from text via
+ *generte_layer(InputArchive)
  **/
 #define CNN_REGISTER_LAYER_SERIALIZER(layer_type, layer_name) \
-CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type, #layer_name, layer_name)
+  CNN_REGISTER_LAYER_SERIALIZER_BODY(layer_type, #layer_name, layer_name)
 
 /**
  * Register layer serializer
- * @todo we need to find better (easier to maintain) way to handle multiple activations
+ * @todo we need to find better (easier to maintain) way to handle multiple
+ *activations
  **/
 #define CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATIONS(layer_type, layer_name) \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, tan_h, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, softmax, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, identity, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, sigmoid, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, relu, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, leaky_relu, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, elu, layer_name); \
-CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, tan_hp1m2, layer_name)
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, tan_h,             \
+                                                layer_name);                   \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, softmax,           \
+                                                layer_name);                   \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, identity,          \
+                                                layer_name);                   \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, sigmoid,           \
+                                                layer_name);                   \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, relu, layer_name); \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, leaky_relu,        \
+                                                layer_name);                   \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, elu, layer_name);  \
+  CNN_REGISTER_LAYER_SERIALIZER_WITH_ACTIVATION(layer_type, tan_hp1m2,         \
+                                                layer_name)
 
-#endif // CNN_NO_SERIALIZATION
-
+#endif  // CNN_NO_SERIALIZATION

--- a/tiny_dnn/util/serialization_helper.h
+++ b/tiny_dnn/util/serialization_helper.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2016, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the tiny-dnn nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <typeindex>
 #include <map>

--- a/tiny_dnn/util/target_cost.h
+++ b/tiny_dnn/util/target_cost.h
@@ -1,3 +1,7 @@
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
 #pragma once
 #include "tiny_dnn/util/util.h"
 #include <numeric> // std::accumulate

--- a/tiny_dnn/util/target_cost.h
+++ b/tiny_dnn/util/target_cost.h
@@ -3,62 +3,75 @@
 // found in the LICENSE file.
 
 #pragma once
+#include <numeric>  // std::accumulate
 #include "tiny_dnn/util/util.h"
-#include <numeric> // std::accumulate
 
 namespace tiny_dnn {
 
 // calculate the number of samples for each class label
 //  - for example, if there are 10 samples having label 0, and
 //    20 samples having label 1, returns a vector [10, 20]
-inline std::vector<cnn_size_t> calculate_label_counts(const std::vector<label_t>& t) {
-    std::vector<cnn_size_t> label_counts;
-    for (label_t label : t) {
-        if (label >= label_counts.size()) {
-            label_counts.resize(label + 1);
-        }
-        label_counts[label]++;
+inline std::vector<cnn_size_t> calculate_label_counts(
+    const std::vector<label_t>& t) {
+  std::vector<cnn_size_t> label_counts;
+  for (label_t label : t) {
+    if (label >= label_counts.size()) {
+      label_counts.resize(label + 1);
     }
-    assert(std::accumulate(label_counts.begin(), label_counts.end(), static_cast<cnn_size_t>(0)) == t.size());
-    return label_counts;
+    label_counts[label]++;
+  }
+  assert(std::accumulate(label_counts.begin(), label_counts.end(),
+                         static_cast<cnn_size_t>(0)) == t.size());
+  return label_counts;
 }
 
 // calculate the weight of a given sample needed for a balanced target cost
-// NB: we call a target cost matrix "balanced", if the cost of each *class* is equal
-//     (this happens when the product weight * sample count is equal between the different
-//      classes, and the sum of these products equals the total number of samples)
-inline float_t get_sample_weight_for_balanced_target_cost(cnn_size_t classes, cnn_size_t total_samples, cnn_size_t this_class_samples)
-{
-    assert(this_class_samples <= total_samples);
-    return total_samples / static_cast<float_t>(classes * this_class_samples);
+// NB: we call a target cost matrix "balanced", if the cost of each *class* is
+// equal
+//     (this happens when the product weight * sample count is equal between the
+//     different
+//      classes, and the sum of these products equals the total number of
+//      samples)
+inline float_t get_sample_weight_for_balanced_target_cost(
+    cnn_size_t classes, cnn_size_t total_samples,
+    cnn_size_t this_class_samples) {
+  assert(this_class_samples <= total_samples);
+  return total_samples / static_cast<float_t>(classes * this_class_samples);
 }
 
-// create a target cost matrix implying equal cost for each *class* (distinct label)
-//  - by default, each *sample* has an equal cost, which means e.g. that a classifier
-//    may prefer to always guess the majority class (in case the degree of imbalance
+// create a target cost matrix implying equal cost for each *class* (distinct
+// label)
+//  - by default, each *sample* has an equal cost, which means e.g. that a
+//  classifier
+//    may prefer to always guess the majority class (in case the degree of
+//    imbalance
 //    is relatively high, and the classification task is relatively difficult)
 //  - the parameter w can be used to fine-tune the balance:
-//    * use 0 to have an equal cost for each *sample* (equal to not supplying any target costs at all)
-//    * use 1 to have an equal cost for each *class* (default behaviour of this function)
+//    * use 0 to have an equal cost for each *sample* (equal to not supplying
+//    any target costs at all)
+//    * use 1 to have an equal cost for each *class* (default behaviour of this
+//    function)
 //    * use a value between 0 and 1 to have something between the two extremes
-inline std::vector<vec_t> create_balanced_target_cost(const std::vector<label_t>& t, float_t w = 1.0)
-{
-    const auto label_counts = calculate_label_counts(t);
-    const cnn_size_t total_sample_count = t.size();
-    const cnn_size_t class_count = label_counts.size();
+inline std::vector<vec_t> create_balanced_target_cost(
+    const std::vector<label_t>& t, float_t w = 1.0) {
+  const auto label_counts = calculate_label_counts(t);
+  const cnn_size_t total_sample_count = t.size();
+  const cnn_size_t class_count = label_counts.size();
 
-    std::vector<vec_t> target_cost(t.size());
+  std::vector<vec_t> target_cost(t.size());
 
-    for (cnn_size_t i = 0; i < total_sample_count; ++i) {
-        vec_t& sample_cost = target_cost[i];
-        sample_cost.resize(class_count);
-        const float_t balanced_weight = get_sample_weight_for_balanced_target_cost(class_count, total_sample_count, label_counts[t[i]]);
-        const float_t unbalanced_weight = 1;
-        const float_t sample_weight = w * balanced_weight + (1 - w) * unbalanced_weight;
-        std::fill(sample_cost.begin(), sample_cost.end(), sample_weight);
-    }
+  for (cnn_size_t i = 0; i < total_sample_count; ++i) {
+    vec_t& sample_cost = target_cost[i];
+    sample_cost.resize(class_count);
+    const float_t balanced_weight = get_sample_weight_for_balanced_target_cost(
+        class_count, total_sample_count, label_counts[t[i]]);
+    const float_t unbalanced_weight = 1;
+    const float_t sample_weight =
+        w * balanced_weight + (1 - w) * unbalanced_weight;
+    std::fill(sample_cost.begin(), sample_cost.end(), sample_weight);
+  }
 
-    return target_cost;
+  return target_cost;
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2013, Taiga Nomi
-    All rights reserved.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
-
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include <vector>
 #include <functional>

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -3,27 +3,27 @@
 // found in the LICENSE file.
 
 #pragma once
-#include <vector>
-#include <functional>
-#include <random>
-#include <type_traits>
-#include <limits>
 #include <cassert>
-#include <cstdio>
 #include <cstdarg>
-#include <string>
+#include <cstdio>
+#include <functional>
+#include <limits>
+#include <random>
 #include <sstream>
+#include <string>
+#include <type_traits>
+#include <vector>
 
-#include <cereal/cereal.hpp>
-#include <cereal/archives/json.hpp>
 #include <cereal/archives/binary.hpp>
+#include <cereal/archives/json.hpp>
+#include <cereal/cereal.hpp>
+#include <cereal/types/deque.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
-#include <cereal/types/deque.hpp>
 
 #include "tiny_dnn/config.h"
-#include "tiny_dnn/util/macro.h"
 #include "tiny_dnn/util/aligned_allocator.h"
+#include "tiny_dnn/util/macro.h"
 #include "tiny_dnn/util/nn_error.h"
 #include "tiny_dnn/util/parallel_for.h"
 #include "tiny_dnn/util/random.h"
@@ -39,171 +39,171 @@
 namespace tiny_dnn {
 
 ///< output label(class-index) for classification
-///< must be equal to cnn_size_t, because size of last layer is equal to num. of classes
+///< must be equal to cnn_size_t, because size of last layer is equal to num. of
+///classes
 typedef cnn_size_t label_t;
 
-typedef cnn_size_t layer_size_t; // for backward compatibility
+typedef cnn_size_t layer_size_t;  // for backward compatibility
 
 typedef std::vector<float_t, aligned_allocator<float_t, 64>> vec_t;
 
 typedef std::vector<vec_t> tensor_t;
 
-enum class net_phase {
-    train,
-    test
-};
+enum class net_phase { train, test };
 
-template<typename T>
+template <typename T>
 T* reverse_endian(T* p) {
-    std::reverse(reinterpret_cast<char*>(p), reinterpret_cast<char*>(p) + sizeof(T));
-    return p;
+  std::reverse(reinterpret_cast<char*>(p),
+               reinterpret_cast<char*>(p) + sizeof(T));
+  return p;
 }
 
 inline bool is_little_endian() {
-    int x = 1;
-    return *(char*) &x != 0;
+  int x = 1;
+  return *(char*)&x != 0;
 }
 
-
-template<typename T>
+template <typename T>
 size_t max_index(const T& vec) {
-    auto begin_iterator = std::begin(vec);
-    return std::max_element(begin_iterator, std::end(vec)) - begin_iterator;
+  auto begin_iterator = std::begin(vec);
+  return std::max_element(begin_iterator, std::end(vec)) - begin_iterator;
 }
 
-template<typename T, typename U>
+template <typename T, typename U>
 U rescale(T x, T src_min, T src_max, U dst_min, U dst_max) {
-    U value =  static_cast<U>(((x - src_min) * (dst_max - dst_min)) / (src_max - src_min) + dst_min);
-    return std::min(dst_max, std::max(value, dst_min));
+  U value = static_cast<U>(
+      ((x - src_min) * (dst_max - dst_min)) / (src_max - src_min) + dst_min);
+  return std::min(dst_max, std::max(value, dst_min));
 }
 
-inline void nop()
-{
-    // do nothing
+inline void nop() {
+  // do nothing
 }
 
-template <typename T> inline T sqr(T value) { return value*value; }
-
-inline bool isfinite(float_t x) {
-    return x == x;
+template <typename T>
+inline T sqr(T value) {
+  return value * value;
 }
 
-template <typename Container> inline bool has_infinite(const Container& c) {
-    for (auto v : c)
-        if (!isfinite(v)) return true;
-    return false;
+inline bool isfinite(float_t x) { return x == x; }
+
+template <typename Container>
+inline bool has_infinite(const Container& c) {
+  for (auto v : c)
+    if (!isfinite(v)) return true;
+  return false;
 }
 
 template <typename Container>
 size_t max_size(const Container& c) {
-    typedef typename Container::value_type value_t;
-    return std::max_element(c.begin(), c.end(),
-        [](const value_t& left, const value_t& right) { return left.size() < right.size(); })->size();
+  typedef typename Container::value_type value_t;
+  return std::max_element(c.begin(), c.end(),
+                          [](const value_t& left, const value_t& right) {
+                            return left.size() < right.size();
+                          })
+      ->size();
 }
 
-inline std::string format_str(const char *fmt, ...) {
-    static char buf[2048];
+inline std::string format_str(const char* fmt, ...) {
+  static char buf[2048];
 
 #ifdef _MSC_VER
-#pragma warning(disable:4996)
+#pragma warning(disable : 4996)
 #endif
-    va_list args;
-    va_start(args, fmt);
-    vsnprintf(buf, sizeof(buf), fmt, args);
-    va_end(args);
+  va_list args;
+  va_start(args, fmt);
+  vsnprintf(buf, sizeof(buf), fmt, args);
+  va_end(args);
 #ifdef _MSC_VER
-#pragma warning(default:4996)
+#pragma warning(default : 4996)
 #endif
-    return std::string(buf);
+  return std::string(buf);
 }
 
 template <typename T>
 struct index3d {
-    index3d(T width, T height, T depth) {
-        reshape(width, height, depth);
-    }
+  index3d(T width, T height, T depth) { reshape(width, height, depth); }
 
-    index3d() : width_(0), height_(0), depth_(0) {}
+  index3d() : width_(0), height_(0), depth_(0) {}
 
-    void reshape(T width, T height, T depth) {
-        width_ = width;
-        height_ = height;
-        depth_ = depth;
+  void reshape(T width, T height, T depth) {
+    width_ = width;
+    height_ = height;
+    depth_ = depth;
 
-        if ((long long) width * height * depth > std::numeric_limits<T>::max())
-            throw nn_error(
-            format_str("error while constructing layer: layer size too large for tiny-dnn\nWidthxHeightxChannels=%dx%dx%d >= max size of [%s](=%d)",
-            width, height, depth, typeid(T).name(), std::numeric_limits<T>::max()));
-    }
+    if ((long long)width * height * depth > std::numeric_limits<T>::max())
+      throw nn_error(format_str(
+          "error while constructing layer: layer size too large for "
+          "tiny-dnn\nWidthxHeightxChannels=%dx%dx%d >= max size of [%s](=%d)",
+          width, height, depth, typeid(T).name(),
+          std::numeric_limits<T>::max()));
+  }
 
-    T get_index(T x, T y, T channel) const {
-        assert(x >= 0 && x < width_);
-        assert(y >= 0 && y < height_);
-        assert(channel >= 0 && channel < depth_);
-        return (height_ * channel + y) * width_ + x;
-    }
+  T get_index(T x, T y, T channel) const {
+    assert(x >= 0 && x < width_);
+    assert(y >= 0 && y < height_);
+    assert(channel >= 0 && channel < depth_);
+    return (height_ * channel + y) * width_ + x;
+  }
 
-    T area() const {
-        return width_ * height_;
-    }
+  T area() const { return width_ * height_; }
 
-    T size() const {
-        return width_ * height_ * depth_;
-    }
+  T size() const { return width_ * height_ * depth_; }
 
-    template <class Archive>
-    void serialize(Archive & ar) {
-        ar(cereal::make_nvp("width", width_));
-        ar(cereal::make_nvp("height", height_));
-        ar(cereal::make_nvp("depth", depth_));
-    }
+  template <class Archive>
+  void serialize(Archive& ar) {
+    ar(cereal::make_nvp("width", width_));
+    ar(cereal::make_nvp("height", height_));
+    ar(cereal::make_nvp("depth", depth_));
+  }
 
-    T width_;
-    T height_;
-    T depth_;
+  T width_;
+  T height_;
+  T depth_;
 };
 
 typedef index3d<cnn_size_t> shape3d;
 
 template <typename T>
-bool operator == (const index3d<T>& lhs, const index3d<T>& rhs) {
-    return (lhs.width_ == rhs.width_) && (lhs.height_ == rhs.height_) && (lhs.depth_ == rhs.depth_);
+bool operator==(const index3d<T>& lhs, const index3d<T>& rhs) {
+  return (lhs.width_ == rhs.width_) && (lhs.height_ == rhs.height_) &&
+         (lhs.depth_ == rhs.depth_);
 }
 
 template <typename T>
-bool operator != (const index3d<T>& lhs, const index3d<T>& rhs) {
-    return !(lhs == rhs);
+bool operator!=(const index3d<T>& lhs, const index3d<T>& rhs) {
+  return !(lhs == rhs);
 }
 
 template <typename Stream, typename T>
-Stream& operator << (Stream& s, const index3d<T>& d) {
-    s << d.width_ << "x" << d.height_ << "x" << d.depth_;
-    return s;
+Stream& operator<<(Stream& s, const index3d<T>& d) {
+  s << d.width_ << "x" << d.height_ << "x" << d.depth_;
+  return s;
 }
 
 template <typename Stream, typename T>
-Stream& operator << (Stream& s, const std::vector<index3d<T>>& d) {
-    s << "[";
-    for (cnn_size_t i = 0; i < d.size(); i++) {
-        if (i) s << ",";
-        s << "[" << d[i] << "]";
-    }
-    s << "]";
-    return s;
+Stream& operator<<(Stream& s, const std::vector<index3d<T>>& d) {
+  s << "[";
+  for (cnn_size_t i = 0; i < d.size(); i++) {
+    if (i) s << ",";
+    s << "[" << d[i] << "]";
+  }
+  s << "]";
+  return s;
 }
 
 // equivalent to std::to_string, which android NDK doesn't support
 template <typename T>
 std::string to_string(T value) {
-    std::ostringstream os;
-    os << value;
-    return os.str();
+  std::ostringstream os;
+  os << value;
+  return os.str();
 }
 
 // boilerplate to resolve dependent name
-#define CNN_USE_LAYER_MEMBERS using layer::parallelize_; \
-    using feedforward_layer<Activation>::h_
-
+#define CNN_USE_LAYER_MEMBERS \
+  using layer::parallelize_;  \
+  using feedforward_layer<Activation>::h_
 
 #define CNN_LOG_VECTOR(vec, name)
 /*
@@ -223,105 +223,101 @@ void CNN_LOG_VECTOR(const vec_t& vec, const std::string& name) {
 }
 */
 
-
 template <typename T, typename Pred, typename Sum>
 cnn_size_t sumif(const std::vector<T>& vec, Pred p, Sum s) {
-    size_t sum = 0;
-    for (size_t i = 0; i < vec.size(); i++) {
-        if (p(i)) sum += s(vec[i]);
-    }
-    return sum;
+  size_t sum = 0;
+  for (size_t i = 0; i < vec.size(); i++) {
+    if (p(i)) sum += s(vec[i]);
+  }
+  return sum;
 }
 
 template <typename T, typename Pred>
 std::vector<T> filter(const std::vector<T>& vec, Pred p) {
-    std::vector<T> res;
-    for (size_t i = 0; i < vec.size(); i++) {
-        if (p(i)) res.push_back(vec[i]);
-    }
-    return res;
+  std::vector<T> res;
+  for (size_t i = 0; i < vec.size(); i++) {
+    if (p(i)) res.push_back(vec[i]);
+  }
+  return res;
 }
 
 template <typename Result, typename T, typename Pred>
 std::vector<Result> map_(const std::vector<T>& vec, Pred p) {
-    std::vector<Result> res;
-    for (auto& v : vec) {
-        res.push_back(p(v));
-    }
-    return res;
+  std::vector<Result> res;
+  for (auto& v : vec) {
+    res.push_back(p(v));
+  }
+  return res;
 }
 
 enum class vector_type : int32_t {
-    // 0x0001XXX : in/out data
-    data = 0x0001000, // input/output data, fed by other layer or input channel
+  // 0x0001XXX : in/out data
+  data = 0x0001000,  // input/output data, fed by other layer or input channel
 
-    // 0x0002XXX : trainable parameters, updated for each back propagation
-    weight = 0x0002000,
-    bias = 0x0002001,
+  // 0x0002XXX : trainable parameters, updated for each back propagation
+  weight = 0x0002000,
+  bias = 0x0002001,
 
-    label = 0x0004000,
-    aux = 0x0010000 // layer-specific storage
+  label = 0x0004000,
+  aux = 0x0010000  // layer-specific storage
 };
 
 inline std::string to_string(vector_type vtype) {
-    switch (vtype)
-    {
+  switch (vtype) {
     case tiny_dnn::vector_type::data:
-        return "data";
+      return "data";
     case tiny_dnn::vector_type::weight:
-        return "weight";
+      return "weight";
     case tiny_dnn::vector_type::bias:
-        return "bias";
+      return "bias";
     case tiny_dnn::vector_type::label:
-        return "label";
+      return "label";
     case tiny_dnn::vector_type::aux:
-        return "aux";
+      return "aux";
     default:
-        return "unknown";
-    }
+      return "unknown";
+  }
 }
 
-inline std::ostream& operator << (std::ostream& os, vector_type vtype) {
-    os << to_string(vtype);
-    return os;
+inline std::ostream& operator<<(std::ostream& os, vector_type vtype) {
+  os << to_string(vtype);
+  return os;
 }
 
-inline vector_type operator & (vector_type lhs, vector_type rhs) {
-    return (vector_type)(static_cast<int32_t>(lhs) & static_cast<int32_t>(rhs));
+inline vector_type operator&(vector_type lhs, vector_type rhs) {
+  return (vector_type)(static_cast<int32_t>(lhs) & static_cast<int32_t>(rhs));
 }
 
 inline bool is_trainable_weight(vector_type vtype) {
-    return (vtype & vector_type::weight) == vector_type::weight;
+  return (vtype & vector_type::weight) == vector_type::weight;
 }
 
 inline std::vector<vector_type> std_input_order(bool has_bias) {
-    if (has_bias) {
-        return{ vector_type::data, vector_type::weight, vector_type::bias };
-    }
-    else {
-        return{ vector_type::data, vector_type::weight };
-    }
+  if (has_bias) {
+    return {vector_type::data, vector_type::weight, vector_type::bias};
+  } else {
+    return {vector_type::data, vector_type::weight};
+  }
 }
 
 inline std::vector<vector_type> std_output_order(bool has_activation) {
-    if (has_activation) {
-        return{ vector_type::data, vector_type::aux };
-    }
-    else {
-        return{ vector_type::data };
-    }
+  if (has_activation) {
+    return {vector_type::data, vector_type::aux};
+  } else {
+    return {vector_type::data};
+  }
 }
 
 inline void fill_tensor(tensor_t& tensor, float_t value) {
-    for (auto& t : tensor) {
-        std::fill(t.begin(), t.end(), value);
-    }
+  for (auto& t : tensor) {
+    std::fill(t.begin(), t.end(), value);
+  }
 }
 
 inline void fill_tensor(tensor_t& tensor, float_t value, cnn_size_t size) {
-    for (auto& t : tensor) {
-        t.resize(size, value);
-    }
+  for (auto& t : tensor) {
+    t.resize(size, value);
+  }
 }
 
 // get all platforms (drivers), e.g. NVIDIA
@@ -330,37 +326,41 @@ inline void fill_tensor(tensor_t& tensor, float_t value, cnn_size_t size) {
 inline void printAvailableDevice(const cnn_size_t platform_id,
                                  const cnn_size_t device_id) {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
-    // Initializes the CLCudaAPI platform and device. This initializes the OpenCL/CUDA back-end and
-    // selects a specific device on the platform.
-    auto platform = CLCudaAPI::Platform(platform_id);
-    auto device = CLCudaAPI::Device(platform, device_id);
+  // Initializes the CLCudaAPI platform and device. This initializes the
+  // OpenCL/CUDA back-end and
+  // selects a specific device on the platform.
+  auto platform = CLCudaAPI::Platform(platform_id);
+  auto device = CLCudaAPI::Device(platform, device_id);
 
-    // Prints information about the chosen device. Most of these results should stay the same when
-    // switching between the CUDA and OpenCL back-ends.
-    printf("\n## Printing device information...\n");
-    printf(" > Platform ID                  %zu\n", platform_id);
-    printf(" > Device ID                    %zu\n", device_id);
-    printf(" > Framework version            %s\n", device.Version().c_str());
-    printf(" > Vendor                       %s\n", device.Vendor().c_str());
-    printf(" > Device name                  %s\n", device.Name().c_str());
-    printf(" > Device type                  %s\n", device.Type().c_str());
-    printf(" > Max work-group size          %zu\n", device.MaxWorkGroupSize());
-    printf(" > Max thread dimensions        %zu\n", device.MaxWorkItemDimensions());
-    printf(" > Max work-group sizes:\n");
-    for (auto i=size_t{0}; i<device.MaxWorkItemDimensions(); ++i) {
-        printf("   - in the %zu-dimension         %zu\n", i, device.MaxWorkItemSizes()[i]);
-    }
-    printf(" > Local memory per work-group  %zu bytes\n", device.LocalMemSize());
-    printf(" > Device capabilities          %s\n", device.Capabilities().c_str());
-    printf(" > Core clock rate              %zu MHz\n", device.CoreClock());
-    printf(" > Number of compute units      %zu\n", device.ComputeUnits());
-    printf(" > Total memory size            %zu bytes\n", device.MemorySize());
-    printf(" > Maximum allocatable memory   %zu bytes\n", device.MaxAllocSize());
-    printf(" > Memory clock rate            %zu MHz\n", device.MemoryClock());
-    printf(" > Memory bus width             %zu bits\n", device.MemoryBusWidth());
+  // Prints information about the chosen device. Most of these results should
+  // stay the same when
+  // switching between the CUDA and OpenCL back-ends.
+  printf("\n## Printing device information...\n");
+  printf(" > Platform ID                  %zu\n", platform_id);
+  printf(" > Device ID                    %zu\n", device_id);
+  printf(" > Framework version            %s\n", device.Version().c_str());
+  printf(" > Vendor                       %s\n", device.Vendor().c_str());
+  printf(" > Device name                  %s\n", device.Name().c_str());
+  printf(" > Device type                  %s\n", device.Type().c_str());
+  printf(" > Max work-group size          %zu\n", device.MaxWorkGroupSize());
+  printf(" > Max thread dimensions        %zu\n",
+         device.MaxWorkItemDimensions());
+  printf(" > Max work-group sizes:\n");
+  for (auto i = size_t{0}; i < device.MaxWorkItemDimensions(); ++i) {
+    printf("   - in the %zu-dimension         %zu\n", i,
+           device.MaxWorkItemSizes()[i]);
+  }
+  printf(" > Local memory per work-group  %zu bytes\n", device.LocalMemSize());
+  printf(" > Device capabilities          %s\n", device.Capabilities().c_str());
+  printf(" > Core clock rate              %zu MHz\n", device.CoreClock());
+  printf(" > Number of compute units      %zu\n", device.ComputeUnits());
+  printf(" > Total memory size            %zu bytes\n", device.MemorySize());
+  printf(" > Maximum allocatable memory   %zu bytes\n", device.MaxAllocSize());
+  printf(" > Memory clock rate            %zu MHz\n", device.MemoryClock());
+  printf(" > Memory bus width             %zu bits\n", device.MemoryBusWidth());
 #else
-    nn_warn("TinyDNN was not build with OpenCL or CUDA support.");
+  nn_warn("TinyDNN was not build with OpenCL or CUDA support.");
 #endif
 }
 
-} // namespace tiny_dnn
+}  // namespace tiny_dnn

--- a/tiny_dnn/util/weight_init.h
+++ b/tiny_dnn/util/weight_init.h
@@ -1,29 +1,7 @@
-/*
-    Copyright (c) 2015, Taiga Nomi
-    All rights reserved.
-    
-    Redistribution and use in source and binary forms, with or without
-    modification, are permitted provided that the following conditions are met:
-    * Redistributions of source code must retain the above copyright
-    notice, this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-    notice, this list of conditions and the following disclaimer in the
-    documentation and/or other materials provided with the distribution.
-    * Neither the name of the <organization> nor the
-    names of its contributors may be used to endorse or promote products
-    derived from this software without specific prior written permission.
+// Copyright (c) 2013-2016, Taiga Nomi. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
-    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY 
-    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED 
-    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE 
-    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY 
-    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES 
-    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; 
-    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND 
-    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT 
-    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
-    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
 #pragma once
 #include "tiny_dnn/util/util.h"
 

--- a/tiny_dnn/util/weight_init.h
+++ b/tiny_dnn/util/weight_init.h
@@ -9,19 +9,18 @@ namespace tiny_dnn {
 namespace weight_init {
 
 class function {
-public:
-    virtual void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) = 0;
+ public:
+  virtual void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) = 0;
 };
 
 class scalable : public function {
-public:
-    scalable(float_t value) : scale_(value) {}
+ public:
+  scalable(float_t value) : scale_(value) {}
 
-    void scale(float_t value) {
-        scale_ = value;
-    }
-protected:
-    float_t scale_;
+  void scale(float_t value) { scale_ = value; }
+
+ protected:
+  float_t scale_;
 };
 
 /**
@@ -32,15 +31,15 @@ protected:
  * Proc. AISTATS 10, May 2010, vol.9, pp249-256
  **/
 class xavier : public scalable {
-public:
-    xavier() : scalable(float_t(6)) {}
-    explicit xavier(float_t value) : scalable(value) {}
+ public:
+  xavier() : scalable(float_t(6)) {}
+  explicit xavier(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
-        const float_t weight_base = std::sqrt(scale_ / (fan_in + fan_out));
+  void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
+    const float_t weight_base = std::sqrt(scale_ / (fan_in + fan_out));
 
-        uniform_rand(weight->begin(), weight->end(), -weight_base, weight_base);     
-    }
+    uniform_rand(weight->begin(), weight->end(), -weight_base, weight_base);
+  }
 };
 
 /**
@@ -51,58 +50,58 @@ public:
  * Neural Networks, Tricks of the Trade, Springer, 1998
  **/
 class lecun : public scalable {
-public:
-    lecun() : scalable(float_t(1)) {}
-    explicit lecun(float_t value) : scalable(value) {}
+ public:
+  lecun() : scalable(float_t(1)) {}
+  explicit lecun(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
-        CNN_UNREFERENCED_PARAMETER(fan_out);
+  void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
+    CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        const float_t weight_base = scale_ / std::sqrt(float_t(fan_in));
+    const float_t weight_base = scale_ / std::sqrt(float_t(fan_in));
 
-        uniform_rand(weight->begin(), weight->end(), -weight_base, weight_base);
-    }
+    uniform_rand(weight->begin(), weight->end(), -weight_base, weight_base);
+  }
 };
 
 class gaussian : public scalable {
-public:
-    gaussian() : scalable(float_t(1)) {}
-    explicit gaussian(float_t sigma) : scalable(sigma) {}
+ public:
+  gaussian() : scalable(float_t(1)) {}
+  explicit gaussian(float_t sigma) : scalable(sigma) {}
 
-    void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
-        CNN_UNREFERENCED_PARAMETER(fan_in);
-        CNN_UNREFERENCED_PARAMETER(fan_out);
+  void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
+    CNN_UNREFERENCED_PARAMETER(fan_in);
+    CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        gaussian_rand(weight->begin(), weight->end(), float_t(0), scale_);
-    }
+    gaussian_rand(weight->begin(), weight->end(), float_t(0), scale_);
+  }
 };
 
 class constant : public scalable {
-public:
-    constant() : scalable(float_t(0)) {}
-    explicit constant(float_t value) : scalable(value) {}
+ public:
+  constant() : scalable(float_t(0)) {}
+  explicit constant(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
-        CNN_UNREFERENCED_PARAMETER(fan_in);
-        CNN_UNREFERENCED_PARAMETER(fan_out);
+  void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
+    CNN_UNREFERENCED_PARAMETER(fan_in);
+    CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        std::fill(weight->begin(), weight->end(), scale_);
-    }
+    std::fill(weight->begin(), weight->end(), scale_);
+  }
 };
 
 class he : public scalable {
-public:
-    he() : scalable(float_t(2)) {}
-    explicit he(float_t value) : scalable(value) {}
+ public:
+  he() : scalable(float_t(2)) {}
+  explicit he(float_t value) : scalable(value) {}
 
-    void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
-        CNN_UNREFERENCED_PARAMETER(fan_out);
+  void fill(vec_t *weight, cnn_size_t fan_in, cnn_size_t fan_out) override {
+    CNN_UNREFERENCED_PARAMETER(fan_out);
 
-        const float_t sigma = std::sqrt(scale_ /fan_in);
+    const float_t sigma = std::sqrt(scale_ / fan_in);
 
-        gaussian_rand(weight->begin(), weight->end(), float_t(0), sigma);
-    }
+    gaussian_rand(weight->begin(), weight->end(), float_t(0), sigma);
+  }
 };
 
-} // namespace weight_init
-} // namespace tiny_dnn
+}  // namespace weight_init
+}  // namespace tiny_dnn


### PR DESCRIPTION
- Normalize the license boilerplate, redirecting to the already existing LICENSE file in the root of the project. This reduces clutter and is common practice (as seen in the Chromium project, Mozilla and others)
- Add clang-format configuration file based on the Google coding style guide, using the most current version 3.9
- Apply all reformatting based on the coding style guide
