### PR TITLE
Add public predict method for vector of tensors

### DIFF
--- a/test/test_target_cost.h
+++ b/test/test_target_cost.h
@@ -21,7 +21,7 @@ TEST(target_cost, calculate_label_counts) {
 
 TEST(target_cost, get_sample_weight_for_balanced_target_cost) {
     const std::vector<cnn_size_t> class_sample_counts = { 1000, 100, 10, 1 };
-    const cnn_size_t class_count = class_sample_counts.size();
+    const cnn_size_t class_count = static_cast<cnn_size_t>(class_sample_counts.size());
     const cnn_size_t total_samples = std::accumulate(class_sample_counts.begin(), class_sample_counts.end(), static_cast<cnn_size_t>(0));
 
     std::vector<float_t> class_weights;

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -382,7 +382,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     void copy_and_pad_input(const tensor_t& in) {
         conv_layer_worker_specific_storage& cws = cws_;
 
-        cnn_size_t sample_count = in.size();
+        cnn_size_t sample_count = static_cast<cnn_size_t>(in.size());
 
         cws.prev_out_padded_.resize(sample_count);
 

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -461,7 +461,7 @@ class network {
         std::vector<tensor_t> v(t.size());
         const cnn_size_t sample_count = static_cast<cnn_size_t>(t.size());
         for (cnn_size_t sample = 0; sample < sample_count; ++sample) {
-            net_.label2vec(&t[sample][0], t[sample].size(), &v[sample]);
+            net_.label2vec(&t[sample][0], static_cast<cnn_size_t>(t[sample].size()), &v[sample]);
         }
 
         for (auto current : net_) {  // ignore first input layer

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -192,6 +192,11 @@ class network {
     tensor_t predict(const tensor_t& in) { return fprop(in); }
 
     /**
+    * executes forward-propagation and returns output
+    **/
+    std::vector<tensor_t> predict(const std::vector<tensor_t>& in) { return fprop(in); }
+
+    /**
      * executes forward-propagation and returns maximum output
      **/
     float_t      predict_max_value(const vec_t& in) {

--- a/tiny_dnn/util/image.h
+++ b/tiny_dnn/util/image.h
@@ -188,7 +188,11 @@ public:
     size_t height() const { return height_; }
     size_t depth() const {return depth_;}
     image_type type() const { return type_; }
-    shape3d shape() const { return shape3d(width_, height_, depth_); }
+    shape3d shape() const {
+        return shape3d(static_cast<cnn_size_t>(width_),
+                       static_cast<cnn_size_t>(height_),
+                       static_cast<cnn_size_t>(depth_));
+    }
     const std::vector<intensity_t>& data() const { return data_; }
     vec_t to_vec() const { return vec_t(begin(), end()); }
 


### PR DESCRIPTION
For completeness. Want to `fprop` multiple samples in parallel (in particular because of how `fully_connected_op_custom` and `conv2d_op_custom` are parallelized at the moment).