### PR TITLE
Fix/#444

### DIFF
--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -169,10 +169,10 @@ public:
             const float_t* inptr  = &in[i][0];
             float_t*       outptr = &out[i][0];
 
-            for (serial_size_t j = 0; j < in_channels_; j++) {
+            for (size_t j = 0; j < in_channels_; j++) {
                 float_t m = mean[j];
 
-                for (serial_size_t k = 0; k < in_spatial_size_; k++) {
+                for (size_t k = 0; k < in_spatial_size_; k++) {
                     *outptr++ = (*inptr++ - m) / stddev_[j];
                 }
             }

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -34,58 +34,67 @@ namespace tiny_dnn {
 
 // x = x / denom
 inline void vector_div(vec_t& x, float_t denom) {
-    std::transform(x.begin(), x.end(), x.begin(), [=](float_t x) { return x / denom; });
+    std::transform(x.begin(), x.end(), x.begin(),
+                   [=](float_t x) { return x / denom; });
 }
 
 namespace detail {
-    inline void moments_impl_calc_mean(serial_size_t num_examples, serial_size_t channels,
-                                       serial_size_t spatial_dim, const tensor_t& in, vec_t& mean) {
-        for (serial_size_t i = 0; i < num_examples; i++) {
-            for (serial_size_t j = 0; j < channels; j++) {
-                float_t& rmean = mean.at(j);
-                const auto it = in[i].begin() + (j * spatial_dim);
-                rmean = std::accumulate(it, it + spatial_dim, rmean);
-            }
+inline void moments_impl_calc_mean(serial_size_t num_examples,
+                                   serial_size_t channels,
+                                   serial_size_t spatial_dim,
+                                   const tensor_t& in, vec_t& mean) {
+    for (serial_size_t i = 0; i < num_examples; i++) {
+        for (serial_size_t j = 0; j < channels; j++) {
+            float_t& rmean = mean.at(j);
+            const auto it = in[i].begin() + (j * spatial_dim);
+            rmean = std::accumulate(it, it + spatial_dim, rmean);
         }
     }
-    inline void moments_impl_calc_variance(serial_size_t num_examples, serial_size_t channels,
-                                           serial_size_t spatial_dim,
-                                           const tensor_t& in, const vec_t& mean, vec_t& variance) {
-        for (serial_size_t i = 0; i < num_examples; i++) {
-            for (serial_size_t j = 0; j < channels; j++) {
-                float_t& rvar = variance.at(j);
-                const auto it = in[i].begin() + (j * spatial_dim);
-                const float_t ex = mean[j];
-                rvar = std::accumulate(it, it + spatial_dim, rvar, [ex](float_t current, float_t x) {
+}
+inline void moments_impl_calc_variance(serial_size_t num_examples,
+                                       serial_size_t channels,
+                                       serial_size_t spatial_dim,
+                                       const tensor_t& in, const vec_t& mean,
+                                       vec_t& variance) {
+    for (serial_size_t i = 0; i < num_examples; i++) {
+        for (serial_size_t j = 0; j < channels; j++) {
+            float_t& rvar = variance.at(j);
+            const auto it = in[i].begin() + (j * spatial_dim);
+            const float_t ex = mean[j];
+            rvar = std::accumulate(
+                it, it + spatial_dim, rvar, [ex](float_t current, float_t x) {
                     return current + pow(x - ex, (float_t)2.0);
                 });
-            }
         }
-        vector_div(variance, std::max(1.0f, num_examples*spatial_dim-1.0f));
     }
+    vector_div(variance, std::max(1.0f, num_examples * spatial_dim - 1.0f));
+}
 }
 /**
  * calculate mean/variance across channels
  */
-inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean) {
+inline void moments(const tensor_t& in, serial_size_t spatial_dim,
+                    serial_size_t channels, vec_t& mean) {
     const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
     mean.resize(channels);
     std::fill(mean.begin(), mean.end(), (float_t)0.0);
-    detail::moments_impl_calc_mean(num_examples, channels, spatial_dim, in, mean);
-    vector_div(mean, (float_t)num_examples*spatial_dim);
+    detail::moments_impl_calc_mean(num_examples, channels, spatial_dim, in,
+                                   mean);
+    vector_div(mean, (float_t)num_examples * spatial_dim);
 }
-inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t channels, vec_t& mean, vec_t& variance) {
+inline void moments(const tensor_t& in, serial_size_t spatial_dim,
+                    serial_size_t channels, vec_t& mean, vec_t& variance) {
     const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
-    //calc mean
+    // calc mean
     moments(in, spatial_dim, channels, mean);
 
     variance.resize(channels);
     std::fill(variance.begin(), variance.end(), (float_t)0.0);
-    detail::moments_impl_calc_variance(num_examples, channels, spatial_dim, in, mean, variance);
+    detail::moments_impl_calc_variance(num_examples, channels, spatial_dim, in,
+                                       mean, variance);
 }
-
 }

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -50,7 +50,7 @@ namespace detail {
     }
     inline void moments_impl_calc_variance(serial_size_t num_examples, serial_size_t channels,
                                            serial_size_t spatial_dim,
-                                           const tensor_t& in, vec_t& mean, vec_t& variance) {
+                                           const tensor_t& in, const vec_t& mean, vec_t& variance) {
         for (serial_size_t i = 0; i < num_examples; i++) {
             for (serial_size_t j = 0; j < channels; j++) {
                 float_t& rvar = variance.at(j);
@@ -80,12 +80,11 @@ inline void moments(const tensor_t& in, serial_size_t spatial_dim, serial_size_t
     const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
-    mean.resize(channels);
-    std::fill(mean.begin(), mean.end(), (float_t)0.0);
+    //calc mean
+    moments(in, spatial_dim, channels, mean);
+
     variance.resize(channels);
     std::fill(variance.begin(), variance.end(), (float_t)0.0);
-    detail::moments_impl_calc_mean(num_examples, channels, spatial_dim, in, mean);
-    vector_div(mean, (float_t)num_examples*spatial_dim);
     detail::moments_impl_calc_variance(num_examples, channels, spatial_dim, in, mean, variance);
 }
 

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -56,9 +56,10 @@ inline void moments_impl_calc_variance(size_t num_examples,
                                        size_t spatial_dim,
                                        const tensor_t& in, const vec_t& mean,
                                        vec_t& variance) {
+    assert(mean.size() >= channels);
     for (size_t i = 0; i < num_examples; i++) {
         for (size_t j = 0; j < channels; j++) {
-            float_t& rvar = variance.at(j);
+            float_t& rvar = variance[j];
             const auto it = in[i].begin() + (j * spatial_dim);
             const float_t ex = mean[j];
             rvar = std::accumulate(

--- a/tiny_dnn/util/math_functions.h
+++ b/tiny_dnn/util/math_functions.h
@@ -39,25 +39,25 @@ inline void vector_div(vec_t& x, float_t denom) {
 }
 
 namespace detail {
-inline void moments_impl_calc_mean(serial_size_t num_examples,
-                                   serial_size_t channels,
-                                   serial_size_t spatial_dim,
+inline void moments_impl_calc_mean(size_t num_examples,
+                                   size_t channels,
+                                   size_t spatial_dim,
                                    const tensor_t& in, vec_t& mean) {
-    for (serial_size_t i = 0; i < num_examples; i++) {
-        for (serial_size_t j = 0; j < channels; j++) {
+    for (size_t i = 0; i < num_examples; i++) {
+        for (size_t j = 0; j < channels; j++) {
             float_t& rmean = mean.at(j);
             const auto it = in[i].begin() + (j * spatial_dim);
             rmean = std::accumulate(it, it + spatial_dim, rmean);
         }
     }
 }
-inline void moments_impl_calc_variance(serial_size_t num_examples,
-                                       serial_size_t channels,
-                                       serial_size_t spatial_dim,
+inline void moments_impl_calc_variance(size_t num_examples,
+                                       size_t channels,
+                                       size_t spatial_dim,
                                        const tensor_t& in, const vec_t& mean,
                                        vec_t& variance) {
-    for (serial_size_t i = 0; i < num_examples; i++) {
-        for (serial_size_t j = 0; j < channels; j++) {
+    for (size_t i = 0; i < num_examples; i++) {
+        for (size_t j = 0; j < channels; j++) {
             float_t& rvar = variance.at(j);
             const auto it = in[i].begin() + (j * spatial_dim);
             const float_t ex = mean[j];
@@ -73,9 +73,9 @@ inline void moments_impl_calc_variance(serial_size_t num_examples,
 /**
  * calculate mean/variance across channels
  */
-inline void moments(const tensor_t& in, serial_size_t spatial_dim,
-                    serial_size_t channels, vec_t& mean) {
-    const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
+inline void moments(const tensor_t& in, size_t spatial_dim,
+                    size_t channels, vec_t& mean) {
+    const size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
     mean.resize(channels);
@@ -84,9 +84,9 @@ inline void moments(const tensor_t& in, serial_size_t spatial_dim,
                                    mean);
     vector_div(mean, (float_t)num_examples * spatial_dim);
 }
-inline void moments(const tensor_t& in, serial_size_t spatial_dim,
-                    serial_size_t channels, vec_t& mean, vec_t& variance) {
-    const serial_size_t num_examples = static_cast<serial_size_t>(in.size());
+inline void moments(const tensor_t& in, size_t spatial_dim,
+                    size_t channels, vec_t& mean, vec_t& variance) {
+    const size_t num_examples = static_cast<serial_size_t>(in.size());
     assert(in[0].size() == spatial_dim * channels);
 
     // calc mean


### PR DESCRIPTION
fix #144 based on @edgarriba 's review.

To apply <80 rule, I use clang-format.

```yaml
---
BasedOnStyle: 'Google'
ColumnLimit: 80
IndentWidth: 4
```

Put this file to root directory, and 

```sh
$ clang-format -i ./tiny_dnn/util/math_functions.h
```

note: LICENSE comment doesn't satisfy <80 rule, so I revert the change clang-format done at that part.