### PR TITLE
tiny_dnn/util/math_functions.h: moments: Why 4th/5th argument is `vec_t *`?

### DIFF
--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -127,8 +127,8 @@ public:
             }
         }
  
-        moments(delta_dot_y, in_spatial_size_, in_channels_, mean_delta_dot_y, nullptr);
-        moments(curr_delta, in_spatial_size_, in_channels_, mean_delta, nullptr);
+        moments(delta_dot_y, in_spatial_size_, in_channels_, mean_delta_dot_y);
+        moments(curr_delta, in_spatial_size_, in_channels_, mean_delta);
         // if Y = (X-mean(X))/(sqrt(var(X)+eps)), then
         //
         // dE(Y)/dX =
@@ -159,7 +159,7 @@ public:
 
         if (phase_ == net_phase::train) {
             // calculate mean/variance from this batch in train phase
-            moments(*in_data[0], in_spatial_size_, in_channels_, mean, &variance);
+            moments(*in_data[0], in_spatial_size_, in_channels_, mean, variance);
         }
 
         // y = (x - mean) ./ sqrt(variance + eps)

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -126,9 +126,9 @@ public:
                 delta_dot_y[i][j] *= curr_delta[i][j];
             }
         }
-        moments(delta_dot_y, in_spatial_size_, in_channels_, &mean_delta_dot_y, nullptr);
-        moments(curr_delta, in_spatial_size_, in_channels_, &mean_delta, nullptr);
  
+        moments(delta_dot_y, in_spatial_size_, in_channels_, mean_delta_dot_y, nullptr);
+        moments(curr_delta, in_spatial_size_, in_channels_, mean_delta, nullptr);
         // if Y = (X-mean(X))/(sqrt(var(X)+eps)), then
         //
         // dE(Y)/dX =
@@ -152,32 +152,25 @@ public:
 
     void forward_propagation(const std::vector<tensor_t*>& in_data,
         std::vector<tensor_t*>& out_data) override {
-        vec_t* mean = nullptr;
-        vec_t* variance = nullptr;
+        vec_t& mean = (phase_ == net_phase::train) ? mean_current_: mean_;
+        vec_t& variance = (phase_ == net_phase::train) ? variance_current_ : variance_;
         tensor_t& in = *in_data[0];
         tensor_t& out = *out_data[0];
 
         if (phase_ == net_phase::train) {
             // calculate mean/variance from this batch in train phase
-            mean = &mean_current_;
-            variance = &variance_current_;
-            moments(*in_data[0], in_spatial_size_, in_channels_, mean, variance);
-        }
-        else {
-            // use stored mean/variance in test phase
-            mean = &mean_;
-            variance = &variance_;
+            moments(*in_data[0], in_spatial_size_, in_channels_, mean, &variance);
         }
 
         // y = (x - mean) ./ sqrt(variance + eps)
-        calc_stddev(*variance);
+        calc_stddev(variance);
 
         for_i(parallelize_, in_data[0]->size(), [&](int i) {
             const float_t* inptr  = &in[i][0];
             float_t*       outptr = &out[i][0];
 
             for (serial_size_t j = 0; j < in_channels_; j++) {
-                float_t m = (*mean)[j];
+                float_t m = mean[j];
 
                 for (serial_size_t k = 0; k < in_spatial_size_; k++) {
                     *outptr++ = (*inptr++ - m) / stddev_[j];

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -39,13 +39,13 @@ inline void vector_div(vec_t& x, float_t denom) {
 /** 
  * calculate mean/variance across channels
  */
-inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t *mean, vec_t *variance) {
+inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean, vec_t *variance) {
     serial_size_t num_examples = static_cast<serial_size_t>(in.size());
 
     assert(in[0].size() == spatial_dim * channels);
 
-    mean->resize(channels);
-    std::fill(mean->begin(), mean->end(), (float_t)0.0);
+    mean.resize(channels);
+    std::fill(mean.begin(), mean.end(), (float_t)0.0);
 
     if (variance != nullptr) {
         variance->resize(channels);
@@ -55,27 +55,27 @@ inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t
     // calculate mean
     for (serial_size_t i = 0; i < num_examples; i++) {
         for (serial_size_t j = 0; j < channels; j++) {
-            float_t*       pmean = &mean->at(j);
+            float_t&       rmean = mean.at(j);
             const float_t* X = &in[i][j*spatial_dim];
 
             for (serial_size_t k = 0; k < spatial_dim; k++) {
-                *pmean += *X++;
+                rmean += *X++;
             }
         }
     }
 
-    vector_div(*mean, (float_t)num_examples*spatial_dim);
+    vector_div(mean, (float_t)num_examples*spatial_dim);
 
     // calculate variance
     if (variance != nullptr) {
         for (serial_size_t i = 0; i < num_examples; i++) {
             for (serial_size_t j = 0; j < channels; j++) {
-                float_t* pvar = &variance->at(j);
+                float_t& rvar = variance->at(j);
                 const float_t* X = &in[i][j*spatial_dim];
-                float_t        EX = (*mean)[j];
+                float_t        EX = mean[j];
 
                 for (serial_size_t k = 0; k < spatial_dim; k++) {
-                    *pvar += pow(*X++ - EX, (float_t)2.0);
+                    rvar += pow(*X++ - EX, (float_t)2.0);
                 }
             }
         }

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -36,52 +36,60 @@ inline void vector_div(vec_t& x, float_t denom) {
     std::transform(x.begin(), x.end(), x.begin(), [=](float_t x) { return x / denom; });
 }
 
-/** 
+namespace detail {
+    inline void moments_impl_calc_mean(serial_size_t num_examples, serial_size_t channels,
+                                       serial_size_t spatial_dim, const tensor_t& in, vec_t& mean) {
+        for (serial_size_t i = 0; i < num_examples; i++) {
+            for (serial_size_t j = 0; j < channels; j++) {
+                float_t& rmean = mean.at(j);
+                const float_t* const X = &in[i][j*spatial_dim];
+
+                for (serial_size_t k = 0; k < spatial_dim; k++) {
+                    rmean += X[k];
+                }
+            }
+        }
+    }
+    inline void moments_impl_calc_variance(serial_size_t num_examples, serial_size_t channels,
+                                           serial_size_t spatial_dim,
+                                           const tensor_t& in, vec_t& mean, vec_t& variance) {
+        for (serial_size_t i = 0; i < num_examples; i++) {
+            for (serial_size_t j = 0; j < channels; j++) {
+                float_t& rvar = variance.at(j);
+                const float_t* const X = &in[i][j*spatial_dim];
+                const float_t       EX = mean[j];
+
+                for (serial_size_t k = 0; k < spatial_dim; k++) {
+                    rvar += pow(X[k] - EX, (float_t)2.0);
+                }
+            }
+        }
+        vector_div(variance, std::max(1.0f, num_examples*spatial_dim-1.0f));
+    }
+}
+/**
  * calculate mean/variance across channels
  */
-inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean, vec_t *variance) {
-    serial_size_t num_examples = static_cast<serial_size_t>(in.size());
-
+inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean) {
+    const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
     mean.resize(channels);
     std::fill(mean.begin(), mean.end(), (float_t)0.0);
-
-    if (variance != nullptr) {
-        variance->resize(channels);
-        std::fill(variance->begin(), variance->end(), (float_t)0.0);
-    }
-
-    // calculate mean
-    for (serial_size_t i = 0; i < num_examples; i++) {
-        for (serial_size_t j = 0; j < channels; j++) {
-            float_t&       rmean = mean.at(j);
-            const float_t* X = &in[i][j*spatial_dim];
-
-            for (serial_size_t k = 0; k < spatial_dim; k++) {
-                rmean += *X++;
-            }
-        }
-    }
-
+    detail::moments_impl_calc_mean(num_examples, channels, spatial_dim, in, mean);
     vector_div(mean, (float_t)num_examples*spatial_dim);
+}
+inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean, vec_t& variance) {
+    const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
+    assert(in[0].size() == spatial_dim * channels);
 
-    // calculate variance
-    if (variance != nullptr) {
-        for (serial_size_t i = 0; i < num_examples; i++) {
-            for (serial_size_t j = 0; j < channels; j++) {
-                float_t& rvar = variance->at(j);
-                const float_t* X = &in[i][j*spatial_dim];
-                float_t        EX = mean[j];
-
-                for (serial_size_t k = 0; k < spatial_dim; k++) {
-                    rvar += pow(*X++ - EX, (float_t)2.0);
-                }
-            }
-        }
-
-        vector_div(*variance, std::max(1.0f, num_examples*spatial_dim-1.0f));
-    }
+    mean.resize(channels);
+    std::fill(mean.begin(), mean.end(), (float_t)0.0);
+    variance.resize(channels);
+    std::fill(variance.begin(), variance.end(), (float_t)0.0);
+    detail::moments_impl_calc_mean(num_examples, channels, spatial_dim, in, mean);
+    vector_div(mean, (float_t)num_examples*spatial_dim);
+    detail::moments_impl_calc_variance(num_examples, channels, spatial_dim, in, mean, variance);
 }
 
 }


### PR DESCRIPTION
To avoid Null-Pointer-Dereference, It's recommended to use lvalue-reference instead.