### PR TITLE
remove warnings & udpate mnist example readme & update CMakeLists.txt for Visual Studio

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -202,6 +202,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR MINGW OR
     check_cxx_compiler_flag("-msse3" COMPILER_HAS_SSE_FLAG)
     check_cxx_compiler_flag("-mavx"  COMPILER_HAS_AVX_FLAG)
     check_cxx_compiler_flag("-mavx2" COMPILER_HAS_AVX2_FLAG)
+    check_cxx_compiler_flag("-mfma" COMPILER_HAS_AVX2_FLAG)
 
     # set Streaming SIMD Extension (SSE) instructions
     if(USE_SSE AND COMPILER_HAS_SSE_FLAG)
@@ -211,7 +212,7 @@ if(CMAKE_COMPILER_IS_GNUCXX OR MINGW OR
     # set Advanced Vector Extensions (AVX)
     if(USE_AVX AND COMPILER_HAS_AVX_FLAG)
         add_definitions(-DCNN_USE_AVX)
-        set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -mavx -mfma")
+        set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} -mavx")
     endif(USE_AVX AND COMPILER_HAS_AVX_FLAG)
     # set Advanced Vector Extensions 2 (AVX2)
     if(USE_AVX2 AND COMPILER_HAS_AVX2_FLAG)
@@ -233,11 +234,21 @@ elseif(MSVC)
         add_definitions(-DCNN_USE_AVX)
         set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} /arch:AVX")
     endif(USE_AVX)
+    if(USE_AVX2)
+        add_definitions(-DCNN_USE_AVX)
+        set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} /arch:AVX2")
+    endif(USE_AVX2)
     # include specific flags for release and debug modes.
     set(EXTRA_C_FLAGS_RELEASE "${EXTRA_C_FLAGS_RELEASE}
-        /Ox /Oi /Ot /Oy /GL /fp:fast /GS- /bigobj /LTCG")
-    set(EXTRA_C_FLAGS_DEBUG "${EXTRA_C_FLAGS_DEBUG} /bigobj")       
+        /Ox /Oi /Ot /Oy /GL /fp:fast /GS-")
+    set(CMAKE_EXE_LINKER_FLAGS_RELEASE "${CMAKE_EXE_LINKER_FLAGS_RELEASE} /LTCG")
+    set(EXTRA_C_FLAGS_DEBUG "${EXTRA_C_FLAGS_DEBUG}")
+    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} /bigobj")
+    # this is fine
     add_definitions(-D _CRT_SECURE_NO_WARNINGS)
+    add_definitions(-D _SCL_SECURE_NO_WARNINGS)
+    # prolly powerless with header-only project
+    set(EXTRA_C_FLAGS "${EXTRA_C_FLAGS} /MP")
 endif()
 
 ####

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -12,6 +12,10 @@ add_executable(example_mnist_test mnist/test.cpp)
 target_link_libraries(example_mnist_test
     ${project_library_target_name} ${REQUIRED_LIBRARIES})
 
+add_executable(example_mnist_quantized_train mnist/quantized.cpp)
+target_link_libraries(example_mnist_quantized_train
+    ${project_library_target_name} ${REQUIRED_LIBRARIES})
+
 add_executable(example_deconv_train deconv/train.cpp)
 target_link_libraries(example_deconv_train
     ${project_library_target_name} ${REQUIRED_LIBRARIES})

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -50,6 +50,10 @@ static void construct_net(network<sequential>& nn) {
     core::backend_t backend_type = core::default_engine();
 
     // construct nets
+    //
+    // C : convolution
+    // S : sub-sampling
+    // F : fully connected
     nn << convolutional_layer<tan_h>(32, 32, 5, 1, 6,  // C1, 1@32x32-in, 6@28x28-out
             padding::valid, true, 1, 1, backend_type)
        << average_pooling_layer<tan_h>(28, 28, 6, 2)   // S2, 6@28x28-in, 6@14x14-out
@@ -77,18 +81,18 @@ static void train_lenet(const std::string& data_dir_path) {
     std::vector<label_t> train_labels, test_labels;
     std::vector<vec_t> train_images, test_images;
 
-    parse_mnist_labels(data_dir_path+"/train-labels.idx1-ubyte",
+    parse_mnist_labels(data_dir_path + "/train-labels.idx1-ubyte",
                        &train_labels);
-    parse_mnist_images(data_dir_path+"/train-images.idx3-ubyte",
+    parse_mnist_images(data_dir_path + "/train-images.idx3-ubyte",
                        &train_images, -1.0, 1.0, 2, 2);
-    parse_mnist_labels(data_dir_path+"/t10k-labels.idx1-ubyte",
+    parse_mnist_labels(data_dir_path + "/t10k-labels.idx1-ubyte",
                        &test_labels);
-    parse_mnist_images(data_dir_path+"/t10k-images.idx3-ubyte",
+    parse_mnist_images(data_dir_path + "/t10k-images.idx3-ubyte",
                        &test_images, -1.0, 1.0, 2, 2);
 
     std::cout << "start training" << std::endl;
 
-    progress_display disp((unsigned long)train_images.size());
+    progress_display disp(static_cast<unsigned long>(train_images.size()));
     timer t;
     int minibatch_size = 10;
     int num_epochs = 30;
@@ -101,7 +105,7 @@ static void train_lenet(const std::string& data_dir_path) {
         tiny_dnn::result res = nn.test(test_images, test_labels);
         std::cout << res.num_success << "/" << res.num_total << std::endl;
 
-        disp.restart((unsigned long)train_images.size());
+        disp.restart(static_cast<unsigned long>(train_images.size()));
         t.restart();
     };
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -17,8 +17,10 @@ enable_testing()
 
 # in ../googletest-src/googletest/CMakeLists.txt, BUILD_SHARED_LIBS is set to OFF
 if(MSVC)
-    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
     set(CMAKE_CXX_FLAGS_DEBUG "${CMAKE_CXX_FLAGS_DEBUG} /MTd")
+    set(CMAKE_CXX_FLAGS_RELEASE "${CMAKE_CXX_FLAGS_RELEASE} /MT")
+    set(CMAKE_CXX_FLAGS_RELWITHDEBINFO "${CMAKE_CXX_FLAGS_RELWITHDEBINFO} /MT")
+    set(CMAKE_CXX_FLAGS_MINSIZEREL "${CMAKE_CXX_FLAGS_MINSIZEREL} /MT")
 endif()
 
 add_executable(print_device print_device.cpp)

--- a/test/test_no_duplicate_symbols.cpp
+++ b/test/test_no_duplicate_symbols.cpp
@@ -24,8 +24,10 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS 
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-
+#ifndef _CRT_SECURE_NO_WARNINGS
 #define _CRT_SECURE_NO_WARNINGS
+#endif
+
  #include "gtest/gtest.h"
 #include "tiny_dnn/tiny_dnn.h"
 

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -207,7 +207,7 @@ class tiny_backend : public backend {
         const vec_t&    W    = (*in_data[1])[0];
         const vec_t&    bias = (*in_data[2])[0];
         tensor_t&       a    = *out_data[1];
-        const tensor_t &in   = *in_data[0]; // input
+        const tensor_t& in   = *in_data[0]; // input
 
         fill_tensor(a, float_t(0), params_d_->out.size()); // deconv2d-kernel requires padded size buffer
 
@@ -222,7 +222,7 @@ class tiny_backend : public backend {
     void deconv2d_q(const std::vector<tensor_t*>&  in_data,
                     std::vector<tensor_t*>&        out_data) override {
         (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const tensor_t &in   =  *in_data[0]; // input
+        const tensor_t& in   =  *in_data[0]; // input
         const vec_t&    W    = (*in_data[1])[0];
         const vec_t&    bias = (*in_data[2])[0];
         tensor_t&       a    =  *out_data[1];
@@ -242,7 +242,7 @@ class tiny_backend : public backend {
     void deconv2d_eq(const std::vector<tensor_t*>&  in_data,
                      std::vector<tensor_t*>&        out_data) override {
         (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
-        const tensor_t &in   =  *in_data[0]; // input
+        const tensor_t& in   =  *in_data[0]; // input
         const vec_t&    W    = (*in_data[1])[0];
         const vec_t&    bias = (*in_data[2])[0];
         const tensor_t& in_r =  *in_data[3];

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -226,7 +226,7 @@ class average_unpooling_layer : public partial_connected_layer<Activation> {
     }
 
  private:
-    size_t stride_;
+    cnn_size_t stride_;
     shape3d in_;
     shape3d out_;
     shape3d w_;

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -203,7 +203,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
             : Base(std::move(other))
             , params_(std::move(other.params_))
             , cws_(std::move(other.cws_)) {
-        init_backend(std::move(Base::get_backend_type()));
+        init_backend(core::backend_t::internal);
     }
 
     ///< number of incoming connections for each output unit

--- a/tiny_dnn/layers/quantized_fully_connected_layer.h
+++ b/tiny_dnn/layers/quantized_fully_connected_layer.h
@@ -57,7 +57,7 @@ public:
     quantized_fully_connected_layer(quantized_fully_connected_layer&& other)
             : Base(std::move(other))
             , params_(std::move(other.params_)) {
-        init_backend(std::move(Base::get_backend_type()));
+        init_backend(core::backend_t::internal);
     }
 
     cnn_size_t fan_in_size() const override {
@@ -138,6 +138,7 @@ protected:
 
         if (backend) {
             Base::set_backend(backend);
+            Base::set_backend_type(backend_type);
             Base::backend_->set_layer(this);
         } else {
             throw nn_error("Could not allocate the backend.");

--- a/tiny_dnn/lossfunctions/loss_function.h
+++ b/tiny_dnn/lossfunctions/loss_function.h
@@ -193,7 +193,7 @@ inline void apply_cost_if_defined(std::vector<vec_t>& sample_gradient,
                                   const std::vector<vec_t>& sample_cost) {
     if (sample_gradient.size() == sample_cost.size()) {
         // @todo consider adding parallelism
-        const cnn_size_t channel_count = sample_gradient.size();
+        const cnn_size_t channel_count = static_cast<cnn_size_t>(sample_gradient.size());
         for (size_t channel = 0; channel < channel_count; ++channel) {
             if (sample_gradient[channel].size() == sample_cost[channel].size()) {
                 const size_t element_count = sample_gradient[channel].size();

--- a/tiny_dnn/util/image.h
+++ b/tiny_dnn/util/image.h
@@ -159,10 +159,18 @@ public:
         std::vector<uint8_t> buf = to_rgb<uint8_t>();
 
         if (detail::ends_with(path, "png")) {
-            ret = stbi_write_png(path.c_str(), width_, height_, depth_, (const void*)&buf[0], 0);
+            ret = stbi_write_png(path.c_str(),
+                                 static_cast<int>(width_),
+                                 static_cast<int>(height_),
+                                 static_cast<int>(depth_),
+                                 (const void*)&buf[0], 0);
         }
         else {
-            ret = stbi_write_bmp(path.c_str(), width_, height_, depth_, (const void*)&buf[0]);
+            ret = stbi_write_bmp(path.c_str(),
+                                 static_cast<int>(width_),
+                                 static_cast<int>(height_),
+                                 static_cast<int>(depth_),
+                                 (const void*)&buf[0]);
         }
         if (ret == 0) {
             throw nn_error("failed to save image:" + path);
@@ -298,11 +306,20 @@ image<float_t> mean_image(const image<T>& src)
 template <typename T>
 inline image<T> resize_image(const image<T>& src, int width, int height)
 {
-    image<T> resized(shape3d(width, height, src.depth()), src.type());
+    image<T> resized(shape3d(static_cast<cnn_size_t>(width),
+                             static_cast<cnn_size_t>(height),
+                             static_cast<cnn_size_t>(src.depth())),
+                     src.type());
     std::vector<T> src_rgb = src.template to_rgb<T>();
     std::vector<T> dst_rgb(resized.shape().size());
 
-    detail::resize_image_core(&src_rgb[0], src.width(), src.height(), &dst_rgb[0], width, height, src.depth());
+    detail::resize_image_core(&src_rgb[0],
+                              static_cast<int>(src.width()),
+                              static_cast<int>(src.height()),
+                              &dst_rgb[0],
+                              width,
+                              height,
+                              static_cast<int>(src.depth()));
 
     resized.from_rgb(dst_rgb.begin(), dst_rgb.end());
 


### PR DESCRIPTION
When I tried to build x64 projects with VisualC++, there were some compiler warnings of implicit conversions between size_t to cnn_size_t and int to cnn_size_t. So removed them using C-style casts.

Updated mnist example readme.md to address the issue #380

Also updated CMakeList.txt to remove a warning with VisualStudio.
