### PR TITLE
Marks unused parameters with CNN_UNREFERENCED_PARAMETER macro.

### DIFF
--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -124,7 +124,9 @@ class backend {
  public:
     // context holds solution-dependent parameters
     // context should be able to hold any types of structures (like boost::any)
-    explicit backend(context* ctx_ = nullptr) {}
+    explicit backend(context* ctx_ = nullptr) {
+        CNN_UNREFERENCED_PARAMETER(ctx_);
+    }
 
     // core math functions
 

--- a/tiny_dnn/core/backend_dnn.h
+++ b/tiny_dnn/core/backend_dnn.h
@@ -41,16 +41,22 @@ class dnn_backend : public backend {
 
     void conv2d(const std::vector<tensor_t*>& in_data,
                 std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void conv2d_eq(const std::vector<tensor_t*>& in_data,
                    std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -58,6 +64,10 @@ class dnn_backend : public backend {
                 const std::vector<tensor_t*>& out_data,
                 std::vector<tensor_t*>&       out_grad,
                 std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
@@ -65,21 +75,31 @@ class dnn_backend : public backend {
                   const std::vector<tensor_t*>& out_data,
                   std::vector<tensor_t*>&       out_grad,
                   std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
     void deconv2d(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void deconv2d_q(const std::vector<tensor_t*>& in_data,
                     std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void deconv2d_eq(const std::vector<tensor_t*>& in_data,
                      std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -87,6 +107,10 @@ class dnn_backend : public backend {
                   const std::vector<tensor_t*>& out_data,
                   std::vector<tensor_t*>&       out_grad,
                   std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
@@ -94,11 +118,17 @@ class dnn_backend : public backend {
                     const std::vector<tensor_t*>& out_data,
                     std::vector<tensor_t*>&       out_grad,
                     std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
     void maxpool(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -106,21 +136,31 @@ class dnn_backend : public backend {
                  const std::vector<tensor_t*>& out_data,
                  std::vector<tensor_t*>&       out_grad,
                  std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
     void fully(const std::vector<tensor_t*>& in_data,
                std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void fully_eq(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -128,6 +168,10 @@ class dnn_backend : public backend {
                const std::vector<tensor_t*>& out_data,
                std::vector<tensor_t*>&       out_grad,
                std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
@@ -135,6 +179,10 @@ class dnn_backend : public backend {
                  const std::vector<tensor_t*>& out_data,
                  std::vector<tensor_t*>&       out_grad,
                  std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 

--- a/tiny_dnn/core/backend_nnp.h
+++ b/tiny_dnn/core/backend_nnp.h
@@ -63,8 +63,10 @@ class nnp_backend : public backend {
 
     void conv2d(const std::vector<tensor_t*>& in_data,
                 std::vector<tensor_t*>&       out_data) override {
-	if (params_c_) return;  // workaround to fix warnings
-	if (params_f_) return;  // workaround to fix warnings
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        if (params_c_) return;  // workaround to fix warnings
+        if (params_f_) return;  // workaround to fix warnings
 	if (params_d_) return;  // workaround to fix warnings
 	if (conv_layer_worker_storage_) return;    // workaround to fix warnings
 	if (deconv_layer_worker_storage_) return;  // workaround to fix warnings
@@ -93,11 +95,15 @@ class nnp_backend : public backend {
 
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void conv2d_eq(const std::vector<tensor_t*>& in_data,
                    std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -105,6 +111,10 @@ class nnp_backend : public backend {
                 const std::vector<tensor_t*>& out_data,
                 std::vector<tensor_t*>&       out_grad,
                 std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
@@ -112,20 +122,30 @@ class nnp_backend : public backend {
                   const std::vector<tensor_t*>& out_data,
                   std::vector<tensor_t*>&       out_grad,
                   std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
     void deconv2d(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
     }
 
     void deconv2d_q(const std::vector<tensor_t*>& in_data,
                     std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void deconv2d_eq(const std::vector<tensor_t*>& in_data,
                      std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -133,6 +153,10 @@ class nnp_backend : public backend {
                   const std::vector<tensor_t*>& out_data,
                   std::vector<tensor_t*>&       out_grad,
                   std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
@@ -140,11 +164,17 @@ class nnp_backend : public backend {
                     const std::vector<tensor_t*>& out_data,
                     std::vector<tensor_t*>&       out_grad,
                     std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
     void maxpool(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         // just to fix warning: remove in future
         if (params_m_) {}
 
@@ -166,11 +196,17 @@ class nnp_backend : public backend {
                  const std::vector<tensor_t*>& out_data,
                  std::vector<tensor_t*>&       out_grad,
                  std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
     void fully(const std::vector<tensor_t*>& in_data,
                std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         /*const tensor_t& in = *in_data[0];
         const vec_t&    W = (*in_data[1])[0];
         vec_t&          b = (*in_data[2])[0];
@@ -182,11 +218,15 @@ class nnp_backend : public backend {
 
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
     void fully_eq(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
     }
 
@@ -194,6 +234,10 @@ class nnp_backend : public backend {
                const std::vector<tensor_t*>& out_data,
                std::vector<tensor_t*>&       out_grad,
                std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 
@@ -201,6 +245,10 @@ class nnp_backend : public backend {
                  const std::vector<tensor_t*>& out_data,
                  std::vector<tensor_t*>&       out_grad,
                  std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("NNPACK does not support back propagation.");
     }
 

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -89,6 +89,8 @@ class tiny_backend : public backend {
 
     void conv2d(const std::vector<tensor_t*>& in_data,
                 std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         /*copy_and_pad_input(*in_data[0]);
         const vec_t& W     = (*in_data[1])[0];
         const vec_t& bias  = (*in_data[2])[0];
@@ -143,6 +145,10 @@ class tiny_backend : public backend {
                 const std::vector<tensor_t*>& out_data,
                 std::vector<tensor_t*>&       out_grad,
                 std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         /*conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
 
         std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
@@ -323,6 +329,8 @@ class tiny_backend : public backend {
     void maxpool(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
         // just to fix warning. Remove in a future
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         if (max_pooling_layer_worker_storage_) {}
         if (out2in_) {}
         if (in2out_) {}
@@ -340,6 +348,10 @@ class tiny_backend : public backend {
                  const std::vector<tensor_t*>& out_data,
                  std::vector<tensor_t*>&       out_grad,
                  std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         /*tensor_t&       prev_delta = *in_grad[0];
         tensor_t&       curr_delta = *out_grad[1];
         std::vector<std::vector<serial_size_t>>& max_idx =
@@ -353,6 +365,8 @@ class tiny_backend : public backend {
 
     void fully(const std::vector<tensor_t*>& in_data,
                std::vector<tensor_t*>&       out_data) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
         /*const tensor_t& in  = *in_data[0];
         const vec_t&    W   = (*in_data[1])[0];
         tensor_t&       a   = *out_data[1];
@@ -404,6 +418,10 @@ class tiny_backend : public backend {
                const std::vector<tensor_t*>& out_data,
                std::vector<tensor_t*>&       out_grad,
                std::vector<tensor_t*>&       in_grad) override {
+        CNN_UNREFERENCED_PARAMETER(in_data);
+        CNN_UNREFERENCED_PARAMETER(out_data);
+        CNN_UNREFERENCED_PARAMETER(out_grad);
+        CNN_UNREFERENCED_PARAMETER(in_grad);
         /*const tensor_t& prev_out   =  *in_data[0];
         const vec_t&    W          = (*in_data[1])[0];
         tensor_t&       dW         =  *in_grad[1];

--- a/tiny_dnn/core/framework/program_manager.h
+++ b/tiny_dnn/core/framework/program_manager.h
@@ -145,7 +145,10 @@ class ProgramManager {
         // Kernel compilation succeed: Register program.
         programs_.insert({ key_program, program });
 */
-#endif  // USE_OPENCL OR USE_CUDA
+#else  // USE_OPENCL OR USE_CUDA
+    CNN_UNREFERENCED_PARAMETER(device);
+    CNN_UNREFERENCED_PARAMETER(layer);
+#endif
     }
 
     // Returns the number of registered programs

--- a/tiny_dnn/core/kernels/conv2d_op_libdnn.h
+++ b/tiny_dnn/core/kernels/conv2d_op_libdnn.h
@@ -180,6 +180,7 @@ class Conv2dLibDNNForwardOp : public core::OpKernel {
         }
 
 #else
+        CNN_UNREFERENCED_PARAMETER(context);
         throw nn_error("TinyDNN was not compiled with LibDNN support.");
 #endif
     }
@@ -291,6 +292,9 @@ class Conv2dLibDNNForwardOp : public core::OpKernel {
 
         // generate sources and compile kernel
         kernel_.reset(new greentea::LibDNNConv<float_t>(config));
+#else
+    CNN_UNREFERENCED_PARAMETER(device);
+    CNN_UNREFERENCED_PARAMETER(params);
 #endif
     }
 
@@ -308,6 +312,7 @@ class Conv2dLibDNNBackwardOp : public core::OpKernel {
         : core::OpKernel(context) {}
 
     void compute(const core::OpKernelContext& context) override {
+        CNN_UNREFERENCED_PARAMETER(context);
         throw nn_error("Not implemented yet.");
     }
 };

--- a/tiny_dnn/core/kernels/conv2d_op_nnpack.h
+++ b/tiny_dnn/core/kernels/conv2d_op_nnpack.h
@@ -114,6 +114,11 @@ conv2d_op_nnpack(const tensor_t&         in_data,
     // TODO: embed it into a class
     pthreadpool_destroy(threadpool);
 #else
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(W);
+    CNN_UNREFERENCED_PARAMETER(bias);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(params);
     throw nn_error("TinyDNN has not been compiled with NNPACK support.");
 #endif
 }

--- a/tiny_dnn/core/kernels/conv2d_op_opencl.h
+++ b/tiny_dnn/core/kernels/conv2d_op_opencl.h
@@ -148,6 +148,7 @@ class Conv2dOpenCLForwardOp : public core::OpKernel {
             std::copy(std::begin(out), std::end(out), std::back_inserter(out_data[i]));
         }
 #else
+        CNN_UNREFERENCED_PARAMETER(context);
         throw nn_error("Not compiled with OpenCL");
 #endif
     }
@@ -159,6 +160,7 @@ class Conv2dOpenCLBackwardOp : public core::OpKernel {
         : core::OpKernel(context) {}
 
     void compute(const core::OpKernelContext& context) override {
+        CNN_UNREFERENCED_PARAMETER(context);
         nn_error("Not implemented yet.");
     }
 };

--- a/tiny_dnn/core/kernels/fully_connected_op_avx.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_avx.h
@@ -48,6 +48,12 @@ fully_connected_op_avx(const tensor_t& in_data,
         params,
         layer_parallelize);
 #else
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(W);
+    CNN_UNREFERENCED_PARAMETER(bias);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(params);
+    CNN_UNREFERENCED_PARAMETER(layer_parallelize);
     throw nn_error("TinyDNN has not been compiled with AVX support.");
 #endif
 }
@@ -73,6 +79,14 @@ fully_connected_op_avx(const tensor_t& prev_out,
         params,
         layer_parallelize);
 #else
+    CNN_UNREFERENCED_PARAMETER(prev_out);
+    CNN_UNREFERENCED_PARAMETER(W);
+    CNN_UNREFERENCED_PARAMETER(dW);
+    CNN_UNREFERENCED_PARAMETER(db);
+    CNN_UNREFERENCED_PARAMETER(curr_delta);
+    CNN_UNREFERENCED_PARAMETER(prev_delta);
+    CNN_UNREFERENCED_PARAMETER(params);
+    CNN_UNREFERENCED_PARAMETER(layer_parallelize);
     throw nn_error("TinyDNN has not been compiled with AVX support.");
 #endif
 

--- a/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_nnpack.h
@@ -73,6 +73,12 @@ fully_connected_op_nnpack(const tensor_t&     in_data,
         });
     }
 #else
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(W);
+    CNN_UNREFERENCED_PARAMETER(bias);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(params);
+    CNN_UNREFERENCED_PARAMETER(layer_parallelize);
     throw nn_error("TinyDNN has not been compiled with NNPACK support.");
 #endif
 }

--- a/tiny_dnn/core/kernels/maxpool_op_nnpack.h
+++ b/tiny_dnn/core/kernels/maxpool_op_nnpack.h
@@ -91,6 +91,9 @@ inline void maxpool_op_nnpack(const tensor_t&      in_data,
     // TODO: embed it into a class
     pthreadpool_destroy(threadpool);
 #else
+    CNN_UNREFERENCED_PARAMETER(in_data);
+    CNN_UNREFERENCED_PARAMETER(out_data);
+    CNN_UNREFERENCED_PARAMETER(params);
     throw nn_error("TinyDNN has not been compiled with NNPACK support.");
 #endif
 }

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -412,6 +412,8 @@ inline void printAvailableDevice(const serial_size_t platform_id,
     printf(" > Memory clock rate            %zu MHz\n", device.MemoryClock());
     printf(" > Memory bus width             %zu bits\n", device.MemoryBusWidth());
 #else
+    CNN_UNREFERENCED_PARAMETER(platform_id);
+    CNN_UNREFERENCED_PARAMETER(device_id);
     nn_warn("TinyDNN was not build with OpenCL or CUDA support.");
 #endif
 }


### PR DESCRIPTION
Using tiny-dnn with default settings results in a lot of compiler warnings about unused variables.
This PR fixes all instances of such warning in tiny_dnn (ignoring third_party/ for now).

Relevant issue: #440 
