### PR TITLE
Fix predict_max_value

### DIFF
--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -727,8 +727,8 @@ class network {
     }
 
  protected:
-    float_t fprop_max(const vec_t& in, int idx = 0) {
-        const vec_t& prediction = fprop(in, idx);
+    float_t fprop_max(const vec_t& in) {
+        const vec_t& prediction = fprop(in);
         return *std::max_element(std::begin(prediction), std::end(prediction));
     }
 


### PR DESCRIPTION
Had to change `fprop_max` to make `max predict_max_value` work, since `fprop` does not accept two parameters (any more?).