### PR TITLE
Fix compilation errors without cereal

### DIFF
--- a/tiny_dnn/layers/arithmetic_layer.h
+++ b/tiny_dnn/layers/arithmetic_layer.h
@@ -83,6 +83,7 @@ public:
             *in_grad[i] = *out_grad[0];
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<elementwise_add_layer> & construct) {
         serial_size_t num_args, dim;
@@ -96,6 +97,8 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("num_args", num_args_), cereal::make_nvp("dim", dim_));
     }
+#endif
+
 private:
     serial_size_t num_args_;
     serial_size_t dim_;

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -253,6 +253,7 @@ class average_pooling_layer : public partial_connected_layer<Activation> {
             Base::bias2out_);
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<average_pooling_layer> & construct) {
         shape3d in;
@@ -280,6 +281,7 @@ class average_pooling_layer : public partial_connected_layer<Activation> {
            cereal::make_nvp("pad_type", pad_type_)
         );
     }
+#endif
 
     std::pair<serial_size_t, serial_size_t> pool_size() const { return std::make_pair(pool_size_x_, pool_size_y_); }
 

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -233,6 +233,7 @@ public:
         calc_stddev(variance);
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<batch_normalization_layer> & construct) {
         shape3d in;
@@ -264,6 +265,7 @@ public:
            cereal::make_nvp("mean", mean_),
            cereal::make_nvp("variance", variance_));
     }
+#endif
 
     float_t epsilon() const {
         return eps_;

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -119,6 +119,7 @@ public:
         }
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<concat_layer> & construct) {
         std::vector<shape3d> in_shapes;
@@ -132,6 +133,7 @@ public:
         layer::serialize_prolog(ar);
         ar(in_shapes_);
     }
+#endif
 
 private:
     std::vector<shape3d> in_shapes_;

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -372,7 +372,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
         return img;
     }
 
-
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(
         Archive & ar, cereal::construct<convolutional_layer> & construct) {
@@ -411,6 +411,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
             cereal::make_nvp("h_stride", params_.h_stride)
             );
     }
+#endif
 
 private:
     tensor_t* in_data_padded(const std::vector<tensor_t*>& in) {

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -164,6 +164,7 @@ public:
 		}
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<dropout_layer> & construct) {
         net_phase phase;
@@ -179,6 +180,7 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("in_size", in_size_), cereal::make_nvp("dropout_rate", dropout_rate_), cereal::make_nvp("phase", phase_));
     }
+#endif
 
 private:
     net_phase phase_;

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -124,6 +124,7 @@ public:
 
     std::string layer_type() const override { return "fully-connected"; }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<fully_connected_layer> & construct) {
         serial_size_t in_dim, out_dim;
@@ -142,6 +143,7 @@ public:
            cereal::make_nvp("out_size", params_.out_size_),
            cereal::make_nvp("has_bias", params_.has_bias_));
     }
+#endif
 
 protected:
 

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -96,6 +96,7 @@ public:
         }
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<linear_layer> & construct) {
         serial_size_t dim;
@@ -111,6 +112,7 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("in_size", dim_), cereal::make_nvp("scale", scale_), cereal::make_nvp("bias", bias_));
     }
+#endif
 
 protected:
     serial_size_t dim_;

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -141,6 +141,7 @@ public:
         throw nn_error("not implemented");
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<lrn_layer> & construct) {
         shape3d in_shape;
@@ -165,6 +166,7 @@ public:
            cereal::make_nvp("beta", beta_),
            cereal::make_nvp("region", region_));
     }
+#endif
 
 private:
     void forward_across(const vec_t& in, vec_t& out) {

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -187,6 +187,7 @@ class max_pooling_layer : public feedforward_layer<Activation> {
     }
 
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void
     load_and_construct(Archive & ar,
@@ -215,6 +216,7 @@ class max_pooling_layer : public feedforward_layer<Activation> {
             cereal::make_nvp("stride_y", params_.stride_y),
             cereal::make_nvp("pad_type", params_.pad_type));
     }
+#endif
 
 private:
     /* The Max Poling operation params */

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -141,6 +141,7 @@ public:
         }
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<max_unpooling_layer> & construct) {
         shape3d in;
@@ -155,6 +156,7 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("in_size", in_), cereal::make_nvp("unpool_size", unpool_size_), cereal::make_nvp("stride", stride_));
     }
+#endif
 
 private:
     serial_size_t unpool_size_;

--- a/tiny_dnn/layers/power_layer.h
+++ b/tiny_dnn/layers/power_layer.h
@@ -110,6 +110,7 @@ public:
         }
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<power_layer> & construct) {
         shape3d in_shape;
@@ -125,6 +126,7 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("in_size", in_shape_), cereal::make_nvp("factor", factor_), cereal::make_nvp("scale", scale_));
     }
+#endif
 
     float_t factor() const {
         return factor_;

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -123,6 +123,7 @@ public:
         }
     }
 
+#ifndef CNN_NO_SERIALIZATION
     template <class Archive>
     static void load_and_construct(Archive & ar, cereal::construct<slice_layer> & construct) {
         shape3d in_shape;
@@ -138,6 +139,8 @@ public:
         layer::serialize_prolog(ar);
         ar(cereal::make_nvp("in_size", in_shape_), cereal::make_nvp("slice_type", slice_type_), cereal::make_nvp("num_outputs", num_outputs_));
     }
+#endif
+
 private:
     void slice_data_forward(const tensor_t& in_data,
                             std::vector<tensor_t*>& out_data) {

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -29,8 +29,11 @@
 #include <vector>
 #include <tuple>
 #include <unordered_map>
+
+#ifndef CNN_NO_SERIALIZATION
 #include <cereal/types/utility.hpp>
 #include <cereal/types/tuple.hpp>
+#endif
 
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -70,8 +70,11 @@
 #include "tiny_dnn/io/cifar10_parser.h"
 #include "tiny_dnn/io/display.h"
 #include "tiny_dnn/io/layer_factory.h"
+
+#ifndef CNN_NO_SERIALIZATION
 #include "tiny_dnn/util/serialization_helper.h"
 #include "tiny_dnn/util/deserialization_helper.h"
+#endif
 
 #ifdef CNN_USE_CAFFE_CONVERTER
 // experimental / require google protobuf

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -36,12 +36,14 @@
 #include <string>
 #include <sstream>
 
+#ifndef CNN_NO_SERIALIZATION
 #include <cereal/cereal.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/archives/binary.hpp>
 #include <cereal/types/string.hpp>
 #include <cereal/types/vector.hpp>
 #include <cereal/types/deque.hpp>
+#endif
 
 #include "tiny_dnn/config.h"
 #include "tiny_dnn/util/macro.h"


### PR DESCRIPTION
Hi, this PR fixes compilation errors when `USE_SERIALIZER` is `OFF` in `CMakeLists.txt` and `cereal` folder is missing. #484 

I wish serialize codes were written in non-intrusive way...