### PR TITLE
Fix conv::bprop with pad_same

### DIFF
--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -702,6 +702,20 @@ TEST(convolutional, gradient_check11_connection_tbl) { // sigmoid - mse - has co
         epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
+TEST(convolutional, gradient_check12_pad_same) { // sigmoid - mse - padding same
+	network<sequential> nn;
+
+	nn << fully_connected_layer<identity>(10, 5*5) <<
+		convolutional_layer<sigmoid>(5, 5, 3, 1, 1, padding::same,
+		true, 1, 1, core::backend_t::internal);
+
+	const auto test_data = generate_gradient_check_data(nn.in_data_size());
+	nn.init_weight();
+	EXPECT_TRUE(nn.gradient_check<mse>(test_data.first,
+		test_data.second,
+		epsilon<float_t>(), GRAD_CHECK_ALL));
+}
+
 TEST(convolutional, read_write)
 {
     convolutional_layer<tan_h> l1(5, 5, 3, 1, 1);

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -272,7 +272,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
         }
 
         if (params_.pad_type == padding::same) {
-            *in_grad_[0] = cws_.prev_delta_padded_;
+            in_grad_[0] = &cws_.prev_delta_padded_;
         }
 
         auto ctx = OpKernelContext(in_data_, out_data, out_grad, in_grad_);


### PR DESCRIPTION
Currently convolutional_layer with padding::same mode never propagate gradient to previous layer. This PR will fix #332