### PR TITLE
Remove deprecated backend methods and reduce warnings

### DIFF
--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -133,19 +133,11 @@ class backend {
 
     // core math functions
 
-    virtual void conv2d(const std::vector<tensor_t*>& in_data,
-                        std::vector<tensor_t*>&       out_data) = 0;
-
     virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
                           std::vector<tensor_t*>&       out_data) = 0;
 
     virtual void conv2d_eq(const std::vector<tensor_t*>& in_data,
                            std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void conv2d(const std::vector<tensor_t*>& in_data,
-                        const std::vector<tensor_t*>& out_data,
-                        std::vector<tensor_t*>&       out_grad,
-                        std::vector<tensor_t*>&       in_grad) = 0;
 
     virtual void conv2d_q(const std::vector<tensor_t*>& in_data,
                           const std::vector<tensor_t*>& out_data,
@@ -171,27 +163,11 @@ class backend {
                             std::vector<tensor_t*>&       out_grad,
                             std::vector<tensor_t*>&       in_grad) = 0;
 
-    virtual void maxpool(const std::vector<tensor_t*>& in_data,
-                         std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void maxpool(const std::vector<tensor_t*>& in_data,
-                         const std::vector<tensor_t*>& out_data,
-                         std::vector<tensor_t*>&       out_grad,
-                         std::vector<tensor_t*>&       in_grad) = 0;
-
-    virtual void fully(const std::vector<tensor_t*>& in_data,
-                       std::vector<tensor_t*>&       out_data) = 0;
-
     virtual void fully_q(const std::vector<tensor_t*>& in_data,
                          std::vector<tensor_t*>&       out_data) = 0;
 
     virtual void fully_eq(const std::vector<tensor_t*>& in_data,
                           std::vector<tensor_t*>&       out_data) = 0;
-
-    virtual void fully(const std::vector<tensor_t*>& in_data,
-                       const std::vector<tensor_t*>& out_data,
-                       std::vector<tensor_t*>&       out_grad,
-                       std::vector<tensor_t*>&       in_grad) = 0;
 
     virtual void fully_q(const std::vector<tensor_t*>& in_data,
                          const std::vector<tensor_t*>& out_data,

--- a/tiny_dnn/core/backend_avx.h
+++ b/tiny_dnn/core/backend_avx.h
@@ -81,22 +81,6 @@ class avx_backend : public backend {
 
     // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*copy_and_pad_input(*in_data[0]);
-        const vec_t& W    = (*in_data[1])[0];
-        const vec_t& bias = (*in_data[2])[0];
-        tensor_t&    a    = *out_data[1];
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
-
-        fill_tensor(a, float_t(0));
-
-        kernels::avx_conv2d_kernel(*params_c_,
-            in, W, bias, a, layer_->parallelize());*/
-    }
-
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -109,40 +93,6 @@ class avx_backend : public backend {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
-    }
-
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
-
-        //std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
-        const vec_t& W  = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = *out_grad[1];
-        tensor_t*    prev_delta = (params_c_->pad_type == padding::same) ?
-                                   &cws.prev_delta_padded_ : in_grad[0];
-
-        assert(W.size() == params_c_->weight.size());
-        assert(dW[0].size() == params_c_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        fill_tensor(*prev_delta, float_t(0));
-
-        kernels::avx_conv2d_back_kernel(*params_c_,
-            prev_out, W, dW, db, curr_delta, prev_delta);
-
-        if (params_c_->pad_type == padding::same) {
-            copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
-        }*/
     }
 
     void conv2d_q(const std::vector<tensor_t*>& in_data,
@@ -226,53 +176,6 @@ class avx_backend : public backend {
         throw nn_error("not implemented yet.");
     }
 
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*const tensor_t& in  = *in_data[0];
-        tensor_t&       a   = *out_data[1];
-        std::vector<std::vector<serial_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        kernels::avx_maxpool_kernel(in, a,
-            max_idx, *out2in_, layer_->parallelize());*/
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
-        std::vector<std::vector<serial_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        CNN_UNREFERENCED_PARAMETER(in_data);
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::avx_maxpool_back_kernel(prev_delta, curr_delta,
-            max_idx, *in2out_,  layer_->parallelize());*/
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*const tensor_t& in = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::avx_fully_connected_kernel(*params_f_,
-            in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(),
-            a, layer_->parallelize());*/
-    }
-
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -285,27 +188,6 @@ class avx_backend : public backend {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*const tensor_t& prev_out = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        tensor_t&       dW = *in_grad[1];
-        tensor_t&       db = *in_grad[2];
-        tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::avx_fully_connected_back_kernel(*params_f_, prev_out,
-            W, dW, prev_delta, curr_delta, db, layer_->parallelize());*/
     }
 
     void fully_q(const std::vector<tensor_t*>& in_data,

--- a/tiny_dnn/core/backend_dnn.h
+++ b/tiny_dnn/core/backend_dnn.h
@@ -39,13 +39,6 @@ class dnn_backend : public backend {
 
     // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        throw nn_error("not implemented yet.");
-    }
-
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -57,17 +50,6 @@ class dnn_backend : public backend {
                    std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
-        throw nn_error("not implemented yet.");
-    }
-
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 
@@ -125,31 +107,6 @@ class dnn_backend : public backend {
         throw nn_error("not implemented yet.");
     }
 
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        throw nn_error("not implemented yet.");
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        throw nn_error("not implemented yet.");
-    }
-
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -161,17 +118,6 @@ class dnn_backend : public backend {
                   std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
-        throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
         throw nn_error("not implemented yet.");
     }
 

--- a/tiny_dnn/core/backend_nnp.h
+++ b/tiny_dnn/core/backend_nnp.h
@@ -61,38 +61,6 @@ class nnp_backend : public backend {
 
     // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        if (params_c_) return;  // workaround to fix warnings
-        if (params_f_) return;  // workaround to fix warnings
-	if (params_d_) return;  // workaround to fix warnings
-	if (conv_layer_worker_storage_) return;    // workaround to fix warnings
-	if (deconv_layer_worker_storage_) return;  // workaround to fix warnings
-
-        /*if (!params_c_->has_bias) {
-            throw nn_error("NNPACK Convolution requires a bias term.");
-        }
-
-        if (params_c_->w_stride != 1 || params_c_->h_stride != 1) {
-            throw nn_error("NNPACK Convolution requires stride 1.");
-        }
-
-        copy_and_pad_input(*in_data[0]);
-        const vec_t& W = (*in_data[1])[0];
-        const vec_t& bias = (*in_data[2])[0];
-        tensor_t&    a = *out_data[1];
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
-
-        fill_tensor(a, float_t(0));
-
-        // TODO
-        throw nn_not_implemented_error();
-
-        kernels::nnp_conv2d_kernel(*params_c_, in, W, bias, a);*/
-    }
-
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -105,17 +73,6 @@ class nnp_backend : public backend {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
-    }
-
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        throw nn_error("NNPACK does not support back propagation.");
     }
 
     void conv2d_q(const std::vector<tensor_t*>& in_data,
@@ -171,51 +128,6 @@ class nnp_backend : public backend {
         throw nn_error("NNPACK does not support back propagation.");
     }
 
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        // just to fix warning: remove in future
-        if (params_m_) {}
-
-        /**if (params_m_->stride_x != 2 || params_m_->stride_y != 2) {
-            throw nn_error("NNPACK Max-Pool requires a stride == 2.");
-        }
-
-        if (params_m_->pool_size_x != 2 || params_m_->pool_size_y != 2) {
-            throw nn_error("NNPACK Max-Pool requires a pool size == 2.");
-        }
-
-        const tensor_t& in = *in_data[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::nnp_maxpool_kernel(*params_m_, in, a);*/
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        throw nn_error("NNPACK does not support back propagation.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*const tensor_t& in = *in_data[0];
-        const vec_t&    W = (*in_data[1])[0];
-        vec_t&          b = (*in_data[2])[0];
-        tensor_t&       a = *out_data[1];
-
-        kernels::nnp_fully_connected_kernel(*params_f_,
-            in, W, b, a, layer_->parallelize());*/
-    }
-
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
         CNN_UNREFERENCED_PARAMETER(in_data);
@@ -228,17 +140,6 @@ class nnp_backend : public backend {
         CNN_UNREFERENCED_PARAMETER(in_data);
         CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_error("not implemented yet.");
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        throw nn_error("NNPACK does not support back propagation.");
     }
 
     void fully_q(const std::vector<tensor_t*>& in_data,

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -87,22 +87,6 @@ class tiny_backend : public backend {
 
     // core math functions
 
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*copy_and_pad_input(*in_data[0]);
-        const vec_t& W     = (*in_data[1])[0];
-        const vec_t& bias  = (*in_data[2])[0];
-        tensor_t&    a     = *out_data[1];
-        const std::vector<const vec_t*> &in = (*conv_layer_worker_storage_).prev_out_padded_; // input // NOLINT
-
-        fill_tensor(a, float_t(0));
-
-        kernels::tiny_conv2d_kernel(*params_c_,
-            in, W, bias, a, layer_->parallelize());*/
-    }
-
     // quantized convolution
     void conv2d_q(const std::vector<tensor_t*>& in_data,
                   std::vector<tensor_t*>&       out_data) override {
@@ -139,40 +123,6 @@ class tiny_backend : public backend {
             kernels::tiny_quantized_conv2d_kernel(*params_c_,
                 *in[i], W, bias, in_r[i], W_r, b_r, a[i], a_r[i], layer_->parallelize());
         }
-    }
-
-    void conv2d(const std::vector<tensor_t*>& in_data,
-                const std::vector<tensor_t*>& out_data,
-                std::vector<tensor_t*>&       out_grad,
-                std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*conv_layer_worker_specific_storage& cws = (*conv_layer_worker_storage_);
-
-        std::vector<const vec_t*>& prev_out = cws.prev_out_padded_;
-        const vec_t& W  = (*in_data[1])[0];
-        tensor_t&    dW = *in_grad[1];
-        tensor_t&    db = *in_grad[2];
-        tensor_t&    curr_delta = *out_grad[1];
-        tensor_t*    prev_delta = (params_c_->pad_type == padding::same) ?
-                                   &cws.prev_delta_padded_ : in_grad[0];
-
-        assert(W.size() == params_c_->weight.size());
-        assert(dW[0].size() == params_c_->weight.size());
-        assert(curr_delta[0].size() ==  layer_->out_shape()[0].size());
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        fill_tensor(*prev_delta, float_t(0));
-
-        kernels::tiny_conv2d_back_kernel(*params_c_,
-            prev_out, W, dW, db, curr_delta, prev_delta);
-
-        if (params_c_->pad_type == padding::same) {
-            copy_and_unpad_delta(cws.prev_delta_padded_, *in_grad[0]);
-        }*/
     }
 
     void conv2d_q(const std::vector<tensor_t*>& in_data,
@@ -326,56 +276,6 @@ class tiny_backend : public backend {
         }
     }
 
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 std::vector<tensor_t*>&       out_data) override {
-        // just to fix warning. Remove in a future
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        if (max_pooling_layer_worker_storage_) {}
-        if (out2in_) {}
-        if (in2out_) {}
-
-        /*const tensor_t& in  = *in_data[0];
-        tensor_t&       a   = *out_data[1];
-        std::vector<std::vector<serial_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        kernels::tiny_maxpool_kernel(in, a,
-            max_idx, *out2in_, layer_->parallelize());*/
-    }
-
-    void maxpool(const std::vector<tensor_t*>& in_data,
-                 const std::vector<tensor_t*>& out_data,
-                 std::vector<tensor_t*>&       out_grad,
-                 std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*tensor_t&       prev_delta = *in_grad[0];
-        tensor_t&       curr_delta = *out_grad[1];
-        std::vector<std::vector<serial_size_t>>& max_idx =
-            (*max_pooling_layer_worker_storage_).out2inmax_;
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::tiny_maxpool_back_kernel(prev_delta, curr_delta,
-            max_idx, *in2out_,  layer_->parallelize());*/
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               std::vector<tensor_t*>&       out_data) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        /*const tensor_t& in  = *in_data[0];
-        const vec_t&    W   = (*in_data[1])[0];
-        tensor_t&       a   = *out_data[1];
-
-        kernels::tiny_fully_connected_kernel(*params_f_,
-            in, W, params_f_->has_bias_ ? (*in_data[2])[0] : vec_t(),
-            a, layer_->parallelize());*/
-    }
-
     void fully_q(const std::vector<tensor_t*>& in_data,
                  std::vector<tensor_t*>&       out_data) override {
 #ifdef CNN_USE_GEMMLOWP
@@ -416,27 +316,6 @@ class tiny_backend : public backend {
         CNN_UNREFERENCED_PARAMETER(out_data);
         throw nn_not_implemented_error("quantized fully op requires gemmlowp library. please define CNN_USE_GEMMLOWP");
 #endif
-    }
-
-    void fully(const std::vector<tensor_t*>& in_data,
-               const std::vector<tensor_t*>& out_data,
-               std::vector<tensor_t*>&       out_grad,
-               std::vector<tensor_t*>&       in_grad) override {
-        CNN_UNREFERENCED_PARAMETER(in_data);
-        CNN_UNREFERENCED_PARAMETER(out_data);
-        CNN_UNREFERENCED_PARAMETER(out_grad);
-        CNN_UNREFERENCED_PARAMETER(in_grad);
-        /*const tensor_t& prev_out   =  *in_data[0];
-        const vec_t&    W          = (*in_data[1])[0];
-        tensor_t&       dW         =  *in_grad[1];
-        tensor_t&       db         =  *in_grad[2];
-        tensor_t&       prev_delta =  *in_grad[0];
-        tensor_t&       curr_delta =  *out_grad[1];
-
-        backward_activation(*out_grad[0], *out_data[0], curr_delta);
-
-        kernels::tiny_fully_connected_back_kernel(*params_f_, prev_out,
-            W, dW, prev_delta, curr_delta, db, layer_->parallelize());*/
     }
 
     void fully_q(const std::vector<tensor_t*>& in_data,

--- a/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
@@ -26,7 +26,6 @@ inline void accumulate_db(
 ) {
     if (out.width_ == 1 && out.height_ == 1) {
         size_t nblocks = out.depth_ / 8;
-        size_t remainder = out.depth_ & 7;
         for (size_t i = 0; i < nblocks; ++i) {
             _mm256_storeu_ps(
                 &db[i*8],
@@ -99,6 +98,7 @@ inline void accumulate_dw(
     std::vector<float, Allocator>&       dW,
     std::vector<float, Allocator>&       db
 ) {
+    CNN_UNREFERENCED_PARAMETER(db);
     auto& in        = params.in;
     auto& out       = params.out;
     auto& in_padded = params.in_padded;
@@ -300,8 +300,8 @@ inline void accumulate_dw(
                                 __m256 b = _mm256_loadu_ps(pb);
                                 sum0 = madd256_ps(a, b, sum0);
                                 for (size_t i = 1; i < nblocks; ++i) {
-                                    __m256 a = _mm256_loadu_ps(pa + 8 * i);
-                                    __m256 b = _mm256_loadu_ps(pb + 8 * i);
+                                    a = _mm256_loadu_ps(pa + 8 * i);
+                                    b = _mm256_loadu_ps(pb + 8 * i);
                                     sum0 = madd256_ps(a, b, sum0);
                                 }
                                 a = _mm256_maskload_ps(
@@ -425,8 +425,8 @@ inline void accumulate_dw(
                                 __m256 b = _mm256_loadu_ps(pb);
                                 sum0 = madd256_ps(a, b, sum0);
                                 for (size_t i = 1; i < nblocks; ++i) {
-                                    __m256 a = _mm256_loadu_ps(pa + 8 * i);
-                                    __m256 b = _mm256_loadu_ps(pb + 8 * i);
+                                    a = _mm256_loadu_ps(pa + 8 * i);
+                                    b = _mm256_loadu_ps(pb + 8 * i);
                                     sum0 = madd256_ps(a, b, sum0);
                                 }
                             }


### PR DESCRIPTION
Hi, this PR removes deprecated backend methods (`conv2d`, `maxpool`, `fully`).
For now, I only removed a few methods since they are replaced and not referenced from anywhere.
I also reduced some warnings.

`OpKernel` pattern has appeared and it should eventually replace math functions in backend classes.
