### PR TITLE
Tensor (reprise)

### DIFF
--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -397,7 +397,7 @@ TEST(tensor, linspace) {
 
     // fill all tensor values with values from 1 to 16
 
-    tensor.linspace(float_t(1.0),float_t(16.0));
+    tensor.linspace(float_t(1.0), float_t(16.0));
 
     for (size_t i = 0; i < tensor.size(); ++i) {
         EXPECT_EQ(tensor[i], float_t(1.0+i));
@@ -406,10 +406,10 @@ TEST(tensor, linspace) {
     Tensor<float_t> tensor2(101,1,1,1);
     // fill all tensor values with from 0 to 1
 
-    tensor2.linspace(float_t(0.0),float_t(1.0));
+    tensor2.linspace(float_t(0.0), float_t(1.0));
 
     for (size_t i = 0; i < tensor2.size(); ++i) {
-        EXPECT_NEAR(tensor2[i], float_t(0.01*i),0.001);
+        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 0.001);
     }
 }
 
@@ -586,7 +586,7 @@ TEST(tensor, exp) {
     Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
-    t.linspace(float_t(1.0),float_t(16.0));
+    t.linspace(float_t(1.0), float_t(16.0));
 
     // calculate exp
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -34,7 +34,7 @@ using namespace tiny_dnn;
 namespace tiny_dnn {
 
 TEST(tensor, shape) {
-    Tensor tensor(1,2,2,2);
+    Tensor<float_t,1,2,2,2> tensor;
 
     EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
     EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
@@ -43,11 +43,11 @@ TEST(tensor, shape) {
 }
 
 TEST(tensor, access_data) {
-    Tensor tensor(1,2,2,2);
+    Tensor<float_t,1,2,2,2> tensor;
 
-    float_t* begin_ptr = tensor.ptr(0,0,0,0);
-    float_t* end1_ptr  = tensor.ptr(0,1,1,0);
-    float_t* end2_ptr  = tensor.ptr(0,1,1,1);
+    float_t* begin_ptr = tensor.ptr<float_t>(0,0,0,0);
+    float_t* end1_ptr  = tensor.ptr<float_t>(0,1,1,0);
+    float_t* end2_ptr  = tensor.ptr<float_t>(0,1,1,1);
 
     // set tensor data
     
@@ -67,9 +67,9 @@ TEST(tensor, access_data) {
         for (cnn_size_t j = 0; j < 2; ++j) {
             for (cnn_size_t k = 0; k < 1; ++k) {
                 if (k == 0) {
-                    EXPECT_EQ(tensor.at(0,i,j,k), cnn_size_t(1));
+                    EXPECT_EQ(tensor.at<float_t>(0,i,j,k), cnn_size_t(1));
                 } else {
-                    EXPECT_EQ(tensor.at(0,i,j,k), cnn_size_t(2));
+                    EXPECT_EQ(tensor.at<float_t>(0,i,j,k), cnn_size_t(2));
                 }
             }
         }

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -42,37 +42,291 @@ TEST(tensor, shape) {
     EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
 }
 
-TEST(tensor, access_data) {
+TEST(tensor, access_data1) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    EXPECT_EQ(tensor.at<float_t>(0,0,0,0), float_t(0.0));
+    EXPECT_EQ(tensor.at<float_t>(0,0,1,0), float_t(0.0));
+    EXPECT_EQ(tensor.at<float_t>(0,1,0,0), float_t(0.0));
+    EXPECT_EQ(tensor.at<float_t>(0,1,1,0), float_t(0.0));
+
+    EXPECT_THROW(tensor.at<float_t>(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.at<float_t>(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.at<float_t>(1,0,0,1), nn_error);
+}
+
+TEST(tensor, access_data2) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    const float* ptr = tensor.ptr<float_t>(0,0,0,0);
+
+    size_t i = 0;
+    EXPECT_EQ(ptr[i++], float_t(0.0));
+    EXPECT_EQ(ptr[i++], float_t(0.0));
+    EXPECT_EQ(ptr[i++], float_t(0.0));
+    EXPECT_EQ(ptr[i++], float_t(0.0));
+}
+
+TEST(tensor, access_data3) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    size_t i = 0;
+    EXPECT_EQ(tensor[i++], float_t(0.0));
+    EXPECT_EQ(tensor[i++], float_t(0.0));
+    EXPECT_EQ(tensor[i++], float_t(0.0));
+    EXPECT_EQ(tensor[i++], float_t(0.0));
+}
+
+TEST(tensor, access_data4) {
     Tensor<float_t> tensor(1,2,2,2);
 
-    float_t* begin_ptr = tensor.ptr<float_t>(0,0,0,0);
-    float_t* end1_ptr  = tensor.ptr<float_t>(0,1,1,0);
-    float_t* end2_ptr  = tensor.ptr<float_t>(0,1,1,1);
+    // modify data using .ptr() accessor
 
-    // set tensor data
-    
-    // channel #1
-    for (float_t* i = begin_ptr; i != end1_ptr + 1; i++) {
-        *i = float_t(1);
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
     }
 
-    // channel #2
-    for (float_t* i = end1_ptr + 1; i != end2_ptr + 1; i++) {
-        *i = float_t(2);
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
     }
 
-    // check data
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data5) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .ptr() accessor
+
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
+    }
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+        }
+    }
+}
+
+
+TEST(tensor, access_data6) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .ptr() accessor
+
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
+    }
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data7) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
     
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            for (cnn_size_t k = 0; k < 1; ++k) {
-                if (k == 0) {
-                    EXPECT_EQ(tensor.at<float_t>(0,i,j,k), cnn_size_t(1));
-                } else {
-                    EXPECT_EQ(tensor.at<float_t>(0,i,j,k), cnn_size_t(2));
-                }
-            }
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
         }
+    }
+}
+
+TEST(tensor, access_data8) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data9) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data10) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data11) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+        }
+    }
+}
+
+TEST(tensor, access_data12) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -52,6 +52,50 @@ using namespace tiny_dnn;
 
 namespace tiny_dnn {
 
+TEST(tensor, constructors) {
+
+    Tensor<float_t> t1;
+    Tensor<float_t> t2(2,2,2,2); t2.fill(float_t(2.0));
+
+    t1 = t2;  // invoke assign copy ctor
+
+    // check that t2 values has been copyied to t1
+    for (size_t i = 0; i < t1.size(); ++i) {
+        EXPECT_EQ(t1[i], float_t(2.0));
+    }
+
+    t1 = Tensor<float_t>(1,1,1,1); // invoke copy ctor
+
+    // check that t1 have default values
+    for (size_t i = 0; i < t1.size(); ++i) {
+        EXPECT_EQ(t1[i], float_t(0.0));
+    }
+
+    // invoke move assign cto
+    t1 = std::move(t2);
+
+    // check that we moved data
+    EXPECT_EQ(t1.size(), cnn_size_t(16));
+#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
+    EXPECT_EQ(t2.size(), cnn_size_t(1.0));
+#else
+    // we'll assume that copy assign ctor is invoked
+    EXPECT_EQ(t2.size(), cnn_size_t(16));
+#endif
+
+    // invoke move ctor
+    Tensor<float_t> t3(std::move(t1));
+
+    // check that we moved data
+    EXPECT_EQ(t3.size(), cnn_size_t(16));
+#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
+    EXPECT_EQ(t1.size(), cnn_size_t(1.0));
+#else
+    // we'll assume that copy assign ctor is invoked
+    EXPECT_EQ(t1.size(), cnn_size_t(16));
+#endif
+}
+
 TEST(tensor, shape) {
     Tensor<float_t> tensor(1,2,2,2);
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -61,14 +61,14 @@ TEST(tensor, constructors) {
 
     // check that t2 values has been copyied to t1
     for (size_t i = 0; i < t1.size(); ++i) {
-        EXPECT_EQ(t1[i], float_t(2.0));
+        EXPECT_EQ(t1.host_data()[i], float_t(2.0));
     }
 
     t1 = Tensor<float_t>(1,1,1,1); // invoke copy ctor
 
     // check that t1 have default values
     for (size_t i = 0; i < t1.size(); ++i) {
-        EXPECT_EQ(t1[i], float_t(0.0));
+        EXPECT_EQ(t1.host_data()[i], float_t(0.0));
     }
 
     // invoke move assign cto
@@ -76,24 +76,14 @@ TEST(tensor, constructors) {
 
     // check that we moved data
     EXPECT_EQ(t1.size(), cnn_size_t(16));
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    EXPECT_EQ(t2.size(), cnn_size_t(1.0));
-#else
-    // we'll assume that copy assign ctor is invoked
-    EXPECT_EQ(t2.size(), cnn_size_t(16));
-#endif
+
+    // expecting something here is wrong. t2 is in a valid but undefined state, no need to test it.
 
     // invoke move ctor
     Tensor<float_t> t3(std::move(t1));
 
     // check that we moved data
     EXPECT_EQ(t3.size(), cnn_size_t(16));
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    EXPECT_EQ(t1.size(), cnn_size_t(1.0));
-#else
-    // we'll assume that copy assign ctor is invoked
-    EXPECT_EQ(t1.size(), cnn_size_t(16));
-#endif
 }
 
 TEST(tensor, shape) {
@@ -135,13 +125,6 @@ TEST(tensor, check_bounds) {
     EXPECT_THROW(tensor.host_ptr(0,0,0,1), nn_error);
     EXPECT_THROW(tensor.host_ptr(1,0,0,0), nn_error);
     EXPECT_THROW(tensor.host_ptr(1,0,0,1), nn_error);
-
-    // check bounds with operator[] accessor
-
-    EXPECT_NO_THROW(tensor[0]);
-    EXPECT_NO_THROW(tensor[3]);
-
-    EXPECT_DEBUG_DEATH(tensor[4], "");
 }
 
 TEST(tensor, access_data1) {
@@ -165,7 +148,7 @@ TEST(tensor, access_data2) {
     Tensor<float_t> tensor(1,2,2,1);
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(0.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(0.0));
     }
 }
 
@@ -250,11 +233,11 @@ TEST(tensor, access_data5) {
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -335,11 +318,11 @@ TEST(tensor, access_data8) {
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -349,21 +332,21 @@ TEST(tensor, access_data9) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -373,11 +356,11 @@ TEST(tensor, access_data10) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .at() accessor
@@ -401,11 +384,11 @@ TEST(tensor, access_data11) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .ptr() accessor
@@ -430,7 +413,7 @@ TEST(tensor, fill) {
     tensor.fill(float_t(1.0));
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
  
     // fill all tensor values with twos
@@ -438,7 +421,7 @@ TEST(tensor, fill) {
     tensor.fill(float_t(2.0));
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(2.0));
     }
 }
 
@@ -475,17 +458,19 @@ TEST(tensor, add1) {
 
     // compute element-wise sum along all tensor values
 
-    Tensor<float_t> t3 = t1.add(t2);
+    Tensor<float_t> t3;
+    
+    layer_add(t3, t1, t2);
 
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(4.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(4.0), 1e-5);
     }
 }
 
-TEST(tensor, add2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, add2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -493,12 +478,34 @@ TEST(tensor, add2) {
 
     // compute element-wise sum along all tensor values
 
-    Tensor<float_t> t2 = t.add(float_t(2.0));
+    Tensor<float_t> t2;
 
     // check that sum is okay
 
+    layer_add(t2, float_t(2.0), t);
+
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(3.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(3.0), 1e-5);
+    }
+}
+
+TEST(tensor, add2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // compute element-wise sum along all tensor values
+
+    Tensor<float_t> t2;
+
+    // check that sum is okay
+
+    layer_add(t2, t, float_t(2.0));
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(3.0), 1e-5);
     }
 }
 
@@ -509,7 +516,9 @@ TEST(tensor, add3) {
     // compute element-wise sum along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.add(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_add(t3, t1, t2); , nn_error);
 }
 
 TEST(tensor, sub1) {
@@ -523,17 +532,18 @@ TEST(tensor, sub1) {
 
     // compute element-wise subtraction along all tensor values
 
-    Tensor<float_t> t3 = t1.sub(t2);
+    Tensor<float_t> t3;
+    layer_sub(t3, t1, t2);
 
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(-2.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(-2.0), 1e-5);
     }
 }
 
-TEST(tensor, sub2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, sub2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -541,12 +551,34 @@ TEST(tensor, sub2) {
 
     // compute element-wise subtraction along all tensor values
 
-    Tensor<float_t> t2 = t.sub(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_sub(t2, t, float_t(2.0));
 
     // check that subtraction is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(-1.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(-1.0), 1e-5);
+    }
+}
+
+TEST(tensor, sub2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise subtraction along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_sub(t2, float_t(1.0), t);
+
+    // check that subtraction is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(-1.0), 1e-5);
     }
 }
 
@@ -557,7 +589,9 @@ TEST(tensor, sub3) {
     // compute element-wise subtraction along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.sub(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_sub(t3,  t1, t2), nn_error);
 }
 
 TEST(tensor, mul1) {
@@ -571,17 +605,19 @@ TEST(tensor, mul1) {
 
     // compute element-wise multiplication along all tensor values
 
-    Tensor<float_t> t3 = t1.mul(t2);
+    Tensor<float_t> t3;
+    
+    layer_mul(t3, t1, t2);
 
     // check that subtraction is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(6.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(6.0), 1e-5);
     }
 }
 
-TEST(tensor, mul2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, mul2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -589,12 +625,36 @@ TEST(tensor, mul2) {
 
     // compute element-wise multiplication along all tensor values
 
-    Tensor<float_t> t2 = t.mul(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_mul(t2, t, float_t(2.0));
+
 
     // check that multiplication is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(4.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(4.0), 1e-5);
+    }
+}
+
+TEST(tensor, mul2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise multiplication along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_mul(t2, float_t(2.0), t);
+
+
+    // check that multiplication is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(4.0), 1e-5);
     }
 }
 
@@ -605,7 +665,9 @@ TEST(tensor, mul3) {
     // compute element-wise multiplication along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.mul(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_mul(t3, t1, t2), nn_error);
 }
 
 TEST(tensor, div1) {
@@ -619,17 +681,19 @@ TEST(tensor, div1) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t3 = t1.div(t2);
+    Tensor<float_t> t3;
+
+    layer_div(t3, t1, t2);
 
     // check that division is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(0.5), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(0.5), 1e-5);
     }
 }
 
-TEST(tensor, div2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, div2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -637,12 +701,34 @@ TEST(tensor, div2) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t2 = t.div(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_div(t2, t, float_t(2.0));
 
     // check that division is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(0.5), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(0.5), 1e-5);
+    }
+}
+
+TEST(tensor, div2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise division along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_div(t2, float_t(1.0), t);
+
+    // check that division is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(0.5), 1e-5);
     }
 }
 
@@ -653,7 +739,9 @@ TEST(tensor, div3) {
     // compute element-wise division along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.div(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_div(t3, t1, t2), nn_error);
 }
 
 TEST(tensor, div4) {
@@ -667,12 +755,14 @@ TEST(tensor, div4) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t3 = t1.div(t2);
+    Tensor<float_t> t3;
+
+    layer_div(t3, t1, t2);
 
     // check that division is NaN
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t3[i]));
+        EXPECT_TRUE(std::isnan(t3.host_data()[i]));
     }
 }
 
@@ -685,12 +775,14 @@ TEST(tensor, div5) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t2 = t.div(float_t(0.0));
+    Tensor<float_t> t2;
+
+    layer_div(t2, t, float_t(0.0));
 
     // check that division is NaN
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t2[i]));
+        EXPECT_TRUE(std::isnan(t2.host_data()[i]));
     }
 }
 
@@ -702,12 +794,14 @@ TEST(tensor, sqrt1) {
 
     // compute element-wise square root along all tensor values
 
-    Tensor<float_t> t2 = t.sqrt();
+    Tensor<float_t> t2;
+    
+    layer_sqrt(t2, t);
 
     // check that root is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(2.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(2.0), 1e-5);
     }
 }
 
@@ -719,12 +813,14 @@ TEST(tensor, sqrt2) {
 
     // compute element-wise square root along all tensor values
 
-    Tensor<float_t> t2 = t.sqrt();
+    Tensor<float_t> t2;
+
+    layer_sqrt(t2, t);
 
     // check that division is NaN
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t2[i]));
+        EXPECT_TRUE(std::isnan(t2.host_data()[i]));
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -392,6 +392,27 @@ TEST(tensor, fill) {
     }
 }
 
+TEST(tensor, linspace) {
+    Tensor<float_t> tensor(2,2,2,2);
+
+    // fill all tensor values with values from 1 to 16
+
+    tensor.linspace(float_t(1.0),float_t(16.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0+i));
+    }
+
+    Tensor<float_t> tensor2(101,1,1,1);
+    // fill all tensor values with from 0 to 1
+
+    tensor2.linspace(float_t(0.0),float_t(1.0));
+
+    for (size_t i = 0; i < tensor2.size(); ++i) {
+        EXPECT_NEAR(tensor2[i], float_t(0.01*i),0.001);
+    }
+}
+
 TEST(tensor, add1) {
     Tensor<float_t> t1(2,2,2,2);
     Tensor<float_t> t2(2,2,2,2);

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -90,7 +90,7 @@ TEST(tensor, check_bounds) {
     EXPECT_NO_THROW(tensor[0]);
     EXPECT_NO_THROW(tensor[3]);
 
-    EXPECT_THROW(tensor[4], nn_error);
+    EXPECT_DEBUG_DEATH(tensor[4], "");
 }
 
 TEST(tensor, access_data1) {

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -61,6 +61,12 @@ TEST(tensor, shape) {
     EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
 }
 
+TEST(tensor, size) {
+    Tensor<float_t> tensor(2,2,2,2);
+
+    EXPECT_EQ(tensor.size(), size_t(2*2*2*2));
+}
+
 TEST(tensor, check_bounds) {
     Tensor<float_t> tensor(1,2,2,1);
 
@@ -604,6 +610,44 @@ TEST(tensor, div3) {
     // Expect a throw since shapes are different
 
     EXPECT_THROW(t1.div(t2), nn_error);
+}
+
+TEST(tensor, div4) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(0.0));
+
+    // compute element-wise division along all tensor values
+
+    Tensor<float_t> t3 = t1.div(t2);
+
+    // check that division is NaN
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_TRUE(std::isnan(t3[i]));
+    }
+}
+
+TEST(tensor, div5) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // compute element-wise division along all tensor values
+
+    Tensor<float_t> t2 = t.div(float_t(0.0));
+
+    // check that division is NaN
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_TRUE(std::isnan(t2[i]));
+    }
 }
 
 TEST(tensor, sqrt) {

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -650,7 +650,7 @@ TEST(tensor, div5) {
     }
 }
 
-TEST(tensor, sqrt) {
+TEST(tensor, sqrt1) {
     Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
@@ -664,6 +664,23 @@ TEST(tensor, sqrt) {
 
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_NEAR(t2[i], float_t(2.0), epsilon<float_t>());
+    }
+}
+
+TEST(tensor, sqrt2) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+    t.fill(float_t(-1.0));
+
+    // compute element-wise square root along all tensor values
+
+    Tensor<float_t> t2 = t.sqrt();
+
+    // check that division is NaN
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_TRUE(std::isnan(t2[i]));
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -1,5 +1,5 @@
 /*
-    Copyright (c) 2013, Taiga Nomi
+    Copyright (c) 2016, Taiga Nomi, Edgar Riba
     All rights reserved.
 
     Redistribution and use in source and binary forms, with or without
@@ -24,51 +24,56 @@
     (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
     SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 */
-#ifndef _CRT_SECURE_NO_WARNINGS
-#define _CRT_SECURE_NO_WARNINGS
-#endif
+#pragma once
 #include "gtest/gtest.h"
+#include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
-using namespace tiny_dnn::activation;
+using namespace tiny_dnn;
 
-#ifndef CNN_NO_SERIALIZATION
-#include "test_serialization.h"
-#endif
-#include "test_network.h"
-#include "test_average_pooling_layer.h"
-// TODO(yida): fix broken test
-//#include "test_average_unpooling_layer.h"
-#include "test_dropout_layer.h"
-#include "test_max_pooling_layer.h"
-#include "test_fully_connected_layer.h"
-#include "test_deconvolutional_layer.h"
-#include "test_convolutional_layer.h"
-#include "test_target_cost.h"
-#include "test_large_thread_count.h"
-#include "test_lrn_layer.h"
-#include "test_batch_norm_layer.h"
-#include "test_nodes.h"
-#include "test_core.h"
-#include "test_models.h"
-#include "test_slice_layer.h"
-#include "test_concat_layer.h"
-#include "test_power_layer.h"
-#include "test_quantization.h"
-#include "test_quantized_convolutional_layer.h"
-#include "test_quantized_deconvolutional_layer.h"
-#ifdef CNN_USE_GEMMLOWP
-#include "test_quantized_fully_connected_layer.h"
-#endif
+namespace tiny_dnn {
 
-#ifdef CNN_USE_CAFFE_CONVERTER
-#include "test_caffe_converter.h"
-#endif
+TEST(tensor, shape) {
+    Tensor tensor(1,2,2,2);
 
-#include "test_tensor.h"
-#include "test_image.h"
-
-int main(int argc, char **argv) {
-    ::testing::InitGoogleTest(&argc, argv);
-    return RUN_ALL_TESTS();
+    EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
+    EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[2], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
 }
+
+TEST(tensor, access_data) {
+    Tensor tensor(1,2,2,2);
+
+    float_t* begin_ptr = tensor.ptr(0,0,0,0);
+    float_t* end1_ptr  = tensor.ptr(0,1,1,0);
+    float_t* end2_ptr  = tensor.ptr(0,1,1,1);
+
+    // set tensor data
+    
+    // channel #1
+    for (float_t* i = begin_ptr; i != end1_ptr + 1; i++) {
+        *i = float_t(1);
+    }
+
+    // channel #2
+    for (float_t* i = end1_ptr + 1; i != end2_ptr + 1; i++) {
+        *i = float_t(2);
+    }
+
+    // check data
+    
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            for (cnn_size_t k = 0; k < 1; ++k) {
+                if (k == 0) {
+                    EXPECT_EQ(tensor.at(0,i,j,k), cnn_size_t(1));
+                } else {
+                    EXPECT_EQ(tensor.at(0,i,j,k), cnn_size_t(2));
+                }
+            }
+        }
+    }
+}
+
+} // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -404,6 +404,7 @@ TEST(tensor, linspace) {
     }
 
     Tensor<float_t> tensor2(101,1,1,1);
+
     // fill all tensor values with from 0 to 1
 
     tensor2.linspace(float_t(0.0), float_t(1.0));
@@ -422,7 +423,7 @@ TEST(tensor, add1) {
     t1.fill(float_t(1.0));
     t2.fill(float_t(3.0));
 
-    // sum tensor along axis 0
+    // compute element-wise sum along all tensor values
 
     Tensor<float_t> t3 = t1.add(t2);
 
@@ -440,7 +441,7 @@ TEST(tensor, add2) {
 
     t.fill(float_t(1.0));
 
-    // sum tensor along axis 0
+    // compute element-wise sum along all tensor values
 
     Tensor<float_t> t2 = t.add(float_t(2.0));
 
@@ -460,7 +461,7 @@ TEST(tensor, sub1) {
     t1.fill(float_t(1.0));
     t2.fill(float_t(3.0));
 
-    // sum tensor along axis 0
+    // compute element-wise subtraction along all tensor values
 
     Tensor<float_t> t3 = t1.sub(t2);
 
@@ -478,11 +479,11 @@ TEST(tensor, sub2) {
 
     t.fill(float_t(1.0));
 
-    // sum tensor along axis 0
+    // compute element-wise subtraction along all tensor values
 
     Tensor<float_t> t2 = t.sub(float_t(2.0));
 
-    // check that sum is okay
+    // check that subtraction is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_EQ(t2[i], float_t(-1.0));
@@ -498,11 +499,11 @@ TEST(tensor, mul1) {
     t1.fill(float_t(2.0));
     t2.fill(float_t(3.0));
 
-    // sum tensor along axis 0
+    // compute element-wise multiplication along all tensor values
 
     Tensor<float_t> t3 = t1.mul(t2);
 
-    // check that sum is okay
+    // check that subtraction is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
         EXPECT_EQ(t3[i], float_t(6.0));
@@ -516,11 +517,11 @@ TEST(tensor, mult2) {
 
     t.fill(float_t(2.0));
 
-    // sum tensor along axis 0
+    // compute element-wise multiplication along all tensor values
 
     Tensor<float_t> t2 = t.mul(float_t(2.0));
 
-    // check that sum is okay
+    // check that multiplication is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_EQ(t2[i], float_t(4.0));
@@ -536,11 +537,11 @@ TEST(tensor, div1) {
     t1.fill(float_t(1.0));
     t2.fill(float_t(2.0));
 
-    // sum tensor along axis 0
+    // compute element-wise division along all tensor values
 
     Tensor<float_t> t3 = t1.div(t2);
 
-    // check that sum is okay
+    // check that division is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
         EXPECT_EQ(t3[i], float_t(0.5));
@@ -554,11 +555,11 @@ TEST(tensor, div2) {
 
     t.fill(float_t(1.0));
 
-    // sum tensor along axis 0
+    // compute element-wise division along all tensor values
 
     Tensor<float_t> t2 = t.div(float_t(2.0));
 
-    // check that sum is okay
+    // check that division is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_EQ(t2[i], float_t(0.5));
@@ -571,7 +572,7 @@ TEST(tensor, sqrt) {
     // fill tensor with initial values
     t.fill(float_t(4.0));
 
-    // calculate square root
+    // compute element-wise square root along all tensor values
 
     Tensor<float_t> t2 = t.sqrt();
 
@@ -588,7 +589,7 @@ TEST(tensor, exp) {
     // fill tensor with initial values
     t.linspace(float_t(1.0), float_t(16.0));
 
-    // calculate exp
+    // compute element-wise exponent along all tensor values
 
     Tensor<float_t> t2 = t.exp();
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -44,6 +44,7 @@
 */
 #pragma once
 #include "gtest/gtest.h"
+#include "testhelper.h"
 
 #include "tiny_dnn/tiny_dnn.h"
 
@@ -179,7 +180,6 @@ TEST(tensor, access_data4) {
         }
     }
 }
-
 
 TEST(tensor, access_data5) {
     Tensor<float_t> tensor(1,2,2,2);
@@ -410,7 +410,7 @@ TEST(tensor, linspace) {
     tensor2.linspace(float_t(0.0), float_t(1.0));
 
     for (size_t i = 0; i < tensor2.size(); ++i) {
-        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 0.001);
+        EXPECT_NEAR(tensor2[i], float_t(0.01*i), epsilon<float_t>());
     }
 }
 
@@ -430,7 +430,7 @@ TEST(tensor, add1) {
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_EQ(t3[i], float_t(4.0));
+        EXPECT_NEAR(t3[i], float_t(4.0), epsilon<float_t>());
     }
 }
 
@@ -448,7 +448,7 @@ TEST(tensor, add2) {
     // check that sum is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_EQ(t2[i], float_t(3.0));
+        EXPECT_NEAR(t2[i], float_t(3.0), epsilon<float_t>());
     }
 }
 
@@ -468,7 +468,7 @@ TEST(tensor, sub1) {
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_EQ(t3[i], float_t(-2.0));
+        EXPECT_NEAR(t3[i], float_t(-2.0), epsilon<float_t>());
     }
 }
 
@@ -486,7 +486,7 @@ TEST(tensor, sub2) {
     // check that subtraction is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_EQ(t2[i], float_t(-1.0));
+        EXPECT_NEAR(t2[i], float_t(-1.0), epsilon<float_t>());
     }
 }
 
@@ -506,7 +506,7 @@ TEST(tensor, mul1) {
     // check that subtraction is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_EQ(t3[i], float_t(6.0));
+        EXPECT_NEAR(t3[i], float_t(6.0), epsilon<float_t>());
     }
 }
 
@@ -524,7 +524,7 @@ TEST(tensor, mult2) {
     // check that multiplication is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_EQ(t2[i], float_t(4.0));
+        EXPECT_NEAR(t2[i], float_t(4.0), epsilon<float_t>());
     }
 }
 
@@ -544,7 +544,7 @@ TEST(tensor, div1) {
     // check that division is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_EQ(t3[i], float_t(0.5));
+        EXPECT_NEAR(t3[i], float_t(0.5), epsilon<float_t>());
     }
 }
 
@@ -562,7 +562,7 @@ TEST(tensor, div2) {
     // check that division is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_EQ(t2[i], float_t(0.5));
+        EXPECT_NEAR(t2[i], float_t(0.5), epsilon<float_t>());
     }
 }
 
@@ -579,7 +579,7 @@ TEST(tensor, sqrt) {
     // check that root is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_EQ(t2[i], float_t(2.0));
+        EXPECT_NEAR(t2[i], float_t(2.0), epsilon<float_t>());
     }
 }
 
@@ -596,7 +596,7 @@ TEST(tensor, exp) {
     // check that exponent is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
+        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), epsilon<float_t>());
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -372,4 +372,25 @@ TEST(tensor, access_data11) {
     }
 }
 
+TEST(tensor, fill) {
+    Tensor<float_t> tensor(2,2,2,2);
+
+    // fill all tensor values with ones
+
+    tensor.fill(float_t(1.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+ 
+    // fill all tensor values with twos
+
+    tensor.fill(float_t(2.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(2.0));
+    }
+}
+
+
 } // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -392,5 +392,156 @@ TEST(tensor, fill) {
     }
 }
 
+TEST(tensor, add1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.add(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(4.0));
+    }
+}
+
+TEST(tensor, add2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.add(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(3.0));
+    }
+}
+
+TEST(tensor, sub1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.sub(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(-2.0));
+    }
+}
+
+TEST(tensor, sub2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.sub(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(-1.0));
+    }
+}
+
+TEST(tensor, mul1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(2.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.mul(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(6.0));
+    }
+}
+
+TEST(tensor, mult2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.mul(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(4.0));
+    }
+}
+
+TEST(tensor, div1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(2.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.div(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(0.5));
+    }
+}
+
+TEST(tensor, div2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.div(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(0.5));
+    }
+}
 
 } // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -75,7 +75,7 @@ TEST(tensor, constructors) {
     t1 = std::move(t2);
 
     // check that we moved data
-    EXPECT_EQ(t1.size(), cnn_size_t(16));
+    EXPECT_EQ(t1.size(), serial_size_t(16));
 
     // expecting something here is wrong. t2 is in a valid but undefined state, no need to test it.
 
@@ -83,16 +83,16 @@ TEST(tensor, constructors) {
     Tensor<float_t> t3(std::move(t1));
 
     // check that we moved data
-    EXPECT_EQ(t3.size(), cnn_size_t(16));
+    EXPECT_EQ(t3.size(), serial_size_t(16));
 }
 
 TEST(tensor, shape) {
     Tensor<float_t> tensor(1,2,2,2);
 
-    EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
-    EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
-    EXPECT_EQ(tensor.shape()[2], cnn_size_t(2));
-    EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[0], serial_size_t(1));
+    EXPECT_EQ(tensor.shape()[1], serial_size_t(2));
+    EXPECT_EQ(tensor.shape()[2], serial_size_t(2));
+    EXPECT_EQ(tensor.shape()[3], serial_size_t(2));
 }
 
 TEST(tensor, size) {
@@ -130,12 +130,12 @@ TEST(tensor, check_bounds) {
 TEST(tensor, access_data1) {
     Tensor<float_t> tensor(1,2,2,1);
 
-    const std::array<cnn_size_t, 4>& shape = tensor.shape();
+    const std::array<serial_size_t, 4>& shape = tensor.shape();
 
-    for (cnn_size_t n = 0; n < shape[0]; ++n) {
-        for (cnn_size_t w = 0; w < shape[1]; ++w) {
-            for (cnn_size_t h = 0; h < shape[2]; ++h) {
-                for (cnn_size_t d = 0; d < shape[3]; ++d) {
+    for (serial_size_t n = 0; n < shape[0]; ++n) {
+        for (serial_size_t w = 0; w < shape[1]; ++w) {
+            for (serial_size_t h = 0; h < shape[2]; ++h) {
+                for (serial_size_t d = 0; d < shape[3]; ++d) {
                     EXPECT_EQ(tensor.host_at(n,w,h,d),   float_t(0.0));
                     EXPECT_EQ(*tensor.host_ptr(n,w,h,d), float_t(0.0));
                 }
@@ -161,11 +161,11 @@ TEST(tensor, access_data3) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
@@ -174,11 +174,11 @@ TEST(tensor, access_data3) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }
@@ -191,24 +191,24 @@ TEST(tensor, access_data4) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -222,21 +222,21 @@ TEST(tensor, access_data5) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -258,14 +258,14 @@ TEST(tensor, access_data6) {
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
     
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -291,11 +291,11 @@ TEST(tensor, access_data7) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }
@@ -317,11 +317,11 @@ TEST(tensor, access_data8) {
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -331,21 +331,21 @@ TEST(tensor, access_data9) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -355,24 +355,24 @@ TEST(tensor, access_data10) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -383,11 +383,11 @@ TEST(tensor, access_data11) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
@@ -396,11 +396,11 @@ TEST(tensor, access_data11) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -416,7 +416,7 @@ TEST(tensor, linspace) {
     tensor2.linspace(float_t(0.0), float_t(1.0));
 
     for (size_t i = 0; i < tensor2.size(); ++i) {
-        EXPECT_NEAR(tensor2[i], float_t(0.01*i), epsilon<float_t>());
+        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 1e-5);
     }
 }
 
@@ -436,7 +436,7 @@ TEST(tensor, add1) {
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(4.0), epsilon<float_t>());
+        EXPECT_NEAR(t3[i], float_t(4.0), 1e-5);
     }
 }
 
@@ -454,7 +454,7 @@ TEST(tensor, add2) {
     // check that sum is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(3.0), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(3.0), 1e-5);
     }
 }
 
@@ -484,7 +484,7 @@ TEST(tensor, sub1) {
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(-2.0), epsilon<float_t>());
+        EXPECT_NEAR(t3[i], float_t(-2.0), 1e-5);
     }
 }
 
@@ -502,7 +502,7 @@ TEST(tensor, sub2) {
     // check that subtraction is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(-1.0), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(-1.0), 1e-5);
     }
 }
 
@@ -532,7 +532,7 @@ TEST(tensor, mul1) {
     // check that subtraction is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(6.0), epsilon<float_t>());
+        EXPECT_NEAR(t3[i], float_t(6.0), 1e-5);
     }
 }
 
@@ -550,7 +550,7 @@ TEST(tensor, mul2) {
     // check that multiplication is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(4.0), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(4.0), 1e-5);
     }
 }
 
@@ -580,7 +580,7 @@ TEST(tensor, div1) {
     // check that division is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(0.5), epsilon<float_t>());
+        EXPECT_NEAR(t3[i], float_t(0.5), 1e-5);
     }
 }
 
@@ -598,7 +598,7 @@ TEST(tensor, div2) {
     // check that division is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(0.5), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(0.5), 1e-5);
     }
 }
 
@@ -663,7 +663,7 @@ TEST(tensor, sqrt1) {
     // check that root is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(2.0), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(2.0), 1e-5);
     }
 }
 
@@ -697,7 +697,7 @@ TEST(tensor, exp) {
     // check that exponent is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), epsilon<float_t>());
+        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -565,4 +565,21 @@ TEST(tensor, div2) {
     }
 }
 
+TEST(tensor, sqrt) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+    t.fill(float_t(4.0));
+
+    // calculate square root
+
+    Tensor<float_t> t2 = t.sqrt();
+
+    // check that root is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(2.0));
+    }
+}
+
 } // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -452,6 +452,16 @@ TEST(tensor, add2) {
     }
 }
 
+TEST(tensor, add3) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(4,4,4,4);
+
+    // compute element-wise sum along all tensor values.
+    // Expect a throw since shapes are different
+
+    EXPECT_THROW(t1.add(t2), nn_error);
+}
+
 TEST(tensor, sub1) {
     Tensor<float_t> t1(2,2,2,2);
     Tensor<float_t> t2(2,2,2,2);
@@ -490,6 +500,16 @@ TEST(tensor, sub2) {
     }
 }
 
+TEST(tensor, sub3) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(4,4,4,4);
+
+    // compute element-wise subtraction along all tensor values.
+    // Expect a throw since shapes are different
+
+    EXPECT_THROW(t1.sub(t2), nn_error);
+}
+
 TEST(tensor, mul1) {
     Tensor<float_t> t1(2,2,2,2);
     Tensor<float_t> t2(2,2,2,2);
@@ -510,7 +530,7 @@ TEST(tensor, mul1) {
     }
 }
 
-TEST(tensor, mult2) {
+TEST(tensor, mul2) {
     Tensor<float_t> t(2,2,2,2);
 
     // fill tensor with initial values
@@ -526,6 +546,16 @@ TEST(tensor, mult2) {
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_NEAR(t2[i], float_t(4.0), epsilon<float_t>());
     }
+}
+
+TEST(tensor, mul3) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(4,4,4,4);
+
+    // compute element-wise multiplication along all tensor values.
+    // Expect a throw since shapes are different
+
+    EXPECT_THROW(t1.mul(t2), nn_error);
 }
 
 TEST(tensor, div1) {
@@ -564,6 +594,16 @@ TEST(tensor, div2) {
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_NEAR(t2[i], float_t(0.5), epsilon<float_t>());
     }
+}
+
+TEST(tensor, div3) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(4,4,4,4);
+
+    // compute element-wise division along all tensor values.
+    // Expect a throw since shapes are different
+
+    EXPECT_THROW(t1.div(t2), nn_error);
 }
 
 TEST(tensor, sqrt) {

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -34,7 +34,7 @@ using namespace tiny_dnn;
 namespace tiny_dnn {
 
 TEST(tensor, shape) {
-    Tensor<float_t,1,2,2,2> tensor;
+    Tensor<float_t> tensor(1,2,2,2);
 
     EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
     EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
@@ -43,7 +43,7 @@ TEST(tensor, shape) {
 }
 
 TEST(tensor, access_data) {
-    Tensor<float_t,1,2,2,2> tensor;
+    Tensor<float_t> tensor(1,2,2,2);
 
     float_t* begin_ptr = tensor.ptr<float_t>(0,0,0,0);
     float_t* end1_ptr  = tensor.ptr<float_t>(0,1,1,0);

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -116,25 +116,25 @@ TEST(tensor, check_bounds) {
 
     // check bounds with .at() accessor
 
-    EXPECT_NO_THROW(tensor.at<float_t>(0,0,0,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,0,1,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,1,0,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,1,1,0));
+    EXPECT_NO_THROW(tensor.host_at(0,0,0,0));
+    EXPECT_NO_THROW(tensor.host_at(0,0,1,0));
+    EXPECT_NO_THROW(tensor.host_at(0,1,0,0));
+    EXPECT_NO_THROW(tensor.host_at(0,1,1,0));
 
-    EXPECT_THROW(tensor.at<float_t>(0,0,0,1), nn_error);
-    EXPECT_THROW(tensor.at<float_t>(1,0,0,0), nn_error);
-    EXPECT_THROW(tensor.at<float_t>(1,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_at(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_at(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.host_at(1,0,0,1), nn_error);
 
     // check bounds with .ptr() accessor
 
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,0,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,1,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,0,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,1,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,0,0,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,0,1,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,1,0,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,1,1,0));
 
-    EXPECT_THROW(tensor.ptr<float_t>(0,0,0,1), nn_error);
-    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,0), nn_error);
-    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_ptr(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_ptr(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.host_ptr(1,0,0,1), nn_error);
 
     // check bounds with operator[] accessor
 
@@ -147,14 +147,14 @@ TEST(tensor, check_bounds) {
 TEST(tensor, access_data1) {
     Tensor<float_t> tensor(1,2,2,1);
 
-    const std::vector<cnn_size_t>& shape = tensor.shape();
+    const std::array<cnn_size_t, 4>& shape = tensor.shape();
 
     for (cnn_size_t n = 0; n < shape[0]; ++n) {
         for (cnn_size_t w = 0; w < shape[1]; ++w) {
             for (cnn_size_t h = 0; h < shape[2]; ++h) {
                 for (cnn_size_t d = 0; d < shape[3]; ++d) {
-                    EXPECT_EQ(tensor.at<float_t>(n,w,h,d),   float_t(0.0));
-                    EXPECT_EQ(*tensor.ptr<float_t>(n,w,h,d), float_t(0.0));
+                    EXPECT_EQ(tensor.host_at(n,w,h,d),   float_t(0.0));
+                    EXPECT_EQ(*tensor.host_ptr(n,w,h,d), float_t(0.0));
                 }
             }
         }
@@ -175,8 +175,8 @@ TEST(tensor, access_data3) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -188,8 +188,8 @@ TEST(tensor, access_data3) {
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -205,8 +205,8 @@ TEST(tensor, access_data4) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -220,13 +220,13 @@ TEST(tensor, access_data4) {
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -236,8 +236,8 @@ TEST(tensor, access_data5) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -263,27 +263,27 @@ TEST(tensor, access_data6) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using .at() accessor
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
     
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -293,20 +293,20 @@ TEST(tensor, access_data7) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -322,15 +322,15 @@ TEST(tensor, access_data8) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using operator[] accessor
 
@@ -384,13 +384,13 @@ TEST(tensor, access_data10) {
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -410,8 +410,8 @@ TEST(tensor, access_data11) {
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -442,27 +442,27 @@ TEST(tensor, fill) {
     }
 }
 
-TEST(tensor, linspace) {
-    Tensor<float_t> tensor(2,2,2,2);
-
-    // fill all tensor values with values from 1 to 16
-
-    tensor.linspace(float_t(1.0), float_t(16.0));
-
-    for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0+i));
-    }
-
-    Tensor<float_t> tensor2(101,1,1,1);
-
-    // fill all tensor values with from 0 to 1
-
-    tensor2.linspace(float_t(0.0), float_t(1.0));
-
-    for (size_t i = 0; i < tensor2.size(); ++i) {
-        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 1e-5);
-    }
-}
+//TEST(tensor, linspace) {
+//    Tensor<float_t> tensor(2,2,2,2);
+//
+//    // fill all tensor values with values from 1 to 16
+//
+//    tensor.linspace(float_t(1.0), float_t(16.0));
+//
+//    for (size_t i = 0; i < tensor.size(); ++i) {
+//        EXPECT_EQ(tensor[i], float_t(1.0+i));
+//    }
+//
+//    Tensor<float_t> tensor2(101,1,1,1);
+//
+//    // fill all tensor values with from 0 to 1
+//
+//    tensor2.linspace(float_t(0.0), float_t(1.0));
+//
+//    for (size_t i = 0; i < tensor2.size(); ++i) {
+//        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 1e-5);
+//    }
+//}
 
 TEST(tensor, add1) {
     Tensor<float_t> t1(2,2,2,2);
@@ -728,21 +728,21 @@ TEST(tensor, sqrt2) {
     }
 }
 
-TEST(tensor, exp) {
-    Tensor<float_t> t(2, 2, 2, 2);
-
-    // fill tensor with initial values
-    t.linspace(float_t(1.0), float_t(16.0));
-
-    // compute element-wise exponent along all tensor values
-
-    Tensor<float_t> t2 = t.exp();
-
-    // check that exponent is okay
-
-    for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
-    }
-}
+//TEST(tensor, exp) {
+//    Tensor<float_t> t(2, 2, 2, 2);
+//
+//    // fill tensor with initial values
+//    t.linspace(float_t(1.0), float_t(16.0));
+//
+//    // compute element-wise exponent along all tensor values
+//
+//    Tensor<float_t> t2 = t.exp();
+//
+//    // check that exponent is okay
+//
+//    for (size_t i = 0; i < t2.size(); ++i) {
+//        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
+//    }
+//}
 
 } // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -582,4 +582,21 @@ TEST(tensor, sqrt) {
     }
 }
 
+TEST(tensor, exp) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+    t.linspace(float_t(1.0),float_t(16.0));
+
+    // calculate exp
+
+    Tensor<float_t> t2 = t.exp();
+
+    // check that exponent is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
+    }
+}
+
 } // namespace tiny-dnn

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -82,6 +82,8 @@ class Tensor {
         resize();
     }
 
+    // Move constructor
+    Tensor(Tensor<U>&& other) = default;
 
     // Returns the tensor shape
     const std::vector<cnn_size_t>& shape() const { return shape_; }
@@ -193,98 +195,98 @@ class Tensor {
 
     /* @brief Element-wise addition
      */
-    Tensor<> add(const Tensor<>& src) const {
+    Tensor<U> add(const Tensor<U>& src) const {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) + src[i];
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise addition
      */
-    Tensor<> add(const float_t scalar) const {
+    Tensor<U> add(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) + scalar;
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise subtraction
      */
-    Tensor<> sub(const Tensor<>& src) const {
+    Tensor<U> sub(const Tensor<U>& src) const {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) - src[i];
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise subtraction
      */
-    Tensor<> sub(const float_t scalar) const {
+    Tensor<U> sub(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) - scalar;
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise multiplication
      */
-    Tensor<> mul(const Tensor<>& src) const {
+    Tensor<U> mul(const Tensor<U>& src) const {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) * src[i];
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise multiplication
      */
-    Tensor<> mul(const float_t scalar) const {
+    Tensor<U> mul(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) * scalar;
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise division
      */
-    Tensor<> div(const Tensor<>& src) const {
+    Tensor<U> div(const Tensor<>& src) const {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) / (src[i] + 1e-10);
         });
 
-        return res;
+        return std::move(res);
     }
 
     /* @brief Element-wise division
      */
-    Tensor<> div(const float_t scalar) const {
+    Tensor<U> div(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) / (scalar + 1e-10);
         });
 
-        return res;
+        return std::move(res);
     }
 
  private:

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -304,7 +304,7 @@ private:
 // Overloaded method to print the Tensor class to the standard output
 template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
-    const Tensor<T>& tensor) {
+                         const Tensor<T>& tensor) {
     const std::vector<serial_size_t>& shape = tensor.shape();
     for (serial_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -44,7 +44,7 @@
 */
 #pragma once
 
-#include <algorithm> // std::fill
+#include <algorithm> // std::fill, std::generate
 
 #include "tiny_dnn/core/framework/device.fwd.h"
 
@@ -191,6 +191,23 @@ class Tensor {
      */
     void fill(const U value) {
         std::fill(host_data_->begin(), host_data_->end(), value);
+    }
+
+    /* @brief Fills the tensor with evenly-spaced values in the interval
+     *
+     * @param from The lower bound of the interval
+     * @param to The upper bound of the interval
+     */
+    void linspace(const U from, const U to) {
+        U start = from,
+            step = (to - from) / (host_data_->end() - host_data_->begin() - 1);
+        std::generate(host_data_->begin(),
+                      host_data_->end(),
+                      [&start, &step]() {
+                        U tmp = start;
+                        start += step;
+                        return tmp;
+                      });
     }
 
     /* @brief Element-wise addition

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -339,7 +339,9 @@ class Tensor {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
-            res[i] = std::sqrt(this->operator[](i));
+            const U tmp = this->operator[](i);
+            res[i] = tmp < U(0.0) ? std::numeric_limits<U>::quiet_NaN()
+                : std::sqrt(tmp);
         });
 
         return std::move(res);

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -256,7 +256,7 @@ class Tensor {
 
     template<typename T>
     T* access_data(const size_t index) {
-        if (index > host_data_->size()) {
+        if (index >= host_data_->size()) {
             throw nn_error("Access tensor out of range.");
         }
 
@@ -273,7 +273,7 @@ class Tensor {
 
     template<typename T>
     T* access_data(const size_t index) const {
-        if (index > host_data_->size()) {
+        if (index >= host_data_->size()) {
             throw nn_error("Access tensor out of range.");
         }
 

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -287,7 +287,8 @@ class Tensor {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) / (src[i] + 1e-10);
+            res[i] = this->operator[](i) / (src[i] +
+                std::numeric_limits<U>::min());
         });
 
         return std::move(res);
@@ -299,7 +300,8 @@ class Tensor {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) / (scalar + 1e-10);
+            res[i] = this->operator[](i) / (scalar +
+                std::numeric_limits<U>::min());
         });
 
         return std::move(res);

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -68,7 +68,7 @@ class Tensor {
     }
 
     // Returns the tensor shape
-    std::vector<cnn_size_t> shape() const { return shape_; }
+    const std::vector<cnn_size_t>& shape() const { return shape_; }
     
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
@@ -304,7 +304,7 @@ class Tensor {
 // Overloaded method to print the Tensor class to the standard output
 inline std::ostream& operator<< (std::ostream &os,
 		                 const Tensor<>& tensor) {
-    std::vector<cnn_size_t> shape = tensor.shape();
+    const std::vector<cnn_size_t>& shape = tensor.shape();
     for (cnn_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";
         for (cnn_size_t j = 0; j < shape[3]; ++j) {

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -130,8 +130,8 @@ public:
 #endif
         data_is_on_host_ = other.data_is_on_host_;
         data_dirty_ = other.data_dirty_;
-        return *this;
     }
+
     Tensor &operator = (Tensor&& other) {
         shape_ = std::move(other.shape_);
         host_data_ = std::move(other.host_data_);
@@ -140,6 +140,7 @@ public:
 #endif
         data_is_on_host_ = other.data_is_on_host_;
         data_dirty_ = other.data_dirty_;
+        return *this;
     }
 #endif
 

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -300,7 +300,7 @@ class Tensor {
 
     /* @brief Element-wise division
      */
-    Tensor<U> div(const Tensor<>& src) const {
+    Tensor<U> div(const Tensor<U>& src) const {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
@@ -308,8 +308,9 @@ class Tensor {
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) / (src[i] +
-                std::numeric_limits<U>::min());
+            const U tmp = src[i];
+            res[i] = tmp == U(0.0) ? std::numeric_limits<U>::quiet_NaN() :
+                this->operator[](i) / (tmp + std::numeric_limits<U>::min());
         });
 
         return std::move(res);
@@ -320,10 +321,14 @@ class Tensor {
     Tensor<U> div(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) / (scalar +
-                std::numeric_limits<U>::min());
-        });
+        if (scalar == float_t(0.0)) {
+            res.fill(std::numeric_limits<U>::quiet_NaN());
+        } else {
+            for_i(true, res.size(), [&](size_t i) {
+                res[i] = this->operator[](i) / (scalar +
+                    std::numeric_limits<U>::min());
+            });
+        }
 
         return std::move(res);
     }

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -173,8 +173,9 @@ class Tensor {
     // Initializes the data buffer with zeroes
     void resize(const U value = 0) {
         if (!host_data_) {
-            host_data_ = std::unique_ptr<std::vector<U> >(
-                new std::vector<U>(size(), value));
+            //host_data_ = std::unique_ptr<std::vector<U> >(
+            //    new std::vector<U>(size(), value));
+            host_data_ = make_unique<std::vector<U> >(size(), value);
         } else {
             host_data_->resize(size(), value);
         }

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -98,7 +98,7 @@ public:
 
     ~Tensor() = default;
 
-    Tensor(const Tensor&) {
+    Tensor(const Tensor&other) {
         other.fromDevice();
         shape_ = other.shape_;
         host_data_ = other.host_data_;
@@ -125,7 +125,9 @@ public:
     Tensor(Tensor&& other) { // for VS2013 we need to manually implement these if we want to have move semantics
         shape_ = std::move(other.shape_);
         host_data_ = std::move(other.host_data_);
+#if defined(USE_OPENCL) || defined(USE_CUDA)
         device_data_ = std::move(other.device_data_);
+#endif
         data_is_on_host_ = other.data_is_on_host_;
         data_dirty_ = other.data_dirty_;
         return *this;
@@ -133,7 +135,9 @@ public:
     Tensor &operator = (Tensor&& other) {
         shape_ = std::move(other.shape_);
         host_data_ = std::move(other.host_data_);
+#if defined(USE_OPENCL) || defined(USE_CUDA)
         device_data_ = std::move(other.device_data_);
+#endif
         data_is_on_host_ = other.data_is_on_host_;
         data_dirty_ = other.data_dirty_;
     }
@@ -205,6 +209,7 @@ public:
         return host_data_.data();
     }
 
+#if defined(USE_OPENCL) || defined(USE_CUDA)
     const void *device_data() const {
         toDevice();
         return (*device_data_)();
@@ -215,6 +220,7 @@ public:
         data_dirty_ = true;
         return (*device_data_)();
     }
+#endif
 
     size_t size() const {
         return host_data_.size();

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -83,10 +83,15 @@ class Tensor {
         resize();
     }
 
+    ~Tensor() = default;
+
+    Tensor(const Tensor&) = default;
+    Tensor &operator =(const Tensor&) = default;
+
 #ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
     // Move constructor
-    Tensor(Tensor<U>&& other) = default;
-    Tensor &operator = (Tensor<U>&&) = default;
+    Tensor(Tensor&& other) = default;
+    Tensor &operator = (Tensor&&) = default;
 #endif
 
     // Returns the tensor shape
@@ -216,7 +221,7 @@ class Tensor {
 
     /* @brief Element-wise addition
      */
-    Tensor<U> add(const Tensor<U>& src) const {
+    Tensor add(const Tensor& src) const {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
@@ -232,7 +237,7 @@ class Tensor {
 
     /* @brief Element-wise addition
      */
-    Tensor<U> add(const float_t scalar) const {
+    Tensor add(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -244,7 +249,7 @@ class Tensor {
 
     /* @brief Element-wise subtraction
      */
-    Tensor<U> sub(const Tensor<U>& src) const {
+    Tensor sub(const Tensor& src) const {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
@@ -260,7 +265,7 @@ class Tensor {
 
     /* @brief Element-wise subtraction
      */
-    Tensor<U> sub(const float_t scalar) const {
+    Tensor sub(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -272,7 +277,7 @@ class Tensor {
 
     /* @brief Element-wise multiplication
      */
-    Tensor<U> mul(const Tensor<U>& src) const {
+    Tensor mul(const Tensor& src) const {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
@@ -288,7 +293,7 @@ class Tensor {
 
     /* @brief Element-wise multiplication
      */
-    Tensor<U> mul(const float_t scalar) const {
+    Tensor mul(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -300,7 +305,7 @@ class Tensor {
 
     /* @brief Element-wise division
      */
-    Tensor<U> div(const Tensor<U>& src) const {
+    Tensor div(const Tensor& src) const {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
@@ -318,7 +323,7 @@ class Tensor {
 
     /* @brief Element-wise division
      */
-    Tensor<U> div(const float_t scalar) const {
+    Tensor div(const float_t scalar) const {
         Tensor<U> res(this->shape());
 
         if (scalar == float_t(0.0)) {
@@ -335,7 +340,7 @@ class Tensor {
 
     /* @brief Element-wise square root
      */
-    Tensor<U> sqrt() const {
+    Tensor sqrt() const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -349,7 +354,7 @@ class Tensor {
 
     /* @brief Element-wise exponential
      */
-    Tensor<U> exp() const {
+    Tensor exp() const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -77,6 +77,12 @@ class Tensor {
         resize();
     }
 
+    explicit Tensor(const std::vector<cnn_size_t>& shape) {
+        reshape(shape[0], shape[1], shape[2], shape[3]);
+        resize();
+    }
+
+
     // Returns the tensor shape
     const std::vector<cnn_size_t>& shape() const { return shape_; }
     
@@ -177,8 +183,108 @@ class Tensor {
         return new_size;
     }
 
+    /* @brief Fills all the tensor values with a given value
+     *
+     * @param value The value to fill the tensor
+     */
     void fill(const U value) {
         std::fill(host_data_->begin(), host_data_->end(), value);
+    }
+
+    /* @brief Element-wise addition
+     */
+    Tensor<> add(const Tensor<>& src) const {
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) + src[i];
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise addition
+     */
+    Tensor<> add(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) + scalar;
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise subtraction
+     */
+    Tensor<> sub(const Tensor<>& src) const {
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) - src[i];
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise subtraction
+     */
+    Tensor<> sub(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) - scalar;
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise multiplication
+     */
+    Tensor<> mul(const Tensor<>& src) const {
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) * src[i];
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise multiplication
+     */
+    Tensor<> mul(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) * scalar;
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise division
+     */
+    Tensor<> div(const Tensor<>& src) const {
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) / (src[i] + 1e-10);
+        });
+
+        return res;
+    }
+
+    /* @brief Element-wise division
+     */
+    Tensor<> div(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) / (scalar + 1e-10);
+        });
+
+        return res;
     }
 
  private:

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -205,7 +205,7 @@ class Tensor {
             throw nn_error("Access tensor out of range.");
         }
 
-        U* value = &host_data_->at(shape_[1] * shape_[2] *
+        U* value = &host_data_->operator[](shape_[1] * shape_[2] *
             ( shape_[3] * d0 + d3 ) + d1 + d2);
 
         // in case that requested type is not the same as
@@ -223,7 +223,7 @@ class Tensor {
             throw nn_error("Access tensor out of range.");
         }
 
-        U* value = &host_data_->at(index);
+        U* value = &host_data_->operator[](index);
 
         // in case that requested type is not the same as
         // the specified during the tensor initilization

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -44,6 +44,7 @@
 */
 #pragma once
 
+#include <cmath> // sqrt
 #include <algorithm> // std::fill, std::generate
 
 #include "tiny_dnn/core/framework/device.fwd.h"
@@ -319,6 +320,18 @@ class Tensor {
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) / (scalar +
                 std::numeric_limits<U>::min());
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise square root
+     */
+    Tensor<U> sqrt() const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+          res[i] = std::sqrt(this->operator[](i));
         });
 
         return std::move(res);

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -337,6 +337,18 @@ class Tensor {
         return std::move(res);
     }
 
+    /* @brief Element-wise square root
+     */
+    Tensor<U> exp() const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+          res[i] = std::exp(this->operator[](i));
+        });
+
+        return std::move(res);
+    }
+
  private:
     // Initializes the data buffer with the given value
     void resize(const U value = 0) {

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -44,7 +44,7 @@
 */
 #pragma once
 
-#include <cmath> // sqrt
+#include <cmath>     // sqrt
 #include <algorithm> // std::fill, std::generate
 
 #include "tiny_dnn/core/framework/device.fwd.h"
@@ -315,7 +315,7 @@ class Tensor {
         for_i(true, res.size(), [&](size_t i) {
             const U tmp = src[i];
             res[i] = tmp == U(0.0) ? std::numeric_limits<U>::quiet_NaN() :
-                this->operator[](i) / (tmp + std::numeric_limits<U>::min());
+                this->operator[](i) / tmp;
         });
 
         return std::move(res);
@@ -330,8 +330,7 @@ class Tensor {
             res.fill(std::numeric_limits<U>::quiet_NaN());
         } else {
             for_i(true, res.size(), [&](size_t i) {
-                res[i] = this->operator[](i) / (scalar +
-                    std::numeric_limits<U>::min());
+                res[i] = this->operator[](i) / scalar;
             });
         }
 
@@ -496,7 +495,7 @@ class Tensor {
 
 // Overloaded method to print the Tensor class to the standard output
 inline std::ostream& operator<< (std::ostream &os,
-		                 const Tensor<>& tensor) {
+                                 const Tensor<>& tensor) {
     const std::vector<cnn_size_t>& shape = tensor.shape();
     for (cnn_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -65,8 +65,8 @@ template<typename U = float_t>
 class Tensor {
 public:
     /*
-        * Initializes an empty tensor.
-        */
+     * Initializes an empty tensor.
+     */
     Tensor() : shape_{ 0,0,0,0 } {}
 
     /*
@@ -145,25 +145,25 @@ public:
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
     U& host_at(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) {
+               const serial_size_t d1,
+               const serial_size_t d2,
+               const serial_size_t d3) {
         return *host_ptr(d0, d1, d2, d3);
     }
 
     U host_at(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) const {
+              const serial_size_t d1,
+              const serial_size_t d2,
+              const serial_size_t d3) const {
         return *host_ptr(d0, d1, d2, d3);
     }
 
     // Returns the pointer to a specified index in the tensor
     // Checked version (throw exceptions for out-of-range error)
     const U* host_ptr(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) const {
+                      const serial_size_t d1,
+                      const serial_size_t d2,
+                      const serial_size_t d3) const {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -178,9 +178,9 @@ public:
     }
 
     U* host_ptr(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) {
+                const serial_size_t d1,
+                const serial_size_t d2,
+                const serial_size_t d3) {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -227,9 +227,9 @@ public:
     }
 
     void reshape(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) {
+                 const serial_size_t d1,
+                 const serial_size_t d2,
+                 const serial_size_t d3) {
         shape_[0] = d0;
         shape_[1] = d1;
         shape_[2] = d2;
@@ -280,11 +280,11 @@ private:
 
 private:
     /* Vector with the size of the tensor
-        * shape_[0]: batch
-        * shape_[1]: width
-        * shape_[2]: height
-        * shape_[3]: depth
-        */
+     * shape_[0]: batch
+     * shape_[1]: width
+     * shape_[2]: height
+     * shape_[3]: depth
+     */
     std::array<serial_size_t, 4> shape_;
 
     /* Pointer to the Tensor data in pure in the host device */
@@ -304,7 +304,7 @@ private:
 // Overloaded method to print the Tensor class to the standard output
 template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
-                         const Tensor<T>& tensor) {
+                                 const Tensor<T>& tensor) {
     const std::vector<serial_size_t>& shape = tensor.shape();
     for (serial_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -46,8 +46,18 @@
 
 #include <cmath>     // sqrt
 #include <algorithm> // std::fill, std::generate
+#include <numeric>   // std::accumulate
+#include <vector>
 
 #include "tiny_dnn/core/framework/device.fwd.h"
+
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+#ifdef USE_OPENCL
+#include "third_party/CLCudaAPI/clpp11.h"
+#else
+#include "third_party/CLCudaAPI/cupp11.h"
+#endif
+#endif
 
 namespace tiny_dnn {
 
@@ -57,7 +67,7 @@ class Tensor {
     /*
      * Initializes an empty tensor.
      */
-    Tensor() {}
+    Tensor() : shape_{ 0,0,0,0 } {}
 
     /*
      * Create a tensor of the given dimension.
@@ -74,144 +84,158 @@ class Tensor {
                     const cnn_size_t d1,
                     const cnn_size_t d2,
                     const cnn_size_t d3) {
-        reshape(d0, d1, d2, d3);
-        resize();
+        resize(d0, d1, d2, d3);
+    }
+
+    explicit Tensor(const std::array<cnn_size_t, 4>& shape) {
+        resize(shape[0], shape[1], shape[2], shape[3]);
     }
 
     explicit Tensor(const std::vector<cnn_size_t>& shape) {
-        reshape(shape[0], shape[1], shape[2], shape[3]);
-        resize();
+        assert(shape.size() == 4);
+        resize(shape[0], shape[1], shape[2], shape[3]);
     }
 
     ~Tensor() = default;
 
-    Tensor(const Tensor&) = default; // copy ctor
-
-    // We need to implement the copy assign constructor in order to make a deep copy
-    // of the data hold by the oject because the supported VS compilers don't allow
-    // move semantics and invoke copy and copy assing constructors instead.
-    // The main reason is that std::unique_ptr can only be moved since have deleted 
-    // copy assign constructors.
+    Tensor(const Tensor&) {
+        other.fromDevice();
+        shape_ = other.shape_;
+        host_data_ = other.host_data_;
+        data_is_on_host_ = true;
+        data_dirty_ = true;       
+        //device_data_ is intentionally left uninitialized.
+    }
 
     Tensor &operator = (const Tensor& other) {
+        other.fromDevice();
         shape_ = other.shape_;
+        data_is_on_host_ = true;
+        data_dirty_ = true;
+        host_data_ = other.host_data_;
 
-        // deep copy of pointed data
-
-        host_data_ = make_unique<
-            std::vector<U, aligned_allocator<U, 64> > >(*other.host_data_);
-
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        device_data_ = make_unique<
-            std::unique_ptr<CLCudaAPI::Buffer<U> > >(*other.device_data_))
-#endif
-
+        //device_data_ is intentionally left as-is. It will be erased only if new tensor won't fit, and only when data gets moved to the GPU.
         return *this;
     }
 
 #ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
     Tensor(Tensor&& other) = default;        // move ctor
     Tensor &operator = (Tensor&&) = default; // move assign
+#else
+    Tensor(Tensor&& other) { // for VS2013 we need to manually implement these if we want to have move semantics
+        shape_ = std::move(other.shape_);
+        host_data_ = std::move(other.host_data_);
+        device_data_ = std::move(other.device_data_);
+        data_is_on_host_ = other.data_is_on_host_;
+        data_dirty_ = other.data_dirty_;
+        return *this;
+    }
+    Tensor &operator = (Tensor&& other) {
+        shape_ = std::move(other.shape_);
+        host_data_ = std::move(other.host_data_);
+        device_data_ = std::move(other.device_data_);
+        data_is_on_host_ = other.data_is_on_host_;
+        data_dirty_ = other.data_dirty_;
+}
 #endif
 
     // Returns the tensor shape
-    const std::vector<cnn_size_t>& shape() const { return shape_; }
+    const std::array<cnn_size_t, 4>& shape() const { return shape_; }
     
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
-    template<typename T>
-    T& at(const cnn_size_t d0,
+    U& host_at(const cnn_size_t d0,
           const cnn_size_t d1,
           const cnn_size_t d2,
           const cnn_size_t d3) {
-        return *access_data<T>(d0, d1, d2, d3);
+        return *host_ptr(d0, d1, d2, d3);
     }
 
-    template<typename T>
-    const T& at(const cnn_size_t d0,
+    U host_at(const cnn_size_t d0,
                 const cnn_size_t d1,
                 const cnn_size_t d2,
                 const cnn_size_t d3) const {
-        return *access_data<T>(d0, d1, d2, d3);
+        return *host_ptr(d0, d1, d2, d3);
     }
 
     // Returns the pointer to a specified index in the tensor
     // Checked version (throw exceptions for out-of-range error)
-    template<typename T>
-    T* ptr(const cnn_size_t d0,
-           const cnn_size_t d1,
-           const cnn_size_t d2,
-           const cnn_size_t d3) {
-        return access_data<T>(d0, d1, d2, d3);
+    const U* host_ptr(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) const {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
+
+        return host_data() + (
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+            );
     }
-    
-    template<typename T>
-    const T* ptr(const cnn_size_t d0,
-                 const cnn_size_t d1,
-                 const cnn_size_t d2,
-                 const cnn_size_t d3) const {
-        return access_data<T>(d0, d1, d2, d3);
+
+    U* host_ptr(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
+
+        return mutable_host_data() + (
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+            );
     }
 
     // zero-overhead version (same performance to raw pointer access.
     // have an assertion for out-of-range error)
     U& operator[] (const size_t index) {
-        return *access_data<U>(index);
+        return mutable_host_data()[index];
     }
 
-    const U& operator[] (const size_t index) const {
-        return *access_data<U>(index);
+    U operator[] (const size_t index) const {
+        return host_data()[index];
     }
 
-    // this is only a proof of concept to copy data
-    // from one device to another.
-    void toDevice(const Device& device) {
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        CLCudaAPI::Context ctx = device.context();
-        CLCudaAPI::Queue queue = device.queue();
-
-        device_data_ = make_unique<CLCudaAPI::Buffer<U> >(
-            ctx, queue, host_data_->begin(), host_data_->end());
-#endif
+    const U* host_data() const {
+        if (!data_is_on_host_ && data_dirty_) {
+            fromDevice();
+        }
+        return host_data_.data();
+    }
+    
+    U* mutable_host_data() {
+        if (!data_is_on_host_ && data_dirty_) {
+            fromDevice();
+        }
+        data_dirty_ = true;
+        return host_data_.data();
     }
 
-    // this is only a proof of concept to copy data
-    // from one device to another.
-    void fromDevice(const Device& device) {
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        CLCudaAPI::Queue queue = device.queue();
-
-        device_data_->Read(
-            queue, host_data_->size(), &host_data_->at(0));
-#endif
+    const void *device_data() const {
+        if (data_is_on_host_ && data_dirty_) const {
+            toDevice();
+        }
+        return (*device_data_)();
     }
 
-    /*template<typename T, typename U = float_t>
-    T host_data() const {
-        return static_cast<T>(*access_data(0));
+    void *mutable_device_data() {
+        if (data_is_on_host_ && data_dirty_) {
+            toDevice();
+        }
+        data_dirty_ = true;
+        return (*device_data_)();
     }
-
-    template<typename T, typename U = float_t>
-    T mutable_host_data() {
-        return static_cast<T>(*access_data(0));
-    }
-
-    template<typename T, typename U = float_t>
-    T device_data() const {
-	fromDevice(device_);
-        return static_cast<T>(*access_data(0));
-    }
-
-    template<typename T, typename U = float_t>
-    T mutable_device_data() {
-	fromDevice(device_);
-        return static_cast<T>(*access_data(0));
-    }*/
 
     size_t size() const {
-        size_t new_size = 1;
-        for (auto d : shape_) { new_size *= d; }
-        return new_size;
+        return host_data_.size();
     }
 
     /* @brief Fills all the tensor values with a given value
@@ -219,303 +243,220 @@ class Tensor {
      * @param value The value to fill the tensor
      */
     void fill(const U value) {
-        std::fill(host_data_->begin(), host_data_->end(), value);
+        data_is_on_host_ = true;
+        data_dirty_ = true;
+        std::fill(host_data_.begin(), host_data_.end(), value);
     }
 
-    /* @brief Fills the tensor with evenly-spaced values in the interval
-     *
-     * @param from The lower bound of the interval
-     * @param to The upper bound of the interval
-     */
-    void linspace(const U from, const U to) {
-        U start = from,
-            step = (to - from) / (host_data_->end() - host_data_->begin() - 1);
-        std::generate(host_data_->begin(),
-                      host_data_->end(),
-                      [&start, &step]() {
-                        U tmp = start;
-                        start += step;
-                        return tmp;
-                      });
-    }
+    // /* @brief Fills the tensor with evenly-spaced values in the interval
+    //  *
+    //  * @param from The lower bound of the interval
+    //  * @param to The upper bound of the interval
+    //  */
+    // void linspace(const U from, const U to) {
+    //     U start = from,
+    //         step = (to - from) / (host_data_->end() - host_data_->begin() - 1);
+    //     std::generate(host_data_->begin(),
+    //                   host_data_->end(),
+    //                   [&start, &step]() {
+    //                     U tmp = start;
+    //                     start += step;
+    //                     return tmp;
+    //                   });
+    // }
 
     /* @brief Element-wise addition
      */
     Tensor add(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) + src[i];
-        });
-
-        return std::move(res);
+        return binary_element_wise_operation(src, std::plus<U>());
     }
 
     /* @brief Element-wise addition
      */
-    Tensor add(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) + scalar;
-        });
-
-        return std::move(res);
+    Tensor add(const U scalar) const {
+        return binary_scalar_operation(scalar, std::plus<U>());
     }
 
     /* @brief Element-wise subtraction
      */
     Tensor sub(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) - src[i];
-        });
-
-        return std::move(res);
+        return binary_element_wise_operation(src, std::minus<U>());
     }
 
     /* @brief Element-wise subtraction
      */
-    Tensor sub(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) - scalar;
-        });
-
-        return std::move(res);
+    Tensor sub(const U scalar) const {
+        return add(-scalar);
     }
 
     /* @brief Element-wise multiplication
      */
     Tensor mul(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) * src[i];
-        });
-
-        return std::move(res);
+        return binary_element_wise_operation(src, std::multiplies<U>());
     }
 
     /* @brief Element-wise multiplication
      */
-    Tensor mul(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) * scalar;
-        });
-
-        return std::move(res);
+    Tensor mul(const U scalar) const {
+        return binary_scalar_operation(scalar, std::multiplies<U>());
     }
 
     /* @brief Element-wise division
      */
     Tensor div(const Tensor& src) const {
+        return binary_element_wise_operation(src, [](U a, U b)
+        {
+            return (b == U(0.0)) ? std::numeric_limits<U>::quiet_NaN() :
+                a / b;
+
+        });
+    }
+
+    /* @brief Element-wise division
+     */
+    Tensor div(const U scalar) const {
+        if (scalar == U(0.0)) {
+            Tensor<U> res(this->shape());
+            res.fill(std::numeric_limits<U>::quiet_NaN());
+            return std::move(res);
+        } else {
+            return binary_scalar_operation(src, std::divides<U>());
+        }
+
+    }
+
+    /* @brief Element-wise square root
+     */
+    Tensor sqrt() const {
+        return unary_element_wise_operation([](U v) {return std::sqrt(v); }); // lambda used because types cannot be deduced by simply specifying std::sqrt 
+    }
+
+    /* @brief Element-wise exponential
+     */
+    Tensor exp() const {
+        return unary_element_wise_operation([](U v) {return std::exp(v); }); // lambda used because types cannot be deduced by simply specifying std::exp
+    }
+
+ private:
+     void toDevice() const {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+         CLCudaAPI::Queue queue = device->queue();
+         if (device_data_ && device_data_->GetSize() >= host_data_.size()) {
+             device_data_->Write(queue, host_data.size(), host_data_.data(), 0);
+         } else {
+             CLCudaAPI::Context ctx = device->context();
+             device_data_ = make_unique<CLCudaAPI::Buffer<U> >(
+                 ctx, queue, host_data_.begin(), host_data_.end());
+         }
+
+#endif
+         data_is_on_host_ = false;
+         data_dirty_ = false;
+     }
+
+     void fromDevice() const {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+         assert(device_);
+         assert(device_data_);
+         device_data_->Read(device_->queue(), host_data_.size(), const_cast<U*>(host_data_.data())); // using const_cast<> to avoid making host_data_ entirely mutable
+#endif
+         data_is_on_host_ = true;
+         data_dirty_ = false;
+     }
+
+    // Initializes the shape vector
+    void resize(const cnn_size_t d0,
+                 const cnn_size_t d1,
+                 const cnn_size_t d2,
+                 const cnn_size_t d3) {
+	    shape_[0] = d0;
+	    shape_[1] = d1;
+	    shape_[2] = d2;
+	    shape_[3] = d3;
+        host_data_.resize(std::accumulate(std::begin(shape_), std::end(shape_), size_t(1), std::multiplies<size_t>()), U(0));
+    }
+
+    template<typename F> Tensor binary_element_wise_operation(const Tensor &src, F f) const
+    {
         if (this->shape() != src.shape()) {
             throw nn_error("Tensor must have same shape");
         }
 
         Tensor<U> res(src.shape());
 
-        for_i(true, res.size(), [&](size_t i) {
-            const U tmp = src[i];
-            res[i] = tmp == U(0.0) ? std::numeric_limits<U>::quiet_NaN() :
-                this->operator[](i) / tmp;
+        const U* dst = res.mutable_host_data();
+        const U* src1 = host_data();
+        const U* src2 = src.host_data();
+
+        for_i(true, res.size(), [dst, src1, src2, &f](size_t i) {
+            dst[i] = f(src1[i], src2[i]);
         });
 
         return std::move(res);
     }
 
-    /* @brief Element-wise division
-     */
-    Tensor div(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        if (scalar == float_t(0.0)) {
-            res.fill(std::numeric_limits<U>::quiet_NaN());
-        } else {
-            for_i(true, res.size(), [&](size_t i) {
-                res[i] = this->operator[](i) / scalar;
-            });
+    template<typename F> Tensor unary_element_wise_operation(F f) const
+    {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
         }
 
-        return std::move(res);
-    }
+        Tensor<U> res(src.shape());
 
-    /* @brief Element-wise square root
-     */
-    Tensor sqrt() const {
-        Tensor<U> res(this->shape());
+        const U* dst = res.mutable_host_data();
+        const U* src1 = host_data();
 
-        for_i(true, res.size(), [&](size_t i) {
-            const U tmp = this->operator[](i);
-            res[i] = tmp < U(0.0) ? std::numeric_limits<U>::quiet_NaN()
-                : std::sqrt(tmp);
+        for_i(true, res.size(), [dst, src1, &f](size_t i) {
+            dst[i] = f(src1[i]);
         });
 
         return std::move(res);
     }
 
-    /* @brief Element-wise exponential
-     */
-    Tensor exp() const {
-        Tensor<U> res(this->shape());
+    template<typename F> Tensor binary_scalar_operation(U scalar, F f) const
+    {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
 
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = std::exp(this->operator[](i));
+        Tensor<U> res(src.shape());
+
+        const U* dst = res.mutable_host_data();
+        const U* src1 = host_data();
+
+        for_i(true, res.size(), [dst, src1, scalar, &f](size_t i) {
+            dst[i] = f(src1[i], scalar);
         });
 
         return std::move(res);
     }
-
- private:
-    // Initializes the data buffer with the given value
-    void resize(const U value = 0) {
-        if (!host_data_) {
-            host_data_ = make_unique<
-                std::vector<U, aligned_allocator<U, 64> > >(size(), value);
-        } else {
-            host_data_->resize(size(), value);
-        }
-    }
-
-    // Initializes the shape vector
-    void reshape(const cnn_size_t d0,
-                 const cnn_size_t d1,
-                 const cnn_size_t d2,
-                 const cnn_size_t d3) {
-	    shape_.resize(4);
-	    shape_[0] = d0;
-	    shape_[1] = d1;
-	    shape_[2] = d2;
-	    shape_[3] = d3;
-    }
-
-    // Method to access to the tensor data.
-    // It checks if the requested position is feasible or not.
-    template<typename T>
-    T* access_data(const cnn_size_t d0,
-                   const cnn_size_t d1,
-                   const cnn_size_t d2,
-                   const cnn_size_t d3) {
-        if (d0 >= shape_[0] || d1 >= shape_[1] ||
-            d2 >= shape_[2] || d3 >= shape_[3]) {
-            throw nn_error("Access tensor out of range.");
-        }
-
-        U* value = &host_data_->operator[](
-            shape_[1] * shape_[2] * shape_[3] * d0 +
-            shape_[1] * shape_[2] * d3 +
-            shape_[1] * d2 +
-            d1
-        );
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
-    }
-
-    // Method to access to the tensor data.
-    // It checks if the requested position is feasible or not.
-    template<typename T>
-    T* access_data(const cnn_size_t d0,
-                   const cnn_size_t d1,
-                   const cnn_size_t d2,
-                   const cnn_size_t d3) const {
-        if (d0 >= shape_[0] || d1 >= shape_[1] ||
-            d2 >= shape_[2] || d3 >= shape_[3]) {
-            throw nn_error("Access tensor out of range.");
-        }
-
-        U* value = &host_data_->operator[](
-            shape_[1] * shape_[2] * shape_[3] * d0 +
-            shape_[1] * shape_[2] * d3 +
-            shape_[1] * d2 +
-            d1
-        );
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
-    }
-
-    template<typename T>
-    T* access_data(const size_t index) {
-        assert(index < host_data_->size() && "Access tensor out of range.");
-
-        U* value = &host_data_->operator[](index);
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
-    }
-
-    template<typename T>
-    T* access_data(const size_t index) const {
-        assert(index < host_data_->size() && "Access tensor out of range.");
-
-        U* value = &host_data_->operator[](index);
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
-    }
-
- private:
+private:
     /* Vector with the size of the tensor
      * shape_[0]: batch
      * shape_[1]: width
      * shape_[2]: height
      * shape_[3]: depth
      */
-    std::vector<cnn_size_t> shape_;
+    std::array<cnn_size_t, 4> shape_;
 
     /* Pointer to the Tensor data in pure in the host device */
-    std::unique_ptr<std::vector<U, aligned_allocator<U, 64> > > host_data_;
+    std::vector<U, aligned_allocator<U, 64> > host_data_;
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
     /* Pointer to the Tensor data in the device */
     std::unique_ptr<CLCudaAPI::Buffer<U> > device_data_;
 #endif
+    mutable bool data_is_on_host_;      //< current data is on host if true, on device if false.
+    mutable bool data_dirty_;           //< set to true if current data might have been modified
 
     /* Pointer to the current device where the data resides */
     Device* device_;
 };
 
 // Overloaded method to print the Tensor class to the standard output
+template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
-                                 const Tensor<>& tensor) {
+                                 const Tensor<T>& tensor) {
     const std::vector<cnn_size_t>& shape = tensor.shape();
     for (cnn_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";
@@ -524,7 +465,7 @@ inline std::ostream& operator<< (std::ostream &os,
             os << "-- Data:\n";
             for (cnn_size_t k = 0; k < shape[1]; ++k) {
                 for (cnn_size_t l = 0; l < shape[2]; ++l) {
-                    os << "   " << tensor.at<float_t>(i,k,l,j) << " ";
+                    os << "   " << tensor.at(i,k,l,j) << " ";
                 }
                 os << ";\n";
             }

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -1,0 +1,156 @@
+/*
+    COPYRIGHT
+
+    All contributions by Taiga Nomi
+    Copyright (c) 2013, Taiga Nomi
+    All rights reserved.
+
+    All other contributions:
+    Copyright (c) 2013-2016, the respective contributors.
+    All rights reserved.
+
+    Each contributor holds copyright over their respective contributions.
+    The project versioning (Git) records all such contribution source information.
+
+    LICENSE
+
+    The BSD 3-Clause License
+
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of tiny-dnn nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+namespace tiny_dnn {
+
+/* Class modelling a Tensor
+ */
+class Tensor {
+ public:
+    /* Default constructor for the Tensor class
+     * @param batch The size of the batch
+     * @param width The width of the tensor
+     * @param heigth The height of the tensor
+     * @param depth The number of channels
+     */
+    explicit Tensor(const cnn_size_t batch,
+                    const cnn_size_t width,
+                    const cnn_size_t height,
+                    const cnn_size_t depth) : shape_(4) {
+        init_data (batch, width, height, depth);
+        init_shape(batch, width, height, depth);
+    }
+    
+    // Returns the tensor shape
+    std::vector<cnn_size_t> shape() const { return shape_; }
+    
+    // Returns the value of a requested position in the tensor
+    float_t at(const cnn_size_t batch,  const cnn_size_t width,
+               const cnn_size_t height, const cnn_size_t depth) const {
+        return *access_data(batch, width, height, depth);
+    }
+
+    // Returns the pointer to a requested position in the tensor
+    float_t* ptr(const cnn_size_t batch,  const cnn_size_t width,
+                 const cnn_size_t height, const cnn_size_t depth) const {
+        return access_data(batch, width, height, depth);
+    }
+
+ private:
+    // Initializes the data buffer with zeroes
+    void init_data(const cnn_size_t batch,  const cnn_size_t width,
+                   const cnn_size_t height, const cnn_size_t depth) {
+        if (batch <= 0 || width <= 0 || height <= 0 || depth <= 0) {
+            nn_error("Tensor size must be a positive number");
+        }
+        data_cpu_ = std::make_shared<std::vector<float_t> >(
+            batch * width * height * depth, float_t(0));
+    }
+
+    // Initializes the shape vector
+    void init_shape(const cnn_size_t batch,  const cnn_size_t width,
+                    const cnn_size_t height, const cnn_size_t depth) {
+       shape_[0] = batch;  shape_[1] = width;
+       shape_[2] = height; shape_[3] = depth;
+    }
+
+    // Method to access to the tensor data.
+    // It checks if the requested position is feasible or not.
+    float_t* access_data(const cnn_size_t batch,
+                         const cnn_size_t width,
+                         const cnn_size_t height,
+                         const cnn_size_t depth) const {
+        if ((batch  < 0 || batch  > shape_[0]) ||
+            (width  < 0 || width  > shape_[1]) ||
+            (height < 0 || height > shape_[2]) ||
+            (depth  < 0 || depth  > shape_[3])) {
+            nn_error("Access tensor out of dimension");
+        }
+        /*return &data_cpu_->at(batch  * shape_[1] * shape_[2] * shape_[3] + 
+                                depth  * shape_[1] * shape_[2] +
+                                height * shape_[1] + width);*/
+        return &data_cpu_->at(shape_[1] * shape_[2] * (
+                      batch * shape_[3] + depth) + height + width);
+    }
+
+
+ private:
+    /* Vector with the size of the tensor
+     * shape_[0]: batch
+     * shape_[1]: width
+     * shape_[2]: height
+     * shape_[3]: depth
+     */
+    std::vector<cnn_size_t> shape_;
+
+    /* Pointer to the Tensor data in CPU mode */
+    std::shared_ptr<std::vector<float_t> > data_cpu_;
+};
+
+// Overloaded method to print the Tensor class to the standard output
+inline std::ostream& operator<< (std::ostream &os, const Tensor& tensor) {
+    std::vector<cnn_size_t> shape = tensor.shape();
+    for (cnn_size_t i = 0; i < shape[0]; ++i) {
+        os << "-- Batch: " << i << "\n";
+        for (cnn_size_t j = 0; j < shape[3]; ++j) {
+            os << "-- Channel: " << j << "\n";
+            os << "-- Data:\n";
+            for (cnn_size_t k = 0; k < shape[1]; ++k) {
+                for (cnn_size_t l = 0; l < shape[2]; ++l) {
+                    os << tensor.at(i,k,l,j) << " ";
+                }
+                os << ";\n";
+            }
+        }
+    }
+    os << "----------------\n" 
+       << "--> Tensor size: [ " 
+       << shape[0] << " x " << shape[1] << " x "
+       << shape[2] << " x " << shape[3] << " ]\n";
+    return os;
+}
+
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -44,6 +44,8 @@
 */
 #pragma once
 
+#include <algorithm> // std::fill
+
 #include "tiny_dnn/core/framework/device.fwd.h"
 
 namespace tiny_dnn {
@@ -173,6 +175,10 @@ class Tensor {
         size_t new_size = 1;
         for (auto d : shape_) { new_size *= d; }
         return new_size;
+    }
+
+    void fill(const U value) {
+        std::fill(host_data_->begin(), host_data_->end(), value);
     }
 
  private:

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -386,9 +386,7 @@ class Tensor {
 
     template<typename T>
     T* access_data(const size_t index) {
-        if (index >= host_data_->size()) {
-            throw nn_error("Access tensor out of range.");
-        }
+        assert(index < host_data_->size() && "Access tensor out of range.");
 
         U* value = &host_data_->operator[](index);
 
@@ -403,9 +401,7 @@ class Tensor {
 
     template<typename T>
     T* access_data(const size_t index) const {
-        if (index >= host_data_->size()) {
-            throw nn_error("Access tensor out of range.");
-        }
+        assert(index < host_data_->size() && "Access tensor out of range.");
 
         U* value = &host_data_->operator[](index);
 

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -70,20 +70,20 @@ public:
     Tensor() : shape_{ 0,0,0,0 } {}
 
     /*
-        * Create a tensor of the given dimension.
-        * It is assumed that a tensor will hold data in NxWxHxD order,
-        * where:
-        *  N the batch axis
-        *  W the width axis
-        *  H the heigth axis
-        *  D the depth axis
-        *
-        *  Data will be hold by a std::vector with 64bytes alignment.
-        */
-    explicit Tensor(const serial_size_t d0,
-        const serial_size_t d1,
-        const serial_size_t d2,
-        const serial_size_t d3) {
+     * Create a tensor of the given dimension.
+     * It is assumed that a tensor will hold data in NxWxHxD order,
+     * where:
+     *  N the batch axis
+     *  W the width axis
+     *  H the heigth axis
+     *  D the depth axis
+     *
+     *  Data will be hold by a std::vector with 64bytes alignment.
+     */
+    explicit Tensor(const cnn_size_t d0,
+                    const cnn_size_t d1,
+                    const cnn_size_t d2,
+                    const cnn_size_t d3) {
         reshape(d0, d1, d2, d3);
     }
 

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -196,6 +196,10 @@ class Tensor {
     /* @brief Element-wise addition
      */
     Tensor<U> add(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -220,6 +224,10 @@ class Tensor {
     /* @brief Element-wise subtraction
      */
     Tensor<U> sub(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -244,6 +252,10 @@ class Tensor {
     /* @brief Element-wise multiplication
      */
     Tensor<U> mul(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {
@@ -268,6 +280,10 @@ class Tensor {
     /* @brief Element-wise division
      */
     Tensor<U> div(const Tensor<>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
         Tensor<U> res(src.shape());
 
         for_i(true, res.size(), [&](size_t i) {

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -83,8 +83,11 @@ class Tensor {
         resize();
     }
 
+#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
     // Move constructor
     Tensor(Tensor<U>&& other) = default;
+    Tensor &operator = (Tensor<U>&&) = default;
+#endif
 
     // Returns the tensor shape
     const std::vector<cnn_size_t>& shape() const { return shape_; }

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -80,10 +80,10 @@ public:
      *
      *  Data will be hold by a std::vector with 64bytes alignment.
      */
-    explicit Tensor(const cnn_size_t d0,
-                    const cnn_size_t d1,
-                    const cnn_size_t d2,
-                    const cnn_size_t d3) {
+    explicit Tensor(const serial_size_t d0,
+                    const serial_size_t d1,
+                    const serial_size_t d2,
+                    const serial_size_t d3) {
         reshape(d0, d1, d2, d3);
     }
 

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -170,12 +170,11 @@ class Tensor {
     }
 
  private:
-    // Initializes the data buffer with zeroes
+    // Initializes the data buffer with the given value
     void resize(const U value = 0) {
         if (!host_data_) {
-            //host_data_ = std::unique_ptr<std::vector<U> >(
-            //    new std::vector<U>(size(), value));
-            host_data_ = make_unique<std::vector<U> >(size(), value);
+            host_data_ = make_unique<
+                std::vector<U, aligned_allocator<U, 64> > >(size(), value);
         } else {
             host_data_->resize(size(), value);
         }
@@ -244,7 +243,7 @@ class Tensor {
     std::vector<cnn_size_t> shape_;
 
     /* Pointer to the Tensor data in pure CPU mode */
-    std::unique_ptr<std::vector<U> > host_data_;
+    std::unique_ptr<std::vector<U, aligned_allocator<U, 64> > > host_data_;
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
     /* Pointer to the Tensor data in OpenCL mode */

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -67,7 +67,10 @@ public:
     /*
      * Initializes an empty tensor.
      */
-    Tensor() : shape_{ 0,0,0,0 } {}
+    Tensor()
+    {
+        reshape(0, 0, 0, 0);
+    }
 
     /*
      * Create a tensor of the given dimension.

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -80,18 +80,18 @@ public:
         *
         *  Data will be hold by a std::vector with 64bytes alignment.
         */
-    explicit Tensor(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    explicit Tensor(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         reshape(d0, d1, d2, d3);
     }
 
-    explicit Tensor(const std::array<cnn_size_t, 4>& shape) {
+    explicit Tensor(const std::array<serial_size_t, 4>& shape) {
         reshape(shape[0], shape[1], shape[2], shape[3]);
     }
 
-    explicit Tensor(const std::vector<cnn_size_t>& shape) {
+    explicit Tensor(const std::vector<serial_size_t>& shape) {
         assert(shape.size() == 4);
         reshape(shape[0], shape[1], shape[2], shape[3]);
     }
@@ -140,30 +140,30 @@ public:
 #endif
 
     // Returns the tensor shape
-    const std::array<cnn_size_t, 4>& shape() const { return shape_; }
+    const std::array<serial_size_t, 4>& shape() const { return shape_; }
 
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
-    U& host_at(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    U& host_at(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         return *host_ptr(d0, d1, d2, d3);
     }
 
-    U host_at(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) const {
+    U host_at(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) const {
         return *host_ptr(d0, d1, d2, d3);
     }
 
     // Returns the pointer to a specified index in the tensor
     // Checked version (throw exceptions for out-of-range error)
-    const U* host_ptr(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) const {
+    const U* host_ptr(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) const {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -177,10 +177,10 @@ public:
             );
     }
 
-    U* host_ptr(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    U* host_ptr(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -226,10 +226,10 @@ public:
         std::fill(std::begin(host_data_), std::end(host_data_), value);
     }
 
-    void reshape(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    void reshape(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         shape_[0] = d0;
         shape_[1] = d1;
         shape_[2] = d2;
@@ -237,7 +237,7 @@ public:
         host_data_.resize(calcSize(), U(0));
     }
 
-    void reshape(const std::array<cnn_size_t, 4> &sz)
+    void reshape(const std::array<serial_size_t, 4> &sz)
     {
         shape_ = sz;
         host_data_.resize(calcSize(), U(0));
@@ -285,7 +285,7 @@ private:
         * shape_[2]: height
         * shape_[3]: depth
         */
-    std::array<cnn_size_t, 4> shape_;
+    std::array<serial_size_t, 4> shape_;
 
     /* Pointer to the Tensor data in pure in the host device */
     std::vector<U, aligned_allocator<U, 64> > host_data_;
@@ -305,14 +305,14 @@ private:
 template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
     const Tensor<T>& tensor) {
-    const std::vector<cnn_size_t>& shape = tensor.shape();
-    for (cnn_size_t i = 0; i < shape[0]; ++i) {
+    const std::vector<serial_size_t>& shape = tensor.shape();
+    for (serial_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";
-        for (cnn_size_t j = 0; j < shape[3]; ++j) {
+        for (serial_size_t j = 0; j < shape[3]; ++j) {
             os << "-- Channel: " << j << "\n";
             os << "-- Data:\n";
-            for (cnn_size_t k = 0; k < shape[1]; ++k) {
-                for (cnn_size_t l = 0; l < shape[2]; ++l) {
+            for (serial_size_t k = 0; k < shape[1]; ++k) {
+                for (serial_size_t l = 0; l < shape[2]; ++l) {
                     os << "   " << tensor.at(i, k, l, j) << " ";
                 }
                 os << ";\n";

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -331,19 +331,19 @@ class Tensor {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
-          res[i] = std::sqrt(this->operator[](i));
+            res[i] = std::sqrt(this->operator[](i));
         });
 
         return std::move(res);
     }
 
-    /* @brief Element-wise square root
+    /* @brief Element-wise exponential
      */
     Tensor<U> exp() const {
         Tensor<U> res(this->shape());
 
         for_i(true, res.size(), [&](size_t i) {
-          res[i] = std::exp(this->operator[](i));
+            res[i] = std::exp(this->operator[](i));
         });
 
         return std::move(res);

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -30,6 +30,8 @@
 #include "tiny_dnn/network.h"
 #include "tiny_dnn/nodes.h"
 
+#include "tiny_dnn/core/framework/tensor.h"
+
 #include "tiny_dnn/core/framework/device.h"
 #include "tiny_dnn/core/framework/program_manager.h"
 

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -416,4 +416,10 @@ inline void printAvailableDevice(const serial_size_t platform_id,
 #endif
 }
 
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
 } // namespace tiny_dnn


### PR DESCRIPTION
Well, as usual, I made a mess with GIT, and apparently I can't easily push to @edgarriba's original PR.

Today I reworked a bit @edgarriba's #400, I changed a bit the interface, added the lazy-allocation and lazy-movement of memory around, renamed accessor to host_ptr and host_at (to clarify they work on host memory), and implemented the generic functions for binary and unary host operations, element-wise and scalar, so it's now easier to implement functions such as add, sub, mul, div, exp, sqrt, ...

I commented out linspace, if someone has a strong opinion about that, we can still get it back in.