### PR TITLE
add Tensor class

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -65,8 +65,8 @@ using namespace tiny_dnn::activation;
 #include "test_caffe_converter.h"
 #endif
 
+#include "test_tensor.h"
 #include "test_image.h"
-
 
 int main(int argc, char **argv) {
     ::testing::InitGoogleTest(&argc, argv);

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -392,6 +392,27 @@ TEST(tensor, fill) {
     }
 }
 
+TEST(tensor, linspace) {
+    Tensor<float_t> tensor(2,2,2,2);
+
+    // fill all tensor values with values from 1 to 16
+
+    tensor.linspace(float_t(1.0), float_t(16.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0+i));
+    }
+
+    Tensor<float_t> tensor2(101,1,1,1);
+    // fill all tensor values with from 0 to 1
+
+    tensor2.linspace(float_t(0.0), float_t(1.0));
+
+    for (size_t i = 0; i < tensor2.size(); ++i) {
+        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 0.001);
+    }
+}
+
 TEST(tensor, add1) {
     Tensor<float_t> t1(2,2,2,2);
     Tensor<float_t> t2(2,2,2,2);
@@ -541,6 +562,40 @@ TEST(tensor, div2) {
 
     for (size_t i = 0; i < t2.size(); ++i) {
         EXPECT_EQ(t2[i], float_t(0.5));
+    }
+}
+
+TEST(tensor, sqrt) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+    t.fill(float_t(4.0));
+
+    // calculate square root
+
+    Tensor<float_t> t2 = t.sqrt();
+
+    // check that root is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, exp) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+    t.linspace(float_t(1.0), float_t(16.0));
+
+    // calculate exp
+
+    Tensor<float_t> t2 = t.exp();
+
+    // check that exponent is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
     }
 }
 

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -1,0 +1,547 @@
+/*
+    COPYRIGHT
+
+    All contributions by Taiga Nomi
+    Copyright (c) 2013, Taiga Nomi
+    All rights reserved.
+
+    All other contributions:
+    Copyright (c) 2013-2016, the respective contributors.
+    All rights reserved.
+
+    Each contributor holds copyright over their respective contributions.
+    The project versioning (Git) records all such contribution source information.
+
+    LICENSE
+
+    The BSD 3-Clause License
+
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of tiny-dnn nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+#include "gtest/gtest.h"
+
+#include "tiny_dnn/tiny_dnn.h"
+
+using namespace tiny_dnn;
+
+namespace tiny_dnn {
+
+TEST(tensor, shape) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
+    EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[2], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
+}
+
+TEST(tensor, check_bounds) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    // check bounds with .at() accessor
+
+    EXPECT_NO_THROW(tensor.at<float_t>(0,0,0,0));
+    EXPECT_NO_THROW(tensor.at<float_t>(0,0,1,0));
+    EXPECT_NO_THROW(tensor.at<float_t>(0,1,0,0));
+    EXPECT_NO_THROW(tensor.at<float_t>(0,1,1,0));
+
+    EXPECT_THROW(tensor.at<float_t>(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.at<float_t>(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.at<float_t>(1,0,0,1), nn_error);
+
+    // check bounds with .ptr() accessor
+
+    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,0,0));
+    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,1,0));
+    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,0,0));
+    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,1,0));
+
+    EXPECT_THROW(tensor.ptr<float_t>(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,1), nn_error);
+
+    // check bounds with operator[] accessor
+
+    EXPECT_NO_THROW(tensor[0]);
+    EXPECT_NO_THROW(tensor[3]);
+
+    EXPECT_DEBUG_DEATH(tensor[4], "");
+}
+
+TEST(tensor, access_data1) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    const std::vector<cnn_size_t>& shape = tensor.shape();
+
+    for (cnn_size_t n = 0; n < shape[0]; ++n) {
+        for (cnn_size_t w = 0; w < shape[1]; ++w) {
+            for (cnn_size_t h = 0; h < shape[2]; ++h) {
+                for (cnn_size_t d = 0; d < shape[3]; ++d) {
+                    EXPECT_EQ(tensor.at<float_t>(n,w,h,d),   float_t(0.0));
+                    EXPECT_EQ(*tensor.ptr<float_t>(n,w,h,d), float_t(0.0));
+                }
+            }
+        }
+    }
+}
+
+TEST(tensor, access_data2) {
+    Tensor<float_t> tensor(1,2,2,1);
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(0.0));
+    }
+}
+
+
+TEST(tensor, access_data3) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .ptr() accessor
+
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
+    }
+
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data4) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .ptr() accessor
+
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
+    }
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+        }
+    }
+}
+
+
+TEST(tensor, access_data5) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .ptr() accessor
+
+    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
+    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr1[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        ptr2[i] = float_t(2.0);
+    }
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data6) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
+    
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+        }
+    }
+}
+
+TEST(tensor, access_data7) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data8) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using .at() accessor
+
+    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
+    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+
+    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
+    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data9) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+    }
+}
+
+TEST(tensor, access_data10) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using .at() accessor
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+        }
+    }
+
+    for (cnn_size_t i = 0; i < 2; ++i) {
+        for (cnn_size_t j = 0; j < 2; ++j) {
+            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+        }
+    }
+}
+
+TEST(tensor, access_data11) {
+    Tensor<float_t> tensor(1,2,2,2);
+
+    // modify data using operator[] accessor
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[i] = float_t(1.0);
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        tensor[4 + i] = float_t(2.0);
+    }
+
+    // check data using .ptr() accessor
+
+    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
+    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr11[i], float_t(1.0));
+    }
+
+    for (cnn_size_t i = 0; i < 4; ++i) {
+        EXPECT_EQ(ptr22[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, fill) {
+    Tensor<float_t> tensor(2,2,2,2);
+
+    // fill all tensor values with ones
+
+    tensor.fill(float_t(1.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(1.0));
+    }
+ 
+    // fill all tensor values with twos
+
+    tensor.fill(float_t(2.0));
+
+    for (size_t i = 0; i < tensor.size(); ++i) {
+        EXPECT_EQ(tensor[i], float_t(2.0));
+    }
+}
+
+TEST(tensor, add1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.add(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(4.0));
+    }
+}
+
+TEST(tensor, add2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.add(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(3.0));
+    }
+}
+
+TEST(tensor, sub1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.sub(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(-2.0));
+    }
+}
+
+TEST(tensor, sub2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.sub(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(-1.0));
+    }
+}
+
+TEST(tensor, mul1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(2.0));
+    t2.fill(float_t(3.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.mul(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(6.0));
+    }
+}
+
+TEST(tensor, mult2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.mul(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(4.0));
+    }
+}
+
+TEST(tensor, div1) {
+    Tensor<float_t> t1(2,2,2,2);
+    Tensor<float_t> t2(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t1.fill(float_t(1.0));
+    t2.fill(float_t(2.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t3 = t1.div(t2);
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t3.size(); ++i) {
+        EXPECT_EQ(t3[i], float_t(0.5));
+    }
+}
+
+TEST(tensor, div2) {
+    Tensor<float_t> t(2,2,2,2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // sum tensor along axis 0
+
+    Tensor<float_t> t2 = t.div(float_t(2.0));
+
+    // check that sum is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_EQ(t2[i], float_t(0.5));
+    }
+}
+
+} // namespace tiny-dnn

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -75,7 +75,7 @@ TEST(tensor, constructors) {
     t1 = std::move(t2);
 
     // check that we moved data
-    EXPECT_EQ(t1.size(), cnn_size_t(16));
+    EXPECT_EQ(t1.size(), serial_size_t(16));
 
     // expecting something here is wrong. t2 is in a valid but undefined state, no need to test it.
 
@@ -83,16 +83,16 @@ TEST(tensor, constructors) {
     Tensor<float_t> t3(std::move(t1));
 
     // check that we moved data
-    EXPECT_EQ(t3.size(), cnn_size_t(16));
+    EXPECT_EQ(t3.size(), serial_size_t(16));
 }
 
 TEST(tensor, shape) {
     Tensor<float_t> tensor(1,2,2,2);
 
-    EXPECT_EQ(tensor.shape()[0], cnn_size_t(1));
-    EXPECT_EQ(tensor.shape()[1], cnn_size_t(2));
-    EXPECT_EQ(tensor.shape()[2], cnn_size_t(2));
-    EXPECT_EQ(tensor.shape()[3], cnn_size_t(2));
+    EXPECT_EQ(tensor.shape()[0], serial_size_t(1));
+    EXPECT_EQ(tensor.shape()[1], serial_size_t(2));
+    EXPECT_EQ(tensor.shape()[2], serial_size_t(2));
+    EXPECT_EQ(tensor.shape()[3], serial_size_t(2));
 }
 
 TEST(tensor, size) {
@@ -130,12 +130,12 @@ TEST(tensor, check_bounds) {
 TEST(tensor, access_data1) {
     Tensor<float_t> tensor(1,2,2,1);
 
-    const std::array<cnn_size_t, 4>& shape = tensor.shape();
+    const std::array<serial_size_t, 4>& shape = tensor.shape();
 
-    for (cnn_size_t n = 0; n < shape[0]; ++n) {
-        for (cnn_size_t w = 0; w < shape[1]; ++w) {
-            for (cnn_size_t h = 0; h < shape[2]; ++h) {
-                for (cnn_size_t d = 0; d < shape[3]; ++d) {
+    for (serial_size_t n = 0; n < shape[0]; ++n) {
+        for (serial_size_t w = 0; w < shape[1]; ++w) {
+            for (serial_size_t h = 0; h < shape[2]; ++h) {
+                for (serial_size_t d = 0; d < shape[3]; ++d) {
                     EXPECT_EQ(tensor.host_at(n,w,h,d),   float_t(0.0));
                     EXPECT_EQ(*tensor.host_ptr(n,w,h,d), float_t(0.0));
                 }
@@ -161,11 +161,11 @@ TEST(tensor, access_data3) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
@@ -174,11 +174,11 @@ TEST(tensor, access_data3) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }
@@ -191,24 +191,24 @@ TEST(tensor, access_data4) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -222,21 +222,21 @@ TEST(tensor, access_data5) {
     float_t* ptr1 = tensor.host_ptr(0,0,0,0);
     float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         ptr2[i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -258,14 +258,14 @@ TEST(tensor, access_data6) {
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
     
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -291,11 +291,11 @@ TEST(tensor, access_data7) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }
@@ -317,11 +317,11 @@ TEST(tensor, access_data8) {
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -331,21 +331,21 @@ TEST(tensor, access_data9) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
@@ -355,24 +355,24 @@ TEST(tensor, access_data10) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .at() accessor
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
-    for (cnn_size_t i = 0; i < 2; ++i) {
-        for (cnn_size_t j = 0; j < 2; ++j) {
+    for (serial_size_t i = 0; i < 2; ++i) {
+        for (serial_size_t j = 0; j < 2; ++j) {
             EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
@@ -383,11 +383,11 @@ TEST(tensor, access_data11) {
 
     // modify data using operator[] accessor
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
@@ -396,11 +396,11 @@ TEST(tensor, access_data11) {
     const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
     const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
     }
 
-    for (cnn_size_t i = 0; i < 4; ++i) {
+    for (serial_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr22[i], float_t(2.0));
     }
 }

--- a/test/test_tensor.h
+++ b/test/test_tensor.h
@@ -61,14 +61,14 @@ TEST(tensor, constructors) {
 
     // check that t2 values has been copyied to t1
     for (size_t i = 0; i < t1.size(); ++i) {
-        EXPECT_EQ(t1[i], float_t(2.0));
+        EXPECT_EQ(t1.host_data()[i], float_t(2.0));
     }
 
     t1 = Tensor<float_t>(1,1,1,1); // invoke copy ctor
 
     // check that t1 have default values
     for (size_t i = 0; i < t1.size(); ++i) {
-        EXPECT_EQ(t1[i], float_t(0.0));
+        EXPECT_EQ(t1.host_data()[i], float_t(0.0));
     }
 
     // invoke move assign cto
@@ -76,24 +76,14 @@ TEST(tensor, constructors) {
 
     // check that we moved data
     EXPECT_EQ(t1.size(), cnn_size_t(16));
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    EXPECT_EQ(t2.size(), cnn_size_t(1.0));
-#else
-    // we'll assume that copy assign ctor is invoked
-    EXPECT_EQ(t2.size(), cnn_size_t(16));
-#endif
+
+    // expecting something here is wrong. t2 is in a valid but undefined state, no need to test it.
 
     // invoke move ctor
     Tensor<float_t> t3(std::move(t1));
 
     // check that we moved data
     EXPECT_EQ(t3.size(), cnn_size_t(16));
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-    EXPECT_EQ(t1.size(), cnn_size_t(1.0));
-#else
-    // we'll assume that copy assign ctor is invoked
-    EXPECT_EQ(t1.size(), cnn_size_t(16));
-#endif
 }
 
 TEST(tensor, shape) {
@@ -116,45 +106,38 @@ TEST(tensor, check_bounds) {
 
     // check bounds with .at() accessor
 
-    EXPECT_NO_THROW(tensor.at<float_t>(0,0,0,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,0,1,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,1,0,0));
-    EXPECT_NO_THROW(tensor.at<float_t>(0,1,1,0));
+    EXPECT_NO_THROW(tensor.host_at(0,0,0,0));
+    EXPECT_NO_THROW(tensor.host_at(0,0,1,0));
+    EXPECT_NO_THROW(tensor.host_at(0,1,0,0));
+    EXPECT_NO_THROW(tensor.host_at(0,1,1,0));
 
-    EXPECT_THROW(tensor.at<float_t>(0,0,0,1), nn_error);
-    EXPECT_THROW(tensor.at<float_t>(1,0,0,0), nn_error);
-    EXPECT_THROW(tensor.at<float_t>(1,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_at(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_at(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.host_at(1,0,0,1), nn_error);
 
     // check bounds with .ptr() accessor
 
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,0,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,0,1,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,0,0));
-    EXPECT_NO_THROW(tensor.ptr<float_t>(0,1,1,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,0,0,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,0,1,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,1,0,0));
+    EXPECT_NO_THROW(tensor.host_ptr(0,1,1,0));
 
-    EXPECT_THROW(tensor.ptr<float_t>(0,0,0,1), nn_error);
-    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,0), nn_error);
-    EXPECT_THROW(tensor.ptr<float_t>(1,0,0,1), nn_error);
-
-    // check bounds with operator[] accessor
-
-    EXPECT_NO_THROW(tensor[0]);
-    EXPECT_NO_THROW(tensor[3]);
-
-    EXPECT_DEBUG_DEATH(tensor[4], "");
+    EXPECT_THROW(tensor.host_ptr(0,0,0,1), nn_error);
+    EXPECT_THROW(tensor.host_ptr(1,0,0,0), nn_error);
+    EXPECT_THROW(tensor.host_ptr(1,0,0,1), nn_error);
 }
 
 TEST(tensor, access_data1) {
     Tensor<float_t> tensor(1,2,2,1);
 
-    const std::vector<cnn_size_t>& shape = tensor.shape();
+    const std::array<cnn_size_t, 4>& shape = tensor.shape();
 
     for (cnn_size_t n = 0; n < shape[0]; ++n) {
         for (cnn_size_t w = 0; w < shape[1]; ++w) {
             for (cnn_size_t h = 0; h < shape[2]; ++h) {
                 for (cnn_size_t d = 0; d < shape[3]; ++d) {
-                    EXPECT_EQ(tensor.at<float_t>(n,w,h,d),   float_t(0.0));
-                    EXPECT_EQ(*tensor.ptr<float_t>(n,w,h,d), float_t(0.0));
+                    EXPECT_EQ(tensor.host_at(n,w,h,d),   float_t(0.0));
+                    EXPECT_EQ(*tensor.host_ptr(n,w,h,d), float_t(0.0));
                 }
             }
         }
@@ -165,7 +148,7 @@ TEST(tensor, access_data2) {
     Tensor<float_t> tensor(1,2,2,1);
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(0.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(0.0));
     }
 }
 
@@ -175,8 +158,8 @@ TEST(tensor, access_data3) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -188,8 +171,8 @@ TEST(tensor, access_data3) {
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -205,8 +188,8 @@ TEST(tensor, access_data4) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -220,13 +203,13 @@ TEST(tensor, access_data4) {
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -236,8 +219,8 @@ TEST(tensor, access_data5) {
 
     // modify data using .ptr() accessor
 
-    float_t* ptr1 = tensor.ptr<float_t>(0,0,0,0);
-    float_t* ptr2 = tensor.ptr<float_t>(0,0,0,1);
+    float_t* ptr1 = tensor.host_ptr(0,0,0,0);
+    float_t* ptr2 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         ptr1[i] = float_t(1.0);
@@ -250,11 +233,11 @@ TEST(tensor, access_data5) {
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -263,27 +246,27 @@ TEST(tensor, access_data6) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using .at() accessor
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
     
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -293,20 +276,20 @@ TEST(tensor, access_data7) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -322,24 +305,24 @@ TEST(tensor, access_data8) {
 
     // modify data using .at() accessor
 
-    tensor.at<float_t>(0,0,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,0,1,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,0,0) = float_t(1.0);
-    tensor.at<float_t>(0,1,1,0) = float_t(1.0);
+    tensor.host_at(0,0,0,0) = float_t(1.0);
+    tensor.host_at(0,0,1,0) = float_t(1.0);
+    tensor.host_at(0,1,0,0) = float_t(1.0);
+    tensor.host_at(0,1,1,0) = float_t(1.0);
 
-    tensor.at<float_t>(0,0,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,0,1,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,0,1) = float_t(2.0);
-    tensor.at<float_t>(0,1,1,1) = float_t(2.0);
+    tensor.host_at(0,0,0,1) = float_t(2.0);
+    tensor.host_at(0,0,1,1) = float_t(2.0);
+    tensor.host_at(0,1,0,1) = float_t(2.0);
+    tensor.host_at(0,1,1,1) = float_t(2.0);
 
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -349,21 +332,21 @@ TEST(tensor, access_data9) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        EXPECT_EQ(tensor[4 + i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[4 + i], float_t(2.0));
     }
 }
 
@@ -373,24 +356,24 @@ TEST(tensor, access_data10) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .at() accessor
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,0), float_t(1.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,0), float_t(1.0));
         }
     }
 
     for (cnn_size_t i = 0; i < 2; ++i) {
         for (cnn_size_t j = 0; j < 2; ++j) {
-            EXPECT_EQ(tensor.at<float_t>(0,i,j,1), float_t(2.0));
+            EXPECT_EQ(tensor.host_at(0,i,j,1), float_t(2.0));
         }
     }
 }
@@ -401,17 +384,17 @@ TEST(tensor, access_data11) {
     // modify data using operator[] accessor
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[i] = float_t(1.0);
+        tensor.mutable_host_data()[i] = float_t(1.0);
     }
 
     for (cnn_size_t i = 0; i < 4; ++i) {
-        tensor[4 + i] = float_t(2.0);
+        tensor.mutable_host_data()[4 + i] = float_t(2.0);
     }
 
     // check data using .ptr() accessor
 
-    const float_t* ptr11 = tensor.ptr<float_t>(0,0,0,0);
-    const float_t* ptr22 = tensor.ptr<float_t>(0,0,0,1);
+    const float_t* ptr11 = tensor.host_ptr(0,0,0,0);
+    const float_t* ptr22 = tensor.host_ptr(0,0,0,1);
 
     for (cnn_size_t i = 0; i < 4; ++i) {
         EXPECT_EQ(ptr11[i], float_t(1.0));
@@ -430,7 +413,7 @@ TEST(tensor, fill) {
     tensor.fill(float_t(1.0));
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(1.0));
     }
  
     // fill all tensor values with twos
@@ -438,31 +421,31 @@ TEST(tensor, fill) {
     tensor.fill(float_t(2.0));
 
     for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(2.0));
+        EXPECT_EQ(tensor.host_data()[i], float_t(2.0));
     }
 }
 
-TEST(tensor, linspace) {
-    Tensor<float_t> tensor(2,2,2,2);
-
-    // fill all tensor values with values from 1 to 16
-
-    tensor.linspace(float_t(1.0), float_t(16.0));
-
-    for (size_t i = 0; i < tensor.size(); ++i) {
-        EXPECT_EQ(tensor[i], float_t(1.0+i));
-    }
-
-    Tensor<float_t> tensor2(101,1,1,1);
-
-    // fill all tensor values with from 0 to 1
-
-    tensor2.linspace(float_t(0.0), float_t(1.0));
-
-    for (size_t i = 0; i < tensor2.size(); ++i) {
-        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 1e-5);
-    }
-}
+//TEST(tensor, linspace) {
+//    Tensor<float_t> tensor(2,2,2,2);
+//
+//    // fill all tensor values with values from 1 to 16
+//
+//    tensor.linspace(float_t(1.0), float_t(16.0));
+//
+//    for (size_t i = 0; i < tensor.size(); ++i) {
+//        EXPECT_EQ(tensor[i], float_t(1.0+i));
+//    }
+//
+//    Tensor<float_t> tensor2(101,1,1,1);
+//
+//    // fill all tensor values with from 0 to 1
+//
+//    tensor2.linspace(float_t(0.0), float_t(1.0));
+//
+//    for (size_t i = 0; i < tensor2.size(); ++i) {
+//        EXPECT_NEAR(tensor2[i], float_t(0.01*i), 1e-5);
+//    }
+//}
 
 TEST(tensor, add1) {
     Tensor<float_t> t1(2,2,2,2);
@@ -475,17 +458,19 @@ TEST(tensor, add1) {
 
     // compute element-wise sum along all tensor values
 
-    Tensor<float_t> t3 = t1.add(t2);
+    Tensor<float_t> t3;
+    
+    layer_add(t3, t1, t2);
 
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(4.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(4.0), 1e-5);
     }
 }
 
-TEST(tensor, add2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, add2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -493,12 +478,34 @@ TEST(tensor, add2) {
 
     // compute element-wise sum along all tensor values
 
-    Tensor<float_t> t2 = t.add(float_t(2.0));
+    Tensor<float_t> t2;
 
     // check that sum is okay
 
+    layer_add(t2, float_t(2.0), t);
+
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(3.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(3.0), 1e-5);
+    }
+}
+
+TEST(tensor, add2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(1.0));
+
+    // compute element-wise sum along all tensor values
+
+    Tensor<float_t> t2;
+
+    // check that sum is okay
+
+    layer_add(t2, t, float_t(2.0));
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(3.0), 1e-5);
     }
 }
 
@@ -509,7 +516,9 @@ TEST(tensor, add3) {
     // compute element-wise sum along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.add(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_add(t3, t1, t2); , nn_error);
 }
 
 TEST(tensor, sub1) {
@@ -523,17 +532,18 @@ TEST(tensor, sub1) {
 
     // compute element-wise subtraction along all tensor values
 
-    Tensor<float_t> t3 = t1.sub(t2);
+    Tensor<float_t> t3;
+    layer_sub(t3, t1, t2);
 
     // check that sum is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(-2.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(-2.0), 1e-5);
     }
 }
 
-TEST(tensor, sub2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, sub2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -541,12 +551,34 @@ TEST(tensor, sub2) {
 
     // compute element-wise subtraction along all tensor values
 
-    Tensor<float_t> t2 = t.sub(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_sub(t2, t, float_t(2.0));
 
     // check that subtraction is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(-1.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(-1.0), 1e-5);
+    }
+}
+
+TEST(tensor, sub2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise subtraction along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_sub(t2, float_t(1.0), t);
+
+    // check that subtraction is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(-1.0), 1e-5);
     }
 }
 
@@ -557,7 +589,9 @@ TEST(tensor, sub3) {
     // compute element-wise subtraction along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.sub(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_sub(t3,  t1, t2), nn_error);
 }
 
 TEST(tensor, mul1) {
@@ -571,17 +605,19 @@ TEST(tensor, mul1) {
 
     // compute element-wise multiplication along all tensor values
 
-    Tensor<float_t> t3 = t1.mul(t2);
+    Tensor<float_t> t3;
+    
+    layer_mul(t3, t1, t2);
 
     // check that subtraction is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(6.0), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(6.0), 1e-5);
     }
 }
 
-TEST(tensor, mul2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, mul2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -589,12 +625,36 @@ TEST(tensor, mul2) {
 
     // compute element-wise multiplication along all tensor values
 
-    Tensor<float_t> t2 = t.mul(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_mul(t2, t, float_t(2.0));
+
 
     // check that multiplication is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(4.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(4.0), 1e-5);
+    }
+}
+
+TEST(tensor, mul2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise multiplication along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_mul(t2, float_t(2.0), t);
+
+
+    // check that multiplication is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(4.0), 1e-5);
     }
 }
 
@@ -605,7 +665,9 @@ TEST(tensor, mul3) {
     // compute element-wise multiplication along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.mul(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_mul(t3, t1, t2), nn_error);
 }
 
 TEST(tensor, div1) {
@@ -619,17 +681,19 @@ TEST(tensor, div1) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t3 = t1.div(t2);
+    Tensor<float_t> t3;
+
+    layer_div(t3, t1, t2);
 
     // check that division is okay
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_NEAR(t3[i], float_t(0.5), 1e-5);
+        EXPECT_NEAR(t3.host_data()[i], float_t(0.5), 1e-5);
     }
 }
 
-TEST(tensor, div2) {
-    Tensor<float_t> t(2,2,2,2);
+TEST(tensor, div2a) {
+    Tensor<float_t> t(2, 2, 2, 2);
 
     // fill tensor with initial values
 
@@ -637,12 +701,34 @@ TEST(tensor, div2) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t2 = t.div(float_t(2.0));
+    Tensor<float_t> t2;
+
+    layer_div(t2, t, float_t(2.0));
 
     // check that division is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(0.5), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(0.5), 1e-5);
+    }
+}
+
+TEST(tensor, div2b) {
+    Tensor<float_t> t(2, 2, 2, 2);
+
+    // fill tensor with initial values
+
+    t.fill(float_t(2.0));
+
+    // compute element-wise division along all tensor values
+
+    Tensor<float_t> t2;
+
+    layer_div(t2, float_t(1.0), t);
+
+    // check that division is okay
+
+    for (size_t i = 0; i < t2.size(); ++i) {
+        EXPECT_NEAR(t2.host_data()[i], float_t(0.5), 1e-5);
     }
 }
 
@@ -653,7 +739,9 @@ TEST(tensor, div3) {
     // compute element-wise division along all tensor values.
     // Expect a throw since shapes are different
 
-    EXPECT_THROW(t1.div(t2), nn_error);
+    Tensor<float_t> t3;
+
+    EXPECT_THROW(layer_div(t3, t1, t2), nn_error);
 }
 
 TEST(tensor, div4) {
@@ -667,12 +755,14 @@ TEST(tensor, div4) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t3 = t1.div(t2);
+    Tensor<float_t> t3;
+
+    layer_div(t3, t1, t2);
 
     // check that division is NaN
 
     for (size_t i = 0; i < t3.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t3[i]));
+        EXPECT_TRUE(std::isnan(t3.host_data()[i]));
     }
 }
 
@@ -685,12 +775,14 @@ TEST(tensor, div5) {
 
     // compute element-wise division along all tensor values
 
-    Tensor<float_t> t2 = t.div(float_t(0.0));
+    Tensor<float_t> t2;
+
+    layer_div(t2, t, float_t(0.0));
 
     // check that division is NaN
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t2[i]));
+        EXPECT_TRUE(std::isnan(t2.host_data()[i]));
     }
 }
 
@@ -702,12 +794,14 @@ TEST(tensor, sqrt1) {
 
     // compute element-wise square root along all tensor values
 
-    Tensor<float_t> t2 = t.sqrt();
+    Tensor<float_t> t2;
+    
+    layer_sqrt(t2, t);
 
     // check that root is okay
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(2.0), 1e-5);
+        EXPECT_NEAR(t2.host_data()[i], float_t(2.0), 1e-5);
     }
 }
 
@@ -719,30 +813,32 @@ TEST(tensor, sqrt2) {
 
     // compute element-wise square root along all tensor values
 
-    Tensor<float_t> t2 = t.sqrt();
+    Tensor<float_t> t2;
+
+    layer_sqrt(t2, t);
 
     // check that division is NaN
 
     for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_TRUE(std::isnan(t2[i]));
+        EXPECT_TRUE(std::isnan(t2.host_data()[i]));
     }
 }
 
-TEST(tensor, exp) {
-    Tensor<float_t> t(2, 2, 2, 2);
-
-    // fill tensor with initial values
-    t.linspace(float_t(1.0), float_t(16.0));
-
-    // compute element-wise exponent along all tensor values
-
-    Tensor<float_t> t2 = t.exp();
-
-    // check that exponent is okay
-
-    for (size_t i = 0; i < t2.size(); ++i) {
-        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
-    }
-}
+//TEST(tensor, exp) {
+//    Tensor<float_t> t(2, 2, 2, 2);
+//
+//    // fill tensor with initial values
+//    t.linspace(float_t(1.0), float_t(16.0));
+//
+//    // compute element-wise exponent along all tensor values
+//
+//    Tensor<float_t> t2 = t.exp();
+//
+//    // check that exponent is okay
+//
+//    for (size_t i = 0; i < t2.size(); ++i) {
+//        EXPECT_NEAR(t2[i], float_t(exp(float_t(i+1))), 1e-5);
+//    }
+//}
 
 } // namespace tiny-dnn

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -46,476 +46,265 @@
 
 #include <cmath>     // sqrt
 #include <algorithm> // std::fill, std::generate
+#include <numeric>   // std::accumulate
+#include <vector>
 
 #include "tiny_dnn/core/framework/device.fwd.h"
+
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+#ifdef USE_OPENCL
+#include "third_party/CLCudaAPI/clpp11.h"
+#else
+#include "third_party/CLCudaAPI/cupp11.h"
+#endif
+#endif
 
 namespace tiny_dnn {
 
 template<typename U = float_t>
 class Tensor {
- public:
+public:
     /*
-     * Initializes an empty tensor.
-     */
-    Tensor() {}
+        * Initializes an empty tensor.
+        */
+    Tensor() : shape_{ 0,0,0,0 } {}
 
     /*
-     * Create a tensor of the given dimension.
-     * It is assumed that a tensor will hold data in NxWxHxD order,
-     * where:
-     *  N the batch axis
-     *  W the width axis
-     *  H the heigth axis
-     *  D the depth axis
-     *
-     *  Data will be hold by a std::vector with 64bytes alignment.
-     */
+        * Create a tensor of the given dimension.
+        * It is assumed that a tensor will hold data in NxWxHxD order,
+        * where:
+        *  N the batch axis
+        *  W the width axis
+        *  H the heigth axis
+        *  D the depth axis
+        *
+        *  Data will be hold by a std::vector with 64bytes alignment.
+        */
     explicit Tensor(const cnn_size_t d0,
-                    const cnn_size_t d1,
-                    const cnn_size_t d2,
-                    const cnn_size_t d3) {
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) {
         reshape(d0, d1, d2, d3);
-        resize();
+    }
+
+    explicit Tensor(const std::array<cnn_size_t, 4>& shape) {
+        reshape(shape[0], shape[1], shape[2], shape[3]);
     }
 
     explicit Tensor(const std::vector<cnn_size_t>& shape) {
+        assert(shape.size() == 4);
         reshape(shape[0], shape[1], shape[2], shape[3]);
-        resize();
     }
 
     ~Tensor() = default;
 
-    Tensor(const Tensor&) = default; // copy ctor
-
-    // We need to implement the copy assign constructor in order to make a deep copy
-    // of the data hold by the oject because the supported VS compilers don't allow
-    // move semantics and invoke copy and copy assing constructors instead.
-    // The main reason is that std::unique_ptr can only be moved since have deleted 
-    // copy assign constructors.
+    Tensor(const Tensor&) {
+        other.fromDevice();
+        shape_ = other.shape_;
+        host_data_ = other.host_data_;
+        data_is_on_host_ = true;
+        data_dirty_ = true;
+        //device_data_ is intentionally left uninitialized.
+    }
 
     Tensor &operator = (const Tensor& other) {
+        other.fromDevice();
         shape_ = other.shape_;
+        data_is_on_host_ = true;
+        data_dirty_ = true;
+        host_data_ = other.host_data_;
 
-        // deep copy of pointed data
-
-        host_data_ = make_unique<
-            std::vector<U, aligned_allocator<U, 64> > >(*other.host_data_);
-
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        device_data_ = make_unique<
-            std::unique_ptr<CLCudaAPI::Buffer<U> > >(*other.device_data_))
-#endif
-
+        //device_data_ is intentionally left as-is. It will be erased only if new tensor won't fit, and only when data gets moved to the GPU.
         return *this;
     }
 
 #ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
     Tensor(Tensor&& other) = default;        // move ctor
     Tensor &operator = (Tensor&&) = default; // move assign
+#else
+    Tensor(Tensor&& other) { // for VS2013 we need to manually implement these if we want to have move semantics
+        shape_ = std::move(other.shape_);
+        host_data_ = std::move(other.host_data_);
+        device_data_ = std::move(other.device_data_);
+        data_is_on_host_ = other.data_is_on_host_;
+        data_dirty_ = other.data_dirty_;
+        return *this;
+    }
+    Tensor &operator = (Tensor&& other) {
+        shape_ = std::move(other.shape_);
+        host_data_ = std::move(other.host_data_);
+        device_data_ = std::move(other.device_data_);
+        data_is_on_host_ = other.data_is_on_host_;
+        data_dirty_ = other.data_dirty_;
+    }
 #endif
 
     // Returns the tensor shape
-    const std::vector<cnn_size_t>& shape() const { return shape_; }
-    
+    const std::array<cnn_size_t, 4>& shape() const { return shape_; }
+
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
-    template<typename T>
-    T& at(const cnn_size_t d0,
-          const cnn_size_t d1,
-          const cnn_size_t d2,
-          const cnn_size_t d3) {
-        return *access_data<T>(d0, d1, d2, d3);
+    U& host_at(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) {
+        return *host_ptr(d0, d1, d2, d3);
     }
 
-    template<typename T>
-    const T& at(const cnn_size_t d0,
-                const cnn_size_t d1,
-                const cnn_size_t d2,
-                const cnn_size_t d3) const {
-        return *access_data<T>(d0, d1, d2, d3);
+    U host_at(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) const {
+        return *host_ptr(d0, d1, d2, d3);
     }
 
     // Returns the pointer to a specified index in the tensor
     // Checked version (throw exceptions for out-of-range error)
-    template<typename T>
-    T* ptr(const cnn_size_t d0,
-           const cnn_size_t d1,
-           const cnn_size_t d2,
-           const cnn_size_t d3) {
-        return access_data<T>(d0, d1, d2, d3);
-    }
-    
-    template<typename T>
-    const T* ptr(const cnn_size_t d0,
-                 const cnn_size_t d1,
-                 const cnn_size_t d2,
-                 const cnn_size_t d3) const {
-        return access_data<T>(d0, d1, d2, d3);
-    }
+    const U* host_ptr(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) const {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
 
-    // zero-overhead version (same performance to raw pointer access.
-    // have an assertion for out-of-range error)
-    U& operator[] (const size_t index) {
-        return *access_data<U>(index);
+        return host_data() + (
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+            );
     }
 
-    const U& operator[] (const size_t index) const {
-        return *access_data<U>(index);
+    U* host_ptr(const cnn_size_t d0,
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
+
+        return mutable_host_data() + (
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+            );
     }
 
-    // this is only a proof of concept to copy data
-    // from one device to another.
-    void toDevice(const Device& device) {
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        CLCudaAPI::Context ctx = device.context();
-        CLCudaAPI::Queue queue = device.queue();
-
-        device_data_ = make_unique<CLCudaAPI::Buffer<U> >(
-            ctx, queue, host_data_->begin(), host_data_->end());
-#endif
+    const U* host_data() const {
+        fromDevice();
+        return host_data_.data();
     }
 
-    // this is only a proof of concept to copy data
-    // from one device to another.
-    void fromDevice(const Device& device) {
-#if defined(USE_OPENCL) || defined(USE_CUDA)
-        CLCudaAPI::Queue queue = device.queue();
-
-        device_data_->Read(
-            queue, host_data_->size(), &host_data_->at(0));
-#endif
+    U* mutable_host_data() {
+        fromDevice();
+        data_dirty_ = true;
+        return host_data_.data();
     }
 
-    /*template<typename T, typename U = float_t>
-    T host_data() const {
-        return static_cast<T>(*access_data(0));
+    const void *device_data() const {
+        toDevice();
+        return (*device_data_)();
     }
 
-    template<typename T, typename U = float_t>
-    T mutable_host_data() {
-        return static_cast<T>(*access_data(0));
+    void *mutable_device_data() {
+        toDevice();
+        data_dirty_ = true;
+        return (*device_data_)();
     }
-
-    template<typename T, typename U = float_t>
-    T device_data() const {
-	fromDevice(device_);
-        return static_cast<T>(*access_data(0));
-    }
-
-    template<typename T, typename U = float_t>
-    T mutable_device_data() {
-	fromDevice(device_);
-        return static_cast<T>(*access_data(0));
-    }*/
 
     size_t size() const {
-        size_t new_size = 1;
-        for (auto d : shape_) { new_size *= d; }
-        return new_size;
+        return host_data_.size();
     }
 
-    /* @brief Fills all the tensor values with a given value
-     *
-     * @param value The value to fill the tensor
-     */
-    void fill(const U value) {
-        std::fill(host_data_->begin(), host_data_->end(), value);
+    void fill(U value) {
+        data_is_on_host_ = true;
+        data_dirty_ = true;
+        std::fill(std::begin(host_data_), std::end(host_data_), value);
     }
 
-    /* @brief Fills the tensor with evenly-spaced values in the interval
-     *
-     * @param from The lower bound of the interval
-     * @param to The upper bound of the interval
-     */
-    void linspace(const U from, const U to) {
-        U start = from,
-            step = (to - from) / (host_data_->end() - host_data_->begin() - 1);
-        std::generate(host_data_->begin(),
-                      host_data_->end(),
-                      [&start, &step]() {
-                        U tmp = start;
-                        start += step;
-                        return tmp;
-                      });
-    }
-
-    /* @brief Element-wise addition
-     */
-    Tensor add(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) + src[i];
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise addition
-     */
-    Tensor add(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) + scalar;
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise subtraction
-     */
-    Tensor sub(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) - src[i];
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise subtraction
-     */
-    Tensor sub(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) - scalar;
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise multiplication
-     */
-    Tensor mul(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) * src[i];
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise multiplication
-     */
-    Tensor mul(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = this->operator[](i) * scalar;
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise division
-     */
-    Tensor div(const Tensor& src) const {
-        if (this->shape() != src.shape()) {
-            throw nn_error("Tensor must have same shape");
-        }
-
-        Tensor<U> res(src.shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            const U tmp = src[i];
-            res[i] = tmp == U(0.0) ? std::numeric_limits<U>::quiet_NaN() :
-                this->operator[](i) / tmp;
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise division
-     */
-    Tensor div(const float_t scalar) const {
-        Tensor<U> res(this->shape());
-
-        if (scalar == float_t(0.0)) {
-            res.fill(std::numeric_limits<U>::quiet_NaN());
-        } else {
-            for_i(true, res.size(), [&](size_t i) {
-                res[i] = this->operator[](i) / scalar;
-            });
-        }
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise square root
-     */
-    Tensor sqrt() const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            const U tmp = this->operator[](i);
-            res[i] = tmp < U(0.0) ? std::numeric_limits<U>::quiet_NaN()
-                : std::sqrt(tmp);
-        });
-
-        return std::move(res);
-    }
-
-    /* @brief Element-wise exponential
-     */
-    Tensor exp() const {
-        Tensor<U> res(this->shape());
-
-        for_i(true, res.size(), [&](size_t i) {
-            res[i] = std::exp(this->operator[](i));
-        });
-
-        return std::move(res);
-    }
-
- private:
-    // Initializes the data buffer with the given value
-    void resize(const U value = 0) {
-        if (!host_data_) {
-            host_data_ = make_unique<
-                std::vector<U, aligned_allocator<U, 64> > >(size(), value);
-        } else {
-            host_data_->resize(size(), value);
-        }
-    }
-
-    // Initializes the shape vector
     void reshape(const cnn_size_t d0,
-                 const cnn_size_t d1,
-                 const cnn_size_t d2,
-                 const cnn_size_t d3) {
-	    shape_.resize(4);
-	    shape_[0] = d0;
-	    shape_[1] = d1;
-	    shape_[2] = d2;
-	    shape_[3] = d3;
+        const cnn_size_t d1,
+        const cnn_size_t d2,
+        const cnn_size_t d3) {
+        shape_[0] = d0;
+        shape_[1] = d1;
+        shape_[2] = d2;
+        shape_[3] = d3;
+        host_data_.resize(calcSize(), U(0));
     }
 
-    // Method to access to the tensor data.
-    // It checks if the requested position is feasible or not.
-    template<typename T>
-    T* access_data(const cnn_size_t d0,
-                   const cnn_size_t d1,
-                   const cnn_size_t d2,
-                   const cnn_size_t d3) {
-        if (d0 >= shape_[0] || d1 >= shape_[1] ||
-            d2 >= shape_[2] || d3 >= shape_[3]) {
-            throw nn_error("Access tensor out of range.");
-        }
-
-        U* value = &host_data_->operator[](
-            shape_[1] * shape_[2] * shape_[3] * d0 +
-            shape_[1] * shape_[2] * d3 +
-            shape_[1] * d2 +
-            d1
-        );
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
+    void reshape(const std::array<cnn_size_t, 4> &sz)
+    {
+        shape_ = sz;
+        host_data_.resize(calcSize(), U(0));
     }
 
-    // Method to access to the tensor data.
-    // It checks if the requested position is feasible or not.
-    template<typename T>
-    T* access_data(const cnn_size_t d0,
-                   const cnn_size_t d1,
-                   const cnn_size_t d2,
-                   const cnn_size_t d3) const {
-        if (d0 >= shape_[0] || d1 >= shape_[1] ||
-            d2 >= shape_[2] || d3 >= shape_[3]) {
-            throw nn_error("Access tensor out of range.");
-        }
-
-        U* value = &host_data_->operator[](
-            shape_[1] * shape_[2] * shape_[3] * d0 +
-            shape_[1] * shape_[2] * d3 +
-            shape_[1] * d2 +
-            d1
-        );
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
-        }
-        return value;
+private:
+    size_t calcSize() const {
+        return std::accumulate(std::begin(shape_), std::end(shape_), size_t(1), std::multiplies<size_t>());
     }
 
-    template<typename T>
-    T* access_data(const size_t index) {
-        assert(index < host_data_->size() && "Access tensor out of range.");
-
-        U* value = &host_data_->operator[](index);
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
+    void toDevice() const {
+        if (data_is_on_host_ && data_dirty_) {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+            CLCudaAPI::Queue queue = device->queue();
+            if (device_data_ && device_data_->GetSize() >= host_data_.size()) {
+                device_data_->Write(queue, host_data.size(), host_data_.data(), 0);
+            }
+            else {
+                CLCudaAPI::Context ctx = device->context();
+                device_data_ = make_unique<CLCudaAPI::Buffer<U> >(
+                    ctx, queue, host_data_.begin(), host_data_.end());
+            }
+#endif
+            data_is_on_host_ = false;
+            data_dirty_ = false;
         }
-        return value;
     }
 
-    template<typename T>
-    T* access_data(const size_t index) const {
-        assert(index < host_data_->size() && "Access tensor out of range.");
-
-        U* value = &host_data_->operator[](index);
-
-        // in case that requested type is not the same as
-        // the specified during the tensor initilization
-        // we cast the type.
-        if (!std::is_same<T,U>::value) {
-            return reinterpret_cast<T*>(value);
+    void fromDevice() const {
+        if (!data_is_on_host_ && data_dirty_) {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+            assert(device_);
+            assert(device_data_);
+            device_data_->Read(device_->queue(), host_data_.size(), const_cast<U*>(host_data_.data())); // using const_cast<> to avoid making host_data_ entirely mutable
+#endif
+            data_is_on_host_ = true;
+            data_dirty_ = false;
         }
-        return value;
     }
 
- private:
+private:
     /* Vector with the size of the tensor
-     * shape_[0]: batch
-     * shape_[1]: width
-     * shape_[2]: height
-     * shape_[3]: depth
-     */
-    std::vector<cnn_size_t> shape_;
+        * shape_[0]: batch
+        * shape_[1]: width
+        * shape_[2]: height
+        * shape_[3]: depth
+        */
+    std::array<cnn_size_t, 4> shape_;
 
     /* Pointer to the Tensor data in pure in the host device */
-    std::unique_ptr<std::vector<U, aligned_allocator<U, 64> > > host_data_;
+    std::vector<U, aligned_allocator<U, 64> > host_data_;
 
 #if defined(USE_OPENCL) || defined(USE_CUDA)
     /* Pointer to the Tensor data in the device */
     std::unique_ptr<CLCudaAPI::Buffer<U> > device_data_;
 #endif
+    mutable bool data_is_on_host_;      //< current data is on host if true, on device if false.
+    mutable bool data_dirty_;           //< set to true if current data might have been modified
 
     /* Pointer to the current device where the data resides */
     Device* device_;
 };
 
 // Overloaded method to print the Tensor class to the standard output
+template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
-                                 const Tensor<>& tensor) {
+    const Tensor<T>& tensor) {
     const std::vector<cnn_size_t>& shape = tensor.shape();
     for (cnn_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";
@@ -524,17 +313,157 @@ inline std::ostream& operator<< (std::ostream &os,
             os << "-- Data:\n";
             for (cnn_size_t k = 0; k < shape[1]; ++k) {
                 for (cnn_size_t l = 0; l < shape[2]; ++l) {
-                    os << "   " << tensor.at<float_t>(i,k,l,j) << " ";
+                    os << "   " << tensor.at(i, k, l, j) << " ";
                 }
                 os << ";\n";
             }
         }
     }
-    os << "----------------\n" 
-       << "--> Tensor size: [ " 
-       << shape[0] << " x " << shape[1] << " x "
-       << shape[2] << " x " << shape[3] << " ]\n";
+    os << "----------------\n"
+        << "--> Tensor size: [ "
+        << shape[0] << " x " << shape[1] << " x "
+        << shape[2] << " x " << shape[3] << " ]\n";
     return os;
+}
+
+// utilities for element-wise and tensor-scalar/scalar-tensor operations
+
+template<typename TD, typename TS1, typename TS2, typename F> void binary_tensor_tensor_elementwise_operation(Tensor<TD> &dst, const Tensor<TS1> &src1, const Tensor<TS2> &src2, F f) {
+    if (src1.shape() != src2.shape()) {
+        throw nn_error("Tensor must have same shape");
+    }
+
+    dst.reshape(src1.shape());
+
+    TD* pdst = dst.mutable_host_data();
+    const TS1* psrc1 = src1.host_data();
+    const TS2* psrc2 = src2.host_data();
+
+    for_i(true, dst.size(), [pdst, psrc1, psrc2, &f](size_t i) {
+        pdst[i] = f(psrc1[i], psrc2[i]);
+    });
+}
+
+template<typename TD, typename TS, typename F> void unary_tensor_elementwise_operation(Tensor<TD> &dst, const Tensor<TS> &src, F f) {
+    dst.reshape(src.shape());
+
+    TD* pdst = dst.mutable_host_data();
+    const TS* psrc = src.host_data();
+
+    for_i(true, dst.size(), [pdst, psrc, &f](size_t i) {
+        pdst[i] = f(psrc[i]);
+    });
+}
+
+template<typename TD, typename TS1, typename TS2, typename F> void binary_tensor_scalar_operation(Tensor<TD> &dst, const Tensor<TS1> &src1, TS2 src2, F f) {
+    dst.reshape(src1.shape());
+
+    TD* pdst = dst.mutable_host_data();
+    const TS1* psrc1 = src1.host_data();
+
+    for_i(true, dst.size(), [pdst, psrc1, src2, &f](size_t i) {
+        pdst[i] = f(psrc1[i], src2);
+    });
+}
+
+template<typename TD, typename TS1, typename TS2, typename F> void binary_scalar_tensor_operation(Tensor<TD> &dst, TS1 src1, const Tensor<TS2> &src2, F f) {
+    dst.reshape(src2.shape());
+
+    TD* pdst = dst.mutable_host_data();
+    const TS2* psrc2 = src2.host_data();
+
+    for_i(true, dst.size(), [pdst, src1, psrc2, &f](size_t i) {
+        pdst[i] = f(src1, psrc2[i]);
+    });
+}
+
+// implementation of 
+
+namespace details {
+    template<typename TS1, typename TS2> auto plus(TS1 s1, TS2 s2) -> decltype(s1 + s2) { return s1 + s2; }
+
+    template<typename TS1, typename TS2> auto minus(TS1 s1, TS2 s2) -> decltype(s1 - s2) { return s1 - s2; }
+
+    template<typename TS1, typename TS2> auto multiplies(TS1 s1, TS2 s2) -> decltype(s1 * s2) { return s1 * s2; }
+
+    template<typename TS1, typename TS2> auto divides_checked(TS1 s1, TS2 s2) -> decltype(s1 / s2) {
+        typedef decltype(s1 / s2) result_type;
+        return (s2 == result_type{}) ? std::numeric_limits<result_type>::quiet_NaN() : s1 / s2;
+    }
+
+    template<typename TS1, typename TS2> auto divides_unchecked(TS1 s1, TS2 s2) -> decltype(s1 / s2) {
+        return s1 / s2;
+    }
+
+    template<typename T> T sqrt_checked(T s1) {
+        return (s1 <= T{}) ? std::numeric_limits<T>::quiet_NaN() : sqrt(s1);
+    }
+
+    // do not inline - this function converts the std::exp overloadeds in a single templated function.
+    template<typename T> T exp(T s1) {
+        return std::exp(s1);
+    }
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_add(Tensor<TD> &dst, TS1 src1, const Tensor<TS2> &src2) {
+    binary_scalar_tensor_operation(dst, src1, src2, details::plus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_add(Tensor<TD> &dst, const Tensor<TS1> &src1, TS2 src2) {
+    binary_tensor_scalar_operation(dst, src1, src2, details::plus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_add(Tensor<TD> &dst, const Tensor<TS1> &src1, const Tensor<TS2> &src2) {
+    binary_tensor_tensor_elementwise_operation(dst, src1, src2, details::plus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_sub(Tensor<TD> &dst, TS1 src1, const Tensor<TS2> &src2) {
+    binary_scalar_tensor_operation(dst, src1, src2, details::minus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_sub(Tensor<TD> &dst, const Tensor<TS1> &src1, TS2 src2) {
+    binary_tensor_scalar_operation(dst, src1, src2, details::minus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_sub(Tensor<TD> &dst, const Tensor<TS1> &src1, const Tensor<TS2> &src2) {
+    binary_tensor_tensor_elementwise_operation(dst, src1, src2, details::minus<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_mul(Tensor<TD> &dst, TS1 src1, const Tensor<TS2> &src2) {
+    binary_scalar_tensor_operation(dst, src1, src2, details::multiplies<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_mul(Tensor<TD> &dst, const Tensor<TS1> &src1, TS2 src2) {
+    binary_tensor_scalar_operation(dst, src1, src2, details::multiplies<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_mul(Tensor<TD> &dst, const Tensor<TS1> &src1, const Tensor<TS2> &src2) {
+    binary_tensor_tensor_elementwise_operation(dst, src1, src2, details::multiplies<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_div(Tensor<TD> &dst, TS1 src1, const Tensor<TS2> &src2) {
+    binary_scalar_tensor_operation(dst, src1, src2, details::divides_checked<TS1, TS2>);
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_div(Tensor<TD> &dst, const Tensor<TS1> &src1, TS2 src2) {
+    if (src2 == TS2(0.0)) {
+        dst.reshape(src1.shape());
+        dst.fill(std::numeric_limits<TD>::quiet_NaN());
+    } else {
+        binary_tensor_scalar_operation(dst, src1, src2, details::divides_unchecked<TS1, TS2>);
+    }
+}
+
+template<typename TD, typename TS1, typename TS2> void layer_div(Tensor<TD> &dst, const Tensor<TS1> &src1, const Tensor<TS2> &src2) {
+    binary_tensor_tensor_elementwise_operation(dst, src1, src2, details::divides_checked<TS1, TS2>);
+}
+
+template<typename TD, typename TS> void layer_sqrt(Tensor<TD> &dst, const Tensor<TS> &src1) {
+    return unary_tensor_elementwise_operation(dst, src1, details::sqrt_checked<TS>);
+}
+
+template<typename TD, typename TS> void layer_exp(Tensor<TD> &dst, const Tensor<TS> &src1) {
+    return unary_tensor_elementwise_operation(dst, src1, details::exp<TS>);
 }
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -1,0 +1,464 @@
+/*
+    COPYRIGHT
+
+    All contributions by Taiga Nomi
+    Copyright (c) 2013, Taiga Nomi
+    All rights reserved.
+
+    All other contributions:
+    Copyright (c) 2013-2016, the respective contributors.
+    All rights reserved.
+
+    Each contributor holds copyright over their respective contributions.
+    The project versioning (Git) records all such contribution source information.
+
+    LICENSE
+
+    The BSD 3-Clause License
+
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+
+    * Redistributions of source code must retain the above copyright notice, this
+      list of conditions and the following disclaimer.
+
+    * Redistributions in binary form must reproduce the above copyright notice,
+      this list of conditions and the following disclaimer in the documentation
+      and/or other materials provided with the distribution.
+
+    * Neither the name of tiny-dnn nor the names of its
+      contributors may be used to endorse or promote products derived from
+      this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+    AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+    IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+    FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+    DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+    SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+    CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+    OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+    OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include <algorithm> // std::fill
+
+#include "tiny_dnn/core/framework/device.fwd.h"
+
+namespace tiny_dnn {
+
+template<typename U = float_t>
+class Tensor {
+ public:
+    /*
+     * Initializes an empty tensor.
+     */
+    Tensor() {}
+
+    /*
+     * Create a tensor of the given dimension.
+     * It is assumed that a tensor will hold data in NxWxHxD order,
+     * where:
+     *  N the batch axis
+     *  W the width axis
+     *  H the heigth axis
+     *  D the depth axis
+     *
+     *  Data will be hold by a std::vector with 64bytes alignment.
+     */
+    explicit Tensor(const cnn_size_t d0,
+                    const cnn_size_t d1,
+                    const cnn_size_t d2,
+                    const cnn_size_t d3) {
+        reshape(d0, d1, d2, d3);
+        resize();
+    }
+
+    explicit Tensor(const std::vector<cnn_size_t>& shape) {
+        reshape(shape[0], shape[1], shape[2], shape[3]);
+        resize();
+    }
+
+    // Move constructor
+    Tensor(Tensor<U>&& other) = default;
+
+    // Returns the tensor shape
+    const std::vector<cnn_size_t>& shape() const { return shape_; }
+    
+    // Returns the value of a specified index in the tensor.
+    // Checked version (throw exceptions for out-of-range error)
+    template<typename T>
+    T& at(const cnn_size_t d0,
+          const cnn_size_t d1,
+          const cnn_size_t d2,
+          const cnn_size_t d3) {
+        return *access_data<T>(d0, d1, d2, d3);
+    }
+
+    template<typename T>
+    const T& at(const cnn_size_t d0,
+                const cnn_size_t d1,
+                const cnn_size_t d2,
+                const cnn_size_t d3) const {
+        return *access_data<T>(d0, d1, d2, d3);
+    }
+
+    // Returns the pointer to a specified index in the tensor
+    // Checked version (throw exceptions for out-of-range error)
+    template<typename T>
+    T* ptr(const cnn_size_t d0,
+           const cnn_size_t d1,
+           const cnn_size_t d2,
+           const cnn_size_t d3) {
+        return access_data<T>(d0, d1, d2, d3);
+    }
+    
+    template<typename T>
+    const T* ptr(const cnn_size_t d0,
+                 const cnn_size_t d1,
+                 const cnn_size_t d2,
+                 const cnn_size_t d3) const {
+        return access_data<T>(d0, d1, d2, d3);
+    }
+
+    // zero-overhead version (same performance to raw pointer access.
+    // have an assertion for out-of-range error)
+    U& operator[] (const size_t index) {
+        return *access_data<U>(index);
+    }
+
+    const U& operator[] (const size_t index) const {
+        return *access_data<U>(index);
+    }
+
+    // this is only a proof of concept to copy data
+    // from one device to another.
+    void toDevice(const Device& device) {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+        CLCudaAPI::Context ctx = device.context();
+        CLCudaAPI::Queue queue = device.queue();
+
+        device_data_ = make_unique<CLCudaAPI::Buffer<U> >(
+            ctx, queue, host_data_->begin(), host_data_->end());
+#endif
+    }
+
+    // this is only a proof of concept to copy data
+    // from one device to another.
+    void fromDevice(const Device& device) {
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+        CLCudaAPI::Queue queue = device.queue();
+
+        device_data_->Read(
+            queue, host_data_->size(), &host_data_->at(0));
+#endif
+    }
+
+    /*template<typename T, typename U = float_t>
+    T host_data() const {
+        return static_cast<T>(*access_data(0));
+    }
+
+    template<typename T, typename U = float_t>
+    T mutable_host_data() {
+        return static_cast<T>(*access_data(0));
+    }
+
+    template<typename T, typename U = float_t>
+    T device_data() const {
+	fromDevice(device_);
+        return static_cast<T>(*access_data(0));
+    }
+
+    template<typename T, typename U = float_t>
+    T mutable_device_data() {
+	fromDevice(device_);
+        return static_cast<T>(*access_data(0));
+    }*/
+
+    size_t size() const {
+        size_t new_size = 1;
+        for (auto d : shape_) { new_size *= d; }
+        return new_size;
+    }
+
+    /* @brief Fills all the tensor values with a given value
+     *
+     * @param value The value to fill the tensor
+     */
+    void fill(const U value) {
+        std::fill(host_data_->begin(), host_data_->end(), value);
+    }
+
+    /* @brief Element-wise addition
+     */
+    Tensor<U> add(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) + src[i];
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise addition
+     */
+    Tensor<U> add(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) + scalar;
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise subtraction
+     */
+    Tensor<U> sub(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) - src[i];
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise subtraction
+     */
+    Tensor<U> sub(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) - scalar;
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise multiplication
+     */
+    Tensor<U> mul(const Tensor<U>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) * src[i];
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise multiplication
+     */
+    Tensor<U> mul(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) * scalar;
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise division
+     */
+    Tensor<U> div(const Tensor<>& src) const {
+        if (this->shape() != src.shape()) {
+            throw nn_error("Tensor must have same shape");
+        }
+
+        Tensor<U> res(src.shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) / (src[i] +
+                std::numeric_limits<U>::min());
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise division
+     */
+    Tensor<U> div(const float_t scalar) const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = this->operator[](i) / (scalar +
+                std::numeric_limits<U>::min());
+        });
+
+        return std::move(res);
+    }
+
+ private:
+    // Initializes the data buffer with the given value
+    void resize(const U value = 0) {
+        if (!host_data_) {
+            host_data_ = make_unique<
+                std::vector<U, aligned_allocator<U, 64> > >(size(), value);
+        } else {
+            host_data_->resize(size(), value);
+        }
+    }
+
+    // Initializes the shape vector
+    void reshape(const cnn_size_t d0,
+                 const cnn_size_t d1,
+                 const cnn_size_t d2,
+                 const cnn_size_t d3) {
+	    shape_.resize(4);
+	    shape_[0] = d0;
+	    shape_[1] = d1;
+	    shape_[2] = d2;
+	    shape_[3] = d3;
+    }
+
+    // Method to access to the tensor data.
+    // It checks if the requested position is feasible or not.
+    template<typename T>
+    T* access_data(const cnn_size_t d0,
+                   const cnn_size_t d1,
+                   const cnn_size_t d2,
+                   const cnn_size_t d3) {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
+
+        U* value = &host_data_->operator[](
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+        );
+
+        // in case that requested type is not the same as
+        // the specified during the tensor initilization
+        // we cast the type.
+        if (!std::is_same<T,U>::value) {
+            return reinterpret_cast<T*>(value);
+        }
+        return value;
+    }
+
+    // Method to access to the tensor data.
+    // It checks if the requested position is feasible or not.
+    template<typename T>
+    T* access_data(const cnn_size_t d0,
+                   const cnn_size_t d1,
+                   const cnn_size_t d2,
+                   const cnn_size_t d3) const {
+        if (d0 >= shape_[0] || d1 >= shape_[1] ||
+            d2 >= shape_[2] || d3 >= shape_[3]) {
+            throw nn_error("Access tensor out of range.");
+        }
+
+        U* value = &host_data_->operator[](
+            shape_[1] * shape_[2] * shape_[3] * d0 +
+            shape_[1] * shape_[2] * d3 +
+            shape_[1] * d2 +
+            d1
+        );
+
+        // in case that requested type is not the same as
+        // the specified during the tensor initilization
+        // we cast the type.
+        if (!std::is_same<T,U>::value) {
+            return reinterpret_cast<T*>(value);
+        }
+        return value;
+    }
+
+    template<typename T>
+    T* access_data(const size_t index) {
+        assert(index < host_data_->size() && "Access tensor out of range.");
+
+        U* value = &host_data_->operator[](index);
+
+        // in case that requested type is not the same as
+        // the specified during the tensor initilization
+        // we cast the type.
+        if (!std::is_same<T,U>::value) {
+            return reinterpret_cast<T*>(value);
+        }
+        return value;
+    }
+
+    template<typename T>
+    T* access_data(const size_t index) const {
+        assert(index < host_data_->size() && "Access tensor out of range.");
+
+        U* value = &host_data_->operator[](index);
+
+        // in case that requested type is not the same as
+        // the specified during the tensor initilization
+        // we cast the type.
+        if (!std::is_same<T,U>::value) {
+            return reinterpret_cast<T*>(value);
+        }
+        return value;
+    }
+
+ private:
+    /* Vector with the size of the tensor
+     * shape_[0]: batch
+     * shape_[1]: width
+     * shape_[2]: height
+     * shape_[3]: depth
+     */
+    std::vector<cnn_size_t> shape_;
+
+    /* Pointer to the Tensor data in pure CPU mode */
+    std::unique_ptr<std::vector<U, aligned_allocator<U, 64> > > host_data_;
+
+#if defined(USE_OPENCL) || defined(USE_CUDA)
+    /* Pointer to the Tensor data in OpenCL mode */
+    std::unique_ptr<CLCudaAPI::Buffer<U> > device_data_;
+#endif
+
+    /* Pointer to the current device where the data resides */
+    Device* device_;
+};
+
+// Overloaded method to print the Tensor class to the standard output
+inline std::ostream& operator<< (std::ostream &os,
+		                 const Tensor<>& tensor) {
+    const std::vector<cnn_size_t>& shape = tensor.shape();
+    for (cnn_size_t i = 0; i < shape[0]; ++i) {
+        os << "-- Batch: " << i << "\n";
+        for (cnn_size_t j = 0; j < shape[3]; ++j) {
+            os << "-- Channel: " << j << "\n";
+            os << "-- Data:\n";
+            for (cnn_size_t k = 0; k < shape[1]; ++k) {
+                for (cnn_size_t l = 0; l < shape[2]; ++l) {
+                    os << "   " << tensor.at<float_t>(i,k,l,j) << " ";
+                }
+                os << ";\n";
+            }
+        }
+    }
+    os << "----------------\n" 
+       << "--> Tensor size: [ " 
+       << shape[0] << " x " << shape[1] << " x "
+       << shape[2] << " x " << shape[3] << " ]\n";
+    return os;
+}
+
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -70,28 +70,28 @@ public:
     Tensor() : shape_{ 0,0,0,0 } {}
 
     /*
-        * Create a tensor of the given dimension.
-        * It is assumed that a tensor will hold data in NxWxHxD order,
-        * where:
-        *  N the batch axis
-        *  W the width axis
-        *  H the heigth axis
-        *  D the depth axis
-        *
-        *  Data will be hold by a std::vector with 64bytes alignment.
-        */
-    explicit Tensor(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+     * Create a tensor of the given dimension.
+     * It is assumed that a tensor will hold data in NxWxHxD order,
+     * where:
+     *  N the batch axis
+     *  W the width axis
+     *  H the heigth axis
+     *  D the depth axis
+     *
+     *  Data will be hold by a std::vector with 64bytes alignment.
+     */
+    explicit Tensor(const serial_size_t d0,
+                    const serial_size_t d1,
+                    const serial_size_t d2,
+                    const serial_size_t d3) {
         reshape(d0, d1, d2, d3);
     }
 
-    explicit Tensor(const std::array<cnn_size_t, 4>& shape) {
+    explicit Tensor(const std::array<serial_size_t, 4>& shape) {
         reshape(shape[0], shape[1], shape[2], shape[3]);
     }
 
-    explicit Tensor(const std::vector<cnn_size_t>& shape) {
+    explicit Tensor(const std::vector<serial_size_t>& shape) {
         assert(shape.size() == 4);
         reshape(shape[0], shape[1], shape[2], shape[3]);
     }
@@ -140,30 +140,30 @@ public:
 #endif
 
     // Returns the tensor shape
-    const std::array<cnn_size_t, 4>& shape() const { return shape_; }
+    const std::array<serial_size_t, 4>& shape() const { return shape_; }
 
     // Returns the value of a specified index in the tensor.
     // Checked version (throw exceptions for out-of-range error)
-    U& host_at(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    U& host_at(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         return *host_ptr(d0, d1, d2, d3);
     }
 
-    U host_at(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) const {
+    U host_at(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) const {
         return *host_ptr(d0, d1, d2, d3);
     }
 
     // Returns the pointer to a specified index in the tensor
     // Checked version (throw exceptions for out-of-range error)
-    const U* host_ptr(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) const {
+    const U* host_ptr(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) const {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -177,10 +177,10 @@ public:
             );
     }
 
-    U* host_ptr(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    U* host_ptr(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         if (d0 >= shape_[0] || d1 >= shape_[1] ||
             d2 >= shape_[2] || d3 >= shape_[3]) {
             throw nn_error("Access tensor out of range.");
@@ -226,10 +226,10 @@ public:
         std::fill(std::begin(host_data_), std::end(host_data_), value);
     }
 
-    void reshape(const cnn_size_t d0,
-        const cnn_size_t d1,
-        const cnn_size_t d2,
-        const cnn_size_t d3) {
+    void reshape(const serial_size_t d0,
+        const serial_size_t d1,
+        const serial_size_t d2,
+        const serial_size_t d3) {
         shape_[0] = d0;
         shape_[1] = d1;
         shape_[2] = d2;
@@ -237,7 +237,7 @@ public:
         host_data_.resize(calcSize(), U(0));
     }
 
-    void reshape(const std::array<cnn_size_t, 4> &sz)
+    void reshape(const std::array<serial_size_t, 4> &sz)
     {
         shape_ = sz;
         host_data_.resize(calcSize(), U(0));
@@ -285,7 +285,7 @@ private:
         * shape_[2]: height
         * shape_[3]: depth
         */
-    std::array<cnn_size_t, 4> shape_;
+    std::array<serial_size_t, 4> shape_;
 
     /* Pointer to the Tensor data in pure in the host device */
     std::vector<U, aligned_allocator<U, 64> > host_data_;
@@ -304,15 +304,15 @@ private:
 // Overloaded method to print the Tensor class to the standard output
 template<typename T>
 inline std::ostream& operator<< (std::ostream &os,
-    const Tensor<T>& tensor) {
-    const std::vector<cnn_size_t>& shape = tensor.shape();
-    for (cnn_size_t i = 0; i < shape[0]; ++i) {
+                         const Tensor<T>& tensor) {
+    const std::vector<serial_size_t>& shape = tensor.shape();
+    for (serial_size_t i = 0; i < shape[0]; ++i) {
         os << "-- Batch: " << i << "\n";
-        for (cnn_size_t j = 0; j < shape[3]; ++j) {
+        for (serial_size_t j = 0; j < shape[3]; ++j) {
             os << "-- Channel: " << j << "\n";
             os << "-- Data:\n";
-            for (cnn_size_t k = 0; k < shape[1]; ++k) {
-                for (cnn_size_t l = 0; l < shape[2]; ++l) {
+            for (serial_size_t k = 0; k < shape[1]; ++k) {
+                for (serial_size_t l = 0; l < shape[2]; ++l) {
                     os << "   " << tensor.at(i, k, l, j) << " ";
                 }
                 os << ";\n";

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -44,7 +44,8 @@
 */
 #pragma once
 
-#include <algorithm> // std::fill
+#include <cmath> // sqrt
+#include <algorithm> // std::fill, std::generate
 
 #include "tiny_dnn/core/framework/device.fwd.h"
 
@@ -193,6 +194,23 @@ class Tensor {
         std::fill(host_data_->begin(), host_data_->end(), value);
     }
 
+    /* @brief Fills the tensor with evenly-spaced values in the interval
+     *
+     * @param from The lower bound of the interval
+     * @param to The upper bound of the interval
+     */
+    void linspace(const U from, const U to) {
+        U start = from,
+            step = (to - from) / (host_data_->end() - host_data_->begin() - 1);
+        std::generate(host_data_->begin(),
+                      host_data_->end(),
+                      [&start, &step]() {
+                        U tmp = start;
+                        start += step;
+                        return tmp;
+                      });
+    }
+
     /* @brief Element-wise addition
      */
     Tensor<U> add(const Tensor<U>& src) const {
@@ -302,6 +320,30 @@ class Tensor {
         for_i(true, res.size(), [&](size_t i) {
             res[i] = this->operator[](i) / (scalar +
                 std::numeric_limits<U>::min());
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise square root
+     */
+    Tensor<U> sqrt() const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = std::sqrt(this->operator[](i));
+        });
+
+        return std::move(res);
+    }
+
+    /* @brief Element-wise exponential
+     */
+    Tensor<U> exp() const {
+        Tensor<U> res(this->shape());
+
+        for_i(true, res.size(), [&](size_t i) {
+            res[i] = std::exp(this->operator[](i));
         });
 
         return std::move(res);

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -30,6 +30,8 @@
 #include "tiny_dnn/network.h"
 #include "tiny_dnn/nodes.h"
 
+#include "tiny_dnn/core/framework/tensor.h"
+
 #include "tiny_dnn/core/framework/device.h"
 #include "tiny_dnn/core/framework/program_manager.h"
 

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -416,4 +416,10 @@ inline void printAvailableDevice(const serial_size_t platform_id,
 #endif
 }
 
+template<typename T, typename... Args>
+std::unique_ptr<T> make_unique(Args&&... args)
+{
+    return std::unique_ptr<T>(new T(std::forward<Args>(args)...));
+}
+
 } // namespace tiny_dnn


### PR DESCRIPTION
This pull requests pretends to substitute the current [`tensor_t`](https://github.com/tiny-dnn/tiny-dnn/blob/master/tiny_dnn/util/util.h#L71) by a full OOP Tensor class.

This is subsequent work from https://github.com/tiny-dnn/tiny-dnn/pull/319 and https://github.com/tiny-dnn/tiny-dnn/pull/411.