### PR TITLE
Type changes

### DIFF
--- a/examples/cifar10/train.cpp
+++ b/examples/cifar10/train.cpp
@@ -76,7 +76,7 @@ void train_cifar10(string data_dir_path, double learning_rate, ostream& log) {
 
     cout << "start learning" << endl;
 
-    progress_display disp((unsigned long)train_images.size());
+    progress_display disp(train_images.size());
     timer t;
     const int n_minibatch = 10;     ///< minibatch size
     const int n_train_epochs = 30;  ///< training duration
@@ -89,7 +89,7 @@ void train_cifar10(string data_dir_path, double learning_rate, ostream& log) {
         tiny_dnn::result res = nn.test(test_images, test_labels);
         log << res.num_success << "/" << res.num_total << endl;
 
-        disp.restart((unsigned long)train_images.size());
+        disp.restart(train_images.size());
         t.restart();
     };
 

--- a/tiny_dnn/core/kernels/conv2d_op_opencl.h
+++ b/tiny_dnn/core/kernels/conv2d_op_opencl.h
@@ -108,10 +108,10 @@ class Conv2dOpenCLForwardOp : public core::OpKernel {
             kernel.SetArgument(6,  dev_out);  // convolved_image
             kernel.SetArgument(7,  0);        // convolved_image_offset
 
-            kernel.SetArgument(8,  static_cast<ushort>(params.in.width_));   // WIDTH
-            kernel.SetArgument(9,  static_cast<ushort>(params.in.height_));  // HEIGHT
-            kernel.SetArgument(10, static_cast<ushort>(params.out.width_));  // OUTPUT_W
-            kernel.SetArgument(11, static_cast<ushort>(params.out.height_)); // OUTPUT_H
+            kernel.SetArgument(8,  static_cast<cl_ushort>(params.in.width_));   // WIDTH
+            kernel.SetArgument(9,  static_cast<cl_ushort>(params.in.height_));  // HEIGHT
+            kernel.SetArgument(10, static_cast<cl_ushort>(params.out.width_));  // OUTPUT_W
+            kernel.SetArgument(11, static_cast<cl_ushort>(params.out.height_)); // OUTPUT_H
 
             // We make sure that work group size is multiple of 16
             cnn_size_t res  = device->device().MaxWorkGroupSize() % 16;

--- a/tiny_dnn/layers/deconvolutional_layer.h
+++ b/tiny_dnn/layers/deconvolutional_layer.h
@@ -467,8 +467,8 @@ private:
             for (cnn_size_t sample = 0; sample < out.size(); sample++) {
                 cnn_size_t idx = 0;
                 vec_t& dst = (*dst_tensor)[sample];
-                size_t wieght_w_half = static_cast<size_t>(floor(params_.weight.width_ / 2));
-                size_t wieght_h_half = static_cast<size_t>(floor(params_.weight.height_ / 2));
+                cnn_size_t wieght_w_half = params_.weight.width_ / 2;
+                cnn_size_t wieght_h_half = params_.weight.height_ / 2;
 
                 for (cnn_size_t c = 0; c < params_.out_unpadded.depth_; c++) {
                     float_t *pimg = &dst[params_.out_unpadded.get_index(0, 0, c)];

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -473,7 +473,7 @@ private:
     void save_connections(OutputArchive& oa) const {
         _graph_connection gc;
         std::unordered_map<node*, cnn_size_t> node2id;
-        size_t idx = 0;
+        cnn_size_t idx = 0;
 
         for (auto n : nodes_) {
             node2id[n] = idx++;


### PR DESCRIPTION
* conv2d_op_opencl was not compiling due to non-existent type ushort, changed to cl_ushort (I assumed that was the intent)
* removed a couple of useless floor(size_t), removed static_cast<size_t>, changed type of two variables wieght_w_half and wieght_h_half in order to avoid cnn_size_t<->size_t warnings.
* removed another cnn_size_t-related warning