### PR TITLE
add a workaround to mitigate memory consumption problem

### DIFF
--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -834,8 +834,14 @@ class network {
     vec_t fprop(const vec_t& in) {
         if (in.size() != (size_t)in_data_size())
             data_mismatch(**net_.begin(), in);
-
+#if 0
         return fprop(std::vector<vec_t>{ in })[0];
+#else
+        // a workaround to reduce memory consumption by skipping wrapper function
+        std::vector<tensor_t> a(1);
+        a[0].emplace_back(in);
+        return fprop(a)[0][0];
+#endif
     }
 
     // convenience wrapper for the function below


### PR DESCRIPTION
This is a temporary workaround to mitigate memory footprint problem.
By skipping calling wrapper function `tiny_dnn::network::fprop(const std::vector<vec_t>& in)`, a number of copies of STL vector container is reduced.

To confirm the effect from this change, I used `examples/benchmarks/main.cpp` program and compare memory usages at head of `tiny_dnn::sequential::forward(const std::vector<tensor_t>& first)`.

I expect ongoing Tensor class should greatly reduce the problem.
