### PR TITLE
stop using lambda with std::transform in layer::update_weight

### DIFF
--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -627,9 +627,9 @@ class layer : public node {
             if (trainable() && is_trainable_weight(in_type_[i])) {
                 vec_t& target = *get_weight_data(i);
                 ith_in_node(i)->merge_grads(&diff);
-                std::transform(diff.begin(), diff.end(),
-                               diff.begin(), [&](float_t x) { // NOLINT
-                                  return x * rcp_batch_size; });
+                for (size_t j=0; j<diff.size(); ++j) {
+                    diff[j] *= rcp_batch_size;
+                }
                 // parallelize only when target size is big enough to mitigate
                 // thread spawning overhead.
                 bool parallelize = (target.size() >= 512);


### PR DESCRIPTION
Hi, this PR improves execution speed on Linux.

I tested with example_mnist_train program on Ubuntu 16.04.1 LTS amd64.

Before
```
0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
48.1733s elapsed.
9637/10000

0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
48.4931s elapsed.
9739/10000
```

After
```
0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
16.2473s elapsed.
9637/10000

0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
16.208s elapsed.
9739/10000
```

Used compiler
```
$ /usr/bin/c++ --version
c++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609
Copyright (C) 2015 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

And this is what I get with Windows 10 Visual Studio 2015 Release x64 build.
```
0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
9.84289s elapsed.
9630/10000

0%   10   20   30   40   50   60   70   80   90   100%
|----|----|----|----|----|----|----|----|----|----|
***************************************************
9.72563s elapsed.
9736/10000
```

So I'll continue to investigate this matter.