### PR TITLE
Subtle speed optimization

### DIFF
--- a/test/test_core.h
+++ b/test/test_core.h
@@ -69,11 +69,11 @@ device_t device_type(size_t *platform, size_t *device) {
 }
 
 #define TINY_DNN_GET_DEVICE_AND_PLATFORM       \
-    int cl_platform = 0, cl_device = 0; \
+    size_t cl_platform = 0, cl_device = 0; \
     device_t device = device_type(&cl_platform, &cl_device);
 #else
 #define TINY_DNN_GET_DEVICE_AND_PLATFORM       \
-    int cl_platform = 0, cl_device = 0; \
+    size_t cl_platform = 0, cl_device = 0; \
     device_t device = device_t::NONE;
 #endif  // defined(USE_OPENCL) || defined(USE_CUDA)
 

--- a/test/test_core.h
+++ b/test/test_core.h
@@ -69,11 +69,11 @@ device_t device_type(size_t *platform, size_t *device) {
 }
 
 #define TINY_DNN_GET_DEVICE_AND_PLATFORM       \
-    size_t cl_platform = 0, cl_device = 0; \
+    int cl_platform = 0, cl_device = 0; \
     device_t device = device_type(&cl_platform, &cl_device);
 #else
 #define TINY_DNN_GET_DEVICE_AND_PLATFORM       \
-    size_t cl_platform = 0, cl_device = 0; \
+    int cl_platform = 0, cl_device = 0; \
     device_t device = device_t::NONE;
 #endif  // defined(USE_OPENCL) || defined(USE_CUDA)
 

--- a/tiny_dnn/activations/activation_function.h
+++ b/tiny_dnn/activations/activation_function.h
@@ -44,13 +44,18 @@ public:
 #endif
     virtual ~function() = default;
 
-    virtual float_t f(const vec_t& v, serial_size_t index) const = 0;
+    virtual float_t f(const vec_t& v, size_t index) const = 0;
+    void itef(vec_t& out, const vec_t& in, size_t cnt) const {
+        for (size_t i = 0; i < cnt; i++) {
+            out[i] = f(in, i);
+        }
+    }
 
     // dfi/dyi
     virtual float_t df(float_t y) const = 0;
 
     // dfi/dyk (k=0,1,..n)
-    virtual vec_t df(const vec_t& y, serial_size_t i) const { vec_t v(y.size(), 0); v[i] = df(y[i]); return v; }
+    virtual vec_t df(const vec_t& y, size_t i) const { vec_t v(y.size(), 0); v[i] = df(y[i]); return v; }
 
     // return if dfi/dyk is one-hot vector
     virtual bool one_hot() const { return true; }
@@ -62,7 +67,7 @@ public:
 class identity : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override { return v[i]; }
+    float_t f(const vec_t& v, size_t i) const override { return v[i]; }
     float_t df(float_t /*y*/) const override { return float_t(1); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
@@ -70,7 +75,7 @@ public:
 class sigmoid : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override { return float_t(1) / (float_t(1) + std::exp(-v[i])); }
+    float_t f(const vec_t& v, size_t i) const override { return float_t(1) / (float_t(1) + std::exp(-v[i])); }
     float_t df(float_t y) const override { return y * (float_t(1) - y); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
@@ -78,7 +83,7 @@ public:
 class relu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override { return std::max(float_t(0), v[i]); }
+    float_t f(const vec_t& v, size_t i) const override { return std::max(float_t(0), v[i]); }
     float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
@@ -88,7 +93,7 @@ typedef relu rectified_linear; // for compatibility
 class leaky_relu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override { return (v[i] > float_t(0)) ? v[i] : float_t(0.01) * v[i]; }
+    float_t f(const vec_t& v, size_t i) const override { return (v[i] > float_t(0)) ? v[i] : float_t(0.01) * v[i]; }
     float_t df(float_t y) const override { return y > float_t(0) ? float_t(1) : float_t(0.01); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
@@ -96,14 +101,14 @@ public:
 class elu : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override { return (v[i]<float_t(0) ? (exp(v[i])- float_t(1)) : v[i]); }
+    float_t f(const vec_t& v, size_t i) const override { return (v[i]<float_t(0) ? (exp(v[i])- float_t(1)) : v[i]); }
     float_t df(float_t y) const override { return (y > float_t(0) ? float_t(1) : (float_t(1)+y)); }
     std::pair<float_t, float_t> scale() const override { return std::make_pair(float_t(0.1), float_t(0.9)); }
 };
 
 class softmax : public function {
 public:
-    float_t f(const vec_t& v, serial_size_t i) const override {
+    float_t f(const vec_t& v, size_t i) const override {
         float_t alpha = *std::max_element(v.begin(), v.end());
         float_t numer = std::exp(v[i] - alpha);
         float_t denom = float_t(0);
@@ -116,9 +121,9 @@ public:
         return y * (float_t(1) - y);
     }
 
-    virtual vec_t df(const vec_t& y, serial_size_t index) const override {
+    virtual vec_t df(const vec_t& y, size_t index) const override {
         vec_t v(y.size(), 0);
-        for (serial_size_t i = 0; i < y.size(); i++)
+        for (size_t i = 0; i < y.size(); i++)
             v[i] = (i == index) ? df(y[index]) : -y[i] * y[index];
 
         return v;
@@ -132,8 +137,15 @@ public:
 class tan_h : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override {
+
+    float_t f(const vec_t& v, size_t i) const override {
         return std::tanh(v[i]);
+    }
+
+    void itef(vec_t& out, const vec_t& in, size_t cnt) const {
+        for (size_t i = 0; i < cnt; i++) {
+            out[i] = std::tanh(in[i]);
+        }
     }
 
     // fast approximation of tanh (improve 2-3% speed in LeNet-5)
@@ -162,7 +174,7 @@ private:
 class tan_hp1m2 : public function {
 public:
     using function::df;
-    float_t f(const vec_t& v, serial_size_t i) const override {
+    float_t f(const vec_t& v, size_t i) const override {
         const float_t ep = std::exp(v[i]);
         return ep / (ep + std::exp(-v[i]));
     }

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -224,11 +224,11 @@ class convolutional_layer : public feedforward_layer<Activation> {
         // apply padding to the input tensor
         padding_op_.copy_and_pad_input(*in_data[0], cws_.prev_out_padded_);
 
-        std::vector<tensor_t*> in_data_;
-        in_data_.push_back(in_data_padded(in_data));
+        std::vector<tensor_t*> in_data_(in_data.size());
+        in_data_[0] = in_data_padded(in_data);
 
         for (serial_size_t i = 1; i < in_data.size(); ++i) {
-            in_data_.push_back(in_data[i]);
+            in_data_[i] = in_data[i];
         }
 
         // forward convolutional op context

--- a/tiny_dnn/layers/feedforward_layer.h
+++ b/tiny_dnn/layers/feedforward_layer.h
@@ -50,10 +50,7 @@ public:
             vec_t& a   = out_tensor[sample];
             out.resize(out_dim);
             a.resize(out_dim);
-
-            for (serial_size_t i = 0; i < out_dim; i++) {
-                out[i] = this->h_.f(a, i);
-            }
+            h_.itef(out, a, out_dim);
         });
     }
 

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -538,6 +538,7 @@ class layer : public node {
                 std::transform(diff.begin(), diff.end(),
                                diff.begin(), [&](float_t x) { // NOLINT
                                   return x * rcp_batch_size; });
+                // parallelize only when target size is big enough to mitigate thread spawning overhead
                 bool parallelize = (target.size() >= 512);
                 o->update(diff, target, parallelize);
             }

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -44,7 +44,7 @@ public:
     typedef layer Base;
 
     /**
-     * @param in_shape �@ [in] size (width * height * channels) of input data
+     * @param in_shape    [in] size (width * height * channels) of input data
      * @param slice_type  [in] target axis of slicing
      * @param num_outputs [in] number of output layers
      *

--- a/tiny_dnn/util/image.h
+++ b/tiny_dnn/util/image.h
@@ -283,7 +283,7 @@ private:
 template <typename T>
 image<float_t> mean_image(const image<T>& src)
 {
-    image<float_t> mean(shape3d(1, 1, src.depth()), src.type());
+    image<float_t> mean(shape3d(1, 1, (serial_size_t)src.depth()), src.type());
 
     for (size_t i = 0; i < src.depth(); i++) {
         float_t sum = 0.0f;


### PR DESCRIPTION
Achieved about 1% speed gain by adjusting 1st parameter (`bool parallelize`) of `for_i` function in `parallel_for.h` file. When the size of data to process is not big enough, suppress parallelization to reduce thread creation overhead.

The downsides of this change
- code gets difficult to read (can be difficult to debug too?)
- may not be a good idea when thread creation is very cheap (thread pooling.. Intel TBB not tested)
- execution flow is not consistent

Here's the outputs of example_mnist_train project release builds to compare the performance.
[before.txt](https://github.com/tiny-dnn/tiny-dnn/files/608955/before.txt)
[after.txt](https://github.com/tiny-dnn/tiny-dnn/files/608956/after.txt)
