### PR TITLE
Modified link to CONTRIBUTING.md in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ more sample, read examples/main.cpp or [MNIST example](https://github.com/tiny-d
 
 ## Contributing
 Since deep learning community is rapidly growing, we'd love to get contributions from you to accelerate tiny-dnn development!
-For a quick guide to contributing, take a look at the [Contribution Documents](docs/developer_guides/How-to-contribute.md).
+For a quick guide to contributing, take a look at the [Contribution Documents](CONTRIBUTING.md).
 
 ## References
 [1] Y. Bengio, [Practical Recommendations for Gradient-Based Training of Deep Architectures.](http://arxiv.org/pdf/1206.5533v2.pdf) 


### PR DESCRIPTION
Hi developers,

I am new to open source and was looking for the contribution guidelines for tiny-dnn when I found the link in README wasn't working. I have updated the README to reflect the changes made in #463

 

