### PR TITLE
Externalize some serialization functions

### DIFF
--- a/tiny_dnn/layers/arithmetic_layer.h
+++ b/tiny_dnn/layers/arithmetic_layer.h
@@ -87,22 +87,8 @@ class elementwise_add_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive & ar,
-        cereal::construct<elementwise_add_layer> & construct
-    ) {
-        serial_size_t num_args, dim;
+    friend void serialize(Archive& ar, elementwise_add_layer& layer);
 
-        ar(cereal::make_nvp("num_args", num_args),
-           cereal::make_nvp("dim", dim));
-        construct(num_args, dim);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("num_args", num_args_),
-           cereal::make_nvp("dim", dim_));
-    }
 #endif
 
  private:

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -264,35 +264,8 @@ class average_pooling_layer : public partial_connected_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive & ar,
-                                   cereal::construct<average_pooling_layer> & construct) {
-        shape3d in;
-        serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
-        padding pad_type;
-
-        ar(cereal::make_nvp("in_size", in),
-           cereal::make_nvp("pool_size_x", pool_size_x),
-           cereal::make_nvp("pool_size_y", pool_size_y),
-           cereal::make_nvp("stride_x", stride_x),
-           cereal::make_nvp("stride_y", stride_y),
-           cereal::make_nvp("pad_type", pad_type));
-
-        construct(in.width_, in.height_, in.depth_,
-                  pool_size_x, pool_size_y,
-                  stride_x, stride_y, pad_type);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_),
-           cereal::make_nvp("pool_size_x", pool_size_x_),
-           cereal::make_nvp("pool_size_y", pool_size_y_),
-           cereal::make_nvp("stride_x", stride_x_),
-           cereal::make_nvp("stride_y", stride_y_),
-           cereal::make_nvp("pad_type", pad_type_));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, average_pooling_layer<Activation>& layer);
 #endif
 
     std::pair<serial_size_t, serial_size_t> pool_size() const { return std::make_pair(pool_size_x_, pool_size_y_); }

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -264,8 +264,8 @@ class average_pooling_layer : public partial_connected_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, average_pooling_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, average_pooling_layer<Activation2>& layer);
 #endif
 
     std::pair<serial_size_t, serial_size_t> pool_size() const { return std::make_pair(pool_size_x_, pool_size_y_); }

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -233,37 +233,7 @@ class batch_normalization_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive & ar,
-                                   cereal::construct<batch_normalization_layer> & construct) {
-        shape3d in;
-        serial_size_t in_spatial_size, in_channels;
-        float_t eps, momentum;
-        net_phase phase;
-        vec_t mean, variance;
-
-        ar(cereal::make_nvp("in_spatial_size", in_spatial_size),
-           cereal::make_nvp("in_channels", in_channels),
-           cereal::make_nvp("epsilon", eps),
-           cereal::make_nvp("momentum", momentum),
-           cereal::make_nvp("phase", phase),
-           cereal::make_nvp("mean", mean),
-           cereal::make_nvp("variance", variance));
-        construct(in_spatial_size, in_channels, eps, momentum, phase);
-        construct->set_mean(mean);
-        construct->set_variance(variance);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_spatial_size", in_spatial_size_),
-           cereal::make_nvp("in_channels", in_channels_),
-           cereal::make_nvp("epsilon", eps_),
-           cereal::make_nvp("momentum", momentum_),
-           cereal::make_nvp("phase", phase_),
-           cereal::make_nvp("mean", mean_),
-           cereal::make_nvp("variance", variance_));
-    }
+    friend void serialize(Archive& ar, batch_normalization_layer& layer);
 #endif
 
     float_t epsilon() const {

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -121,18 +121,7 @@ class concat_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive & ar, cereal::construct<concat_layer> & construct) {
-        std::vector<shape3d> in_shapes;
-
-        ar(cereal::make_nvp("in_size", in_shapes));
-        construct(in_shapes);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(in_shapes_);
-    }
+    friend void serialize(Archive& ar, concat_layer& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -374,47 +374,9 @@ class convolutional_layer : public feedforward_layer<Activation> {
 #endif  // DNN_USE_IMAGE_API
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<convolutional_layer>& construct) {
-        serial_size_t w_width, w_height, out_ch, w_stride, h_stride;
-        bool has_bias;
-        shape3d in;
-        padding pad_type;
-        connection_table tbl;
-
-        ar(cereal::make_nvp("in_size", in),
-           cereal::make_nvp("window_width", w_width),
-           cereal::make_nvp("window_height", w_height),
-           cereal::make_nvp("out_channels", out_ch),
-           cereal::make_nvp("connection_table", tbl),
-           cereal::make_nvp("pad_type", pad_type),
-           cereal::make_nvp("has_bias", has_bias),
-           cereal::make_nvp("w_stride", w_stride),
-           cereal::make_nvp("h_stride", h_stride));
-
-        construct(in.width_, in.height_, w_width, w_height, in.depth_,
-                  out_ch, tbl, pad_type, has_bias, w_stride, h_stride);
-    }
-#endif  // CNN_NO_SERIALIZATION
-
-    template <class Archive>
-    void serialize(Archive& ar) {
-#ifndef CNN_NO_SERIALIZATION
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in),
-            cereal::make_nvp("window_width", params_.weight.width_),
-            cereal::make_nvp("window_height", params_.weight.height_),
-            cereal::make_nvp("out_channels", params_.out.depth_),
-            cereal::make_nvp("connection_table", params_.tbl),
-            cereal::make_nvp("pad_type", params_.pad_type),
-            cereal::make_nvp("has_bias", params_.has_bias),
-            cereal::make_nvp("w_stride", params_.w_stride),
-            cereal::make_nvp("h_stride", params_.h_stride));
-#else
-        throw nn_error("TinyDNN was not built with Serialization support");
-#endif  // CNN_NO_SERIALIZATION
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, convolutional_layer<Activation>& layer);
+#endif
 
  private:
     tensor_t* in_data_padded(const std::vector<tensor_t*>& in) {

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -374,8 +374,8 @@ class convolutional_layer : public feedforward_layer<Activation> {
 #endif  // DNN_USE_IMAGE_API
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, convolutional_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, convolutional_layer<Activation2>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/deconvolutional_layer.h
+++ b/tiny_dnn/layers/deconvolutional_layer.h
@@ -326,7 +326,7 @@ class deconvolutional_layer : public feedforward_layer<Activation> {
                         return Base::backward_activation(p_delta, out, c_delta);
                     },
                     &deconv_layer_worker_storage_);
-        #ifdef CNN_USE_AVX
+#ifdef CNN_USE_AVX
         } else if (backend_type == backend_t::avx) {
             backend = std::make_shared<core::avx_backend>(&params_,
                     [this](const tensor_t& in) {

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -161,25 +161,7 @@ class dropout_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive & ar,
-                                   cereal::construct<dropout_layer> & construct) {
-        net_phase phase;
-        float_t dropout_rate;
-        serial_size_t in_size;
-
-        ar(cereal::make_nvp("in_size", in_size),
-           cereal::make_nvp("dropout_rate", dropout_rate),
-           cereal::make_nvp("phase", phase));
-        construct(in_size, dropout_rate, phase);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_size_),
-           cereal::make_nvp("dropout_rate", dropout_rate_),
-           cereal::make_nvp("phase", phase_));
-    }
+    friend void serialize(Archive& ar, dropout_layer& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -125,8 +125,8 @@ class fully_connected_layer : public feedforward_layer<Activation> {
     std::string layer_type() const override { return "fully-connected"; }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, fully_connected_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, fully_connected_layer<Activation2>& layer);
 #endif
 
  protected:

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -125,25 +125,8 @@ class fully_connected_layer : public feedforward_layer<Activation> {
     std::string layer_type() const override { return "fully-connected"; }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive & ar,
-                                   cereal::construct<fully_connected_layer> & construct) {
-        serial_size_t in_dim, out_dim;
-        bool has_bias;
-
-        ar(cereal::make_nvp("in_size", in_dim),
-           cereal::make_nvp("out_size", out_dim),
-           cereal::make_nvp("has_bias", has_bias));
-        construct(in_dim, out_dim, has_bias);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in_size_),
-           cereal::make_nvp("out_size", params_.out_size_),
-           cereal::make_nvp("has_bias", params_.has_bias_));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, fully_connected_layer<Activation>& layer);
 #endif
 
  protected:

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -100,8 +100,8 @@ class linear_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, linear_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, linear_layer<Activation2>& layer);
 #endif
 
  protected:

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -100,26 +100,8 @@ class linear_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<linear_layer>& construct) {
-        serial_size_t dim;
-        float_t scale, bias;
-
-        ar(cereal::make_nvp("in_size", dim),
-           cereal::make_nvp("scale", scale),
-           cereal::make_nvp("bias", bias));
-
-        construct(dim, scale, bias);
-    }
-
-    template <class Archive>
-    void serialize(Archive& ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", dim_),
-           cereal::make_nvp("scale", scale_),
-           cereal::make_nvp("bias", bias_));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, linear_layer<Activation>& layer);
 #endif
 
  protected:

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -143,31 +143,8 @@ class lrn_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<lrn_layer>& construct) {
-        shape3d in_shape;
-        serial_size_t size;
-        float_t alpha, beta;
-        norm_region region;
-
-        ar(cereal::make_nvp("in_shape", in_shape),
-           cereal::make_nvp("size", size),
-           cereal::make_nvp("alpha", alpha),
-           cereal::make_nvp("beta", beta),
-           cereal::make_nvp("region", region));
-        construct(in_shape, size, alpha, beta, region);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_shape", in_shape_),
-           cereal::make_nvp("size", size_),
-           cereal::make_nvp("alpha", alpha_),
-           cereal::make_nvp("beta", beta_),
-           cereal::make_nvp("region", region_));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, lrn_layer<Activation>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -143,8 +143,8 @@ class lrn_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, lrn_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, lrn_layer<Activation2>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -183,8 +183,8 @@ class max_pooling_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, max_pooling_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, max_pooling_layer<Activation2>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -182,36 +182,9 @@ class max_pooling_layer : public feedforward_layer<Activation> {
             sample_count, std::vector<serial_size_t>(params_.out.size()));
     }
 
-
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void
-    load_and_construct(Archive & ar,
-                       cereal::construct<max_pooling_layer> & construct) {
-        shape3d in;
-        serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
-        padding pad_type;
-
-        ar(cereal::make_nvp("in_size", in),
-           cereal::make_nvp("pool_size_x", pool_size_x),
-           cereal::make_nvp("pool_size_y", pool_size_y),
-           cereal::make_nvp("stride_x", stride_x),
-           cereal::make_nvp("stride_y", stride_y),
-           cereal::make_nvp("pad_type", pad_type));
-        construct(in.width_, in.height_, in.depth_, pool_size_x, pool_size_y,
-                  stride_x, stride_y, pad_type);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", params_.in),
-           cereal::make_nvp("pool_size_x", params_.pool_size_x),
-           cereal::make_nvp("pool_size_y", params_.pool_size_y),
-           cereal::make_nvp("stride_x", params_.stride_x),
-           cereal::make_nvp("stride_y", params_.stride_y),
-           cereal::make_nvp("pad_type", params_.pad_type));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, max_pooling_layer<Activation>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -146,25 +146,8 @@ class max_unpooling_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<max_unpooling_layer>& construct) {
-        shape3d in;
-        serial_size_t stride, unpool_size;
-
-        ar(cereal::make_nvp("in_size", in),
-           cereal::make_nvp("unpool_size", unpool_size),
-           cereal::make_nvp("stride", stride));
-        construct(in, unpool_size, stride);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_),
-           cereal::make_nvp("unpool_size", unpool_size_),
-           cereal::make_nvp("stride", stride_));
-    }
+    template <class Archive, typename Activation>
+    friend void serialize(Archive& ar, max_unpooling_layer<Activation>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -146,8 +146,8 @@ class max_unpooling_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation>
-    friend void serialize(Archive& ar, max_unpooling_layer<Activation>& layer);
+    template <class Archive, typename Activation2>
+    friend void serialize(Archive& ar, max_unpooling_layer<Activation2>& layer);
 #endif
 
  private:

--- a/tiny_dnn/layers/power_layer.h
+++ b/tiny_dnn/layers/power_layer.h
@@ -112,25 +112,7 @@ class power_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<power_layer>& construct) {
-        shape3d in_shape;
-        float_t factor;
-        float_t scale {1.0};
-
-        ar(cereal::make_nvp("in_size", in_shape),
-           cereal::make_nvp("factor", factor),
-           cereal::make_nvp("scale", scale));
-        construct(in_shape, factor, scale);
-    }
-
-    template <class Archive>
-    void serialize(Archive & ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_shape_),
-           cereal::make_nvp("factor", factor_),
-           cereal::make_nvp("scale", scale_));
-    }
+    friend void serialize(Archive& ar, power_layer& layer);
 #endif
 
     float_t factor() const {

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -129,25 +129,7 @@ class slice_layer : public layer {
 
 #ifndef CNN_NO_SERIALIZATION
     template <class Archive>
-    static void load_and_construct(Archive& ar,
-                                   cereal::construct<slice_layer>& construct) {
-        shape3d in_shape;
-        slice_type slice_type;
-        serial_size_t num_outputs;
-
-        ar(cereal::make_nvp("in_size", in_shape),
-           cereal::make_nvp("slice_type", slice_type),
-           cereal::make_nvp("num_outputs", num_outputs));
-        construct(in_shape, slice_type, num_outputs);
-    }
-
-    template <class Archive>
-    void serialize(Archive& ar) {
-        layer::serialize_prolog(ar);
-        ar(cereal::make_nvp("in_size", in_shape_),
-           cereal::make_nvp("slice_type", slice_type_),
-           cereal::make_nvp("num_outputs", num_outputs_));
-    }
+    friend void serialize(Archive& ar, slice_layer& layer);
 #endif
 
  private:

--- a/tiny_dnn/util/deserialization_helper.h
+++ b/tiny_dnn/util/deserialization_helper.h
@@ -37,6 +37,7 @@
 
 #include "tiny_dnn/util/nn_error.h"
 #include "tiny_dnn/util/macro.h"
+#include "tiny_dnn/util/serialization_functions.h"
 #include "tiny_dnn/layers/layers.h"
 
 namespace tiny_dnn {

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -34,7 +34,7 @@ namespace cereal {
 template <> struct LoadAndConstruct<tiny_dnn::elementwise_add_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::elementwise_add_layer> & construct) {
+                                   cereal::construct<tiny_dnn::elementwise_add_layer>& construct) {
         tiny_dnn::serial_size_t num_args, dim;
 
         ar(cereal::make_nvp("num_args", num_args),
@@ -47,7 +47,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::average_pooling_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::average_pooling_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::average_pooling_layer<Activation>>& construct) {
         tiny_dnn::shape3d in;
         tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
         tiny_dnn::padding pad_type;
@@ -65,20 +65,20 @@ struct LoadAndConstruct<tiny_dnn::average_pooling_layer<Activation>> {
 template <> struct LoadAndConstruct<tiny_dnn::batch_normalization_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::batch_normalization_layer> & construct) {
+                                   cereal::construct<tiny_dnn::batch_normalization_layer>& construct) {
         tiny_dnn::shape3d in;
-        serial_size_t in_spatial_size, in_channels;
+        tiny_dnn::serial_size_t in_spatial_size, in_channels;
         tiny_dnn::float_t eps, momentum;
         tiny_dnn::net_phase phase;
         tiny_dnn::vec_t mean, variance;
         
         ar(cereal::make_nvp("in_spatial_size", in_spatial_size),
-            cereal::make_nvp("in_channels", in_channels),
-            cereal::make_nvp("epsilon", eps),
-            cereal::make_nvp("momentum", momentum),
-            cereal::make_nvp("phase", phase),
-            cereal::make_nvp("mean", mean),
-            cereal::make_nvp("variance", variance));
+           cereal::make_nvp("in_channels", in_channels),
+           cereal::make_nvp("epsilon", eps),
+           cereal::make_nvp("momentum", momentum),
+           cereal::make_nvp("phase", phase),
+           cereal::make_nvp("mean", mean),
+           cereal::make_nvp("variance", variance));
         construct(in_spatial_size, in_channels, eps, momentum, phase);
         construct->set_mean(mean);
         construct->set_variance(variance);
@@ -88,7 +88,7 @@ template <> struct LoadAndConstruct<tiny_dnn::batch_normalization_layer> {
 template <> struct LoadAndConstruct<tiny_dnn::concat_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::concat_layer> & construct) {
+                                   cereal::construct<tiny_dnn::concat_layer>& construct) {
         std::vector<tiny_dnn::shape3d> in_shapes;
 
         ar(cereal::make_nvp("in_size", in_shapes));
@@ -100,7 +100,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::convolutional_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::convolutional_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::convolutional_layer<Activation>>& construct) {
         tiny_dnn::serial_size_t w_width, w_height, out_ch, w_stride, h_stride;
         bool has_bias;
         tiny_dnn::shape3d in;
@@ -125,7 +125,7 @@ struct LoadAndConstruct<tiny_dnn::convolutional_layer<Activation>> {
 template <> struct LoadAndConstruct<tiny_dnn::dropout_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::dropout_layer> & construct) {
+                                   cereal::construct<tiny_dnn::dropout_layer>& construct) {
         tiny_dnn::net_phase phase;
         tiny_dnn::float_t dropout_rate;
         tiny_dnn::serial_size_t in_size;
@@ -141,7 +141,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::fully_connected_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::fully_connected_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::fully_connected_layer<Activation>>& construct) {
         tiny_dnn::serial_size_t in_dim, out_dim;
         bool has_bias;
 
@@ -156,7 +156,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::linear_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::linear_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::linear_layer<Activation>>& construct) {
         tiny_dnn::serial_size_t dim;
         tiny_dnn::float_t scale, bias;
 
@@ -172,7 +172,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::lrn_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::lrn_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::lrn_layer<Activation>>& construct) {
         tiny_dnn::shape3d in_shape;
         tiny_dnn::serial_size_t size;
         tiny_dnn::float_t alpha, beta;
@@ -191,7 +191,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::max_pooling_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::max_pooling_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::max_pooling_layer<Activation>>& construct) {
         tiny_dnn::shape3d in;
         tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
         tiny_dnn::padding pad_type;
@@ -211,7 +211,7 @@ template <typename Activation>
 struct LoadAndConstruct<tiny_dnn::max_unpooling_layer<Activation>> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::max_unpooling_layer<Activation>> & construct) {
+                                   cereal::construct<tiny_dnn::max_unpooling_layer<Activation>>& construct) {
         tiny_dnn::shape3d in;
         tiny_dnn::serial_size_t stride, unpool_size;
 
@@ -225,7 +225,7 @@ struct LoadAndConstruct<tiny_dnn::max_unpooling_layer<Activation>> {
 template <> struct LoadAndConstruct<tiny_dnn::power_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::power_layer> & construct) {
+                                   cereal::construct<tiny_dnn::power_layer>& construct) {
         tiny_dnn::shape3d in_shape;
         tiny_dnn::float_t factor;
         tiny_dnn::float_t scale(1.0f);
@@ -240,7 +240,7 @@ template <> struct LoadAndConstruct<tiny_dnn::power_layer> {
 template <> struct LoadAndConstruct<tiny_dnn::slice_layer> {
     template <class Archive>
     static void load_and_construct(Archive& ar,
-                                   cereal::construct<tiny_dnn::slice_layer> & construct) {
+                                   cereal::construct<tiny_dnn::slice_layer>& construct) {
         tiny_dnn::shape3d in_shape;
         tiny_dnn::slice_type slice_type;
         tiny_dnn::serial_size_t num_outputs;
@@ -308,11 +308,11 @@ void serialize(Archive& ar,
                tiny_dnn::average_pooling_layer<Activation>& layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_size", layer.in_),
-        cereal::make_nvp("pool_size_x", layer.pool_size_x_),
-        cereal::make_nvp("pool_size_y", layer.pool_size_y_),
-        cereal::make_nvp("stride_x", layer.stride_x_),
-        cereal::make_nvp("stride_y", layer.stride_y_),
-        cereal::make_nvp("pad_type", layer.pad_type_));
+       cereal::make_nvp("pool_size_x", layer.pool_size_x_),
+       cereal::make_nvp("pool_size_y", layer.pool_size_y_),
+       cereal::make_nvp("stride_x", layer.stride_x_),
+       cereal::make_nvp("stride_y", layer.stride_y_),
+       cereal::make_nvp("pad_type", layer.pad_type_));
 }
 
 template <class Archive>
@@ -320,12 +320,12 @@ void serialize(Archive& ar,
                tiny_dnn::batch_normalization_layer& layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_spatial_size", layer.in_spatial_size_),
-        cereal::make_nvp("in_channels", layer.in_channels_),
-        cereal::make_nvp("epsilon", layer.eps_),
-        cereal::make_nvp("momentum", layer.momentum_),
-        cereal::make_nvp("phase", layer.phase_),
-        cereal::make_nvp("mean", layer.mean_),
-        cereal::make_nvp("variance", layer.variance_));
+       cereal::make_nvp("in_channels", layer.in_channels_),
+       cereal::make_nvp("epsilon", layer.eps_),
+       cereal::make_nvp("momentum", layer.momentum_),
+       cereal::make_nvp("phase", layer.phase_),
+       cereal::make_nvp("mean", layer.mean_),
+       cereal::make_nvp("variance", layer.variance_));
 }
 
 template <class Archive>
@@ -366,8 +366,8 @@ void serialize(Archive& ar,
     layer.serialize_prolog(ar);
     auto& params_ = layer.params_;
     ar(cereal::make_nvp("in_size", params_.in_size_),
-        cereal::make_nvp("out_size", params_.out_size_),
-        cereal::make_nvp("has_bias", params_.has_bias_));
+       cereal::make_nvp("out_size", params_.out_size_),
+       cereal::make_nvp("has_bias", params_.has_bias_));
 }
 
 template <class Archive, typename Activation>

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -1,0 +1,433 @@
+/*
+    Copyright (c) 2013, Taiga Nomi
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+    * Redistributions of source code must retain the above copyright
+    notice, this list of conditions and the following disclaimer.
+    * Redistributions in binary form must reproduce the above copyright
+    notice, this list of conditions and the following disclaimer in the
+    documentation and/or other materials provided with the distribution.
+    * Neither the name of the <organization> nor the
+    names of its contributors may be used to endorse or promote products
+    derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*/
+#pragma once
+
+#include "tiny_dnn/tiny_dnn.h"
+#include <cereal/access.hpp> // For LoadAndConstruct
+
+namespace cereal {
+
+template <> struct LoadAndConstruct<tiny_dnn::elementwise_add_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::elementwise_add_layer> & construct) {
+        tiny_dnn::serial_size_t num_args, dim;
+
+        ar(cereal::make_nvp("num_args", num_args),
+           cereal::make_nvp("dim", dim));
+        construct(num_args, dim);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::average_pooling_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::average_pooling_layer<Activation>> & construct) {
+        tiny_dnn::shape3d in;
+        tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
+        tiny_dnn::padding pad_type;
+
+        ar(cereal::make_nvp("in_size", in),
+           cereal::make_nvp("pool_size_x", pool_size_x),
+           cereal::make_nvp("pool_size_y", pool_size_y),
+           cereal::make_nvp("stride_x", stride_x),
+           cereal::make_nvp("stride_y", stride_y),
+           cereal::make_nvp("pad_type", pad_type));
+        construct(in.width_, in.height_, in.depth_, pool_size_x, pool_size_y, stride_x, stride_y, pad_type);
+    }
+};
+
+template <> struct LoadAndConstruct<tiny_dnn::batch_normalization_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::batch_normalization_layer> & construct) {
+        tiny_dnn::shape3d in;
+        serial_size_t in_spatial_size, in_channels;
+        tiny_dnn::float_t eps, momentum;
+        tiny_dnn::net_phase phase;
+        tiny_dnn::vec_t mean, variance;
+        
+        ar(cereal::make_nvp("in_spatial_size", in_spatial_size),
+            cereal::make_nvp("in_channels", in_channels),
+            cereal::make_nvp("epsilon", eps),
+            cereal::make_nvp("momentum", momentum),
+            cereal::make_nvp("phase", phase),
+            cereal::make_nvp("mean", mean),
+            cereal::make_nvp("variance", variance));
+        construct(in_spatial_size, in_channels, eps, momentum, phase);
+        construct->set_mean(mean);
+        construct->set_variance(variance);
+    }
+};
+
+template <> struct LoadAndConstruct<tiny_dnn::concat_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::concat_layer> & construct) {
+        std::vector<tiny_dnn::shape3d> in_shapes;
+
+        ar(cereal::make_nvp("in_size", in_shapes));
+        construct(in_shapes);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::convolutional_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::convolutional_layer<Activation>> & construct) {
+        tiny_dnn::serial_size_t w_width, w_height, out_ch, w_stride, h_stride;
+        bool has_bias;
+        tiny_dnn::shape3d in;
+        tiny_dnn::padding pad_type;
+        tiny_dnn::core::connection_table tbl;
+
+        ar(cereal::make_nvp("in_size", in),
+           cereal::make_nvp("window_width", w_width),
+           cereal::make_nvp("window_height", w_height),
+           cereal::make_nvp("out_channels", out_ch),
+           cereal::make_nvp("connection_table", tbl),
+           cereal::make_nvp("pad_type", pad_type),
+           cereal::make_nvp("has_bias", has_bias),
+           cereal::make_nvp("w_stride", w_stride),
+           cereal::make_nvp("h_stride", h_stride));
+
+        construct(in.width_, in.height_, w_width, w_height, in.depth_,
+                  out_ch, tbl, pad_type, has_bias, w_stride, h_stride);
+    }
+};
+
+template <> struct LoadAndConstruct<tiny_dnn::dropout_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::dropout_layer> & construct) {
+        tiny_dnn::net_phase phase;
+        tiny_dnn::float_t dropout_rate;
+        tiny_dnn::serial_size_t in_size;
+
+        ar(cereal::make_nvp("in_size", in_size),
+           cereal::make_nvp("dropout_rate", dropout_rate),
+           cereal::make_nvp("phase", phase));
+        construct(in_size, dropout_rate, phase);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::fully_connected_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::fully_connected_layer<Activation>> & construct) {
+        tiny_dnn::serial_size_t in_dim, out_dim;
+        bool has_bias;
+
+        ar(cereal::make_nvp("in_size", in_dim),
+           cereal::make_nvp("out_size", out_dim),
+           cereal::make_nvp("has_bias", has_bias));
+        construct(in_dim, out_dim, has_bias);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::linear_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::linear_layer<Activation>> & construct) {
+        tiny_dnn::serial_size_t dim;
+        tiny_dnn::float_t scale, bias;
+
+        ar(cereal::make_nvp("in_size", dim),
+           cereal::make_nvp("scale", scale),
+           cereal::make_nvp("bias", bias));
+
+        construct(dim, scale, bias);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::lrn_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::lrn_layer<Activation>> & construct) {
+        tiny_dnn::shape3d in_shape;
+        tiny_dnn::serial_size_t size;
+        tiny_dnn::float_t alpha, beta;
+        tiny_dnn::norm_region region;
+
+        ar(cereal::make_nvp("in_shape", in_shape),
+           cereal::make_nvp("size",     size),
+           cereal::make_nvp("alpha",    alpha),
+           cereal::make_nvp("beta",     beta),
+           cereal::make_nvp("region",   region));
+        construct(in_shape, size, alpha, beta, region);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::max_pooling_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::max_pooling_layer<Activation>> & construct) {
+        tiny_dnn::shape3d in;
+        tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
+        tiny_dnn::padding pad_type;
+
+        ar(cereal::make_nvp("in_size", in),
+           cereal::make_nvp("pool_size_x", pool_size_x),
+           cereal::make_nvp("pool_size_y", pool_size_y),
+           cereal::make_nvp("stride_x", stride_x),
+           cereal::make_nvp("stride_y", stride_y),
+           cereal::make_nvp("pad_type", pad_type));
+        construct(in.width_, in.height_, in.depth_, pool_size_x, pool_size_y,
+                  stride_x, stride_y, pad_type);
+    }
+};
+
+template <typename Activation>
+struct LoadAndConstruct<tiny_dnn::max_unpooling_layer<Activation>> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::max_unpooling_layer<Activation>> & construct) {
+        tiny_dnn::shape3d in;
+        tiny_dnn::serial_size_t stride, unpool_size;
+
+        ar(cereal::make_nvp("in_size", in),
+           cereal::make_nvp("unpool_size", unpool_size),
+           cereal::make_nvp("stride", stride));
+        construct(in, unpool_size, stride);
+    }
+};
+
+template <> struct LoadAndConstruct<tiny_dnn::power_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::power_layer> & construct) {
+        tiny_dnn::shape3d in_shape;
+        tiny_dnn::float_t factor;
+        tiny_dnn::float_t scale(1.0f);
+
+        ar(cereal::make_nvp("in_size", in_shape),
+           cereal::make_nvp("factor", factor),
+           cereal::make_nvp("scale", scale));
+        construct(in_shape, factor, scale);
+    }
+};
+
+template <> struct LoadAndConstruct<tiny_dnn::slice_layer> {
+    template <class Archive>
+    static void load_and_construct(Archive& ar,
+                                   cereal::construct<tiny_dnn::slice_layer> & construct) {
+        tiny_dnn::shape3d in_shape;
+        tiny_dnn::slice_type slice_type;
+        tiny_dnn::serial_size_t num_outputs;
+
+        ar(cereal::make_nvp("in_size", in_shape),
+           cereal::make_nvp("slice_type", slice_type),
+           cereal::make_nvp("num_outputs", num_outputs));
+        construct(in_shape, slice_type, num_outputs);
+    }
+};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::elementwise_add_layer, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::average_pooling_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::batch_normalization_layer, cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::concat_layer, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::convolutional_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::dropout_layer, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::fully_connected_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::linear_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::lrn_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::max_pooling_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive, typename Activation>
+struct specialize<Archive, tiny_dnn::max_unpooling_layer<Activation>, cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::power_layer, cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive, tiny_dnn::slice_layer, cereal::specialization::non_member_serialize> {};
+
+} // namespace cereal
+
+namespace tiny_dnn {
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::elementwise_add_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("num_args", layer.num_args_),
+       cereal::make_nvp("dim", layer.dim_));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::average_pooling_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_),
+        cereal::make_nvp("pool_size_x", layer.pool_size_x_),
+        cereal::make_nvp("pool_size_y", layer.pool_size_y_),
+        cereal::make_nvp("stride_x", layer.stride_x_),
+        cereal::make_nvp("stride_y", layer.stride_y_),
+        cereal::make_nvp("pad_type", layer.pad_type_));
+}
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::batch_normalization_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_spatial_size", layer.in_spatial_size_),
+        cereal::make_nvp("in_channels", layer.in_channels_),
+        cereal::make_nvp("epsilon", layer.eps_),
+        cereal::make_nvp("momentum", layer.momentum_),
+        cereal::make_nvp("phase", layer.phase_),
+        cereal::make_nvp("mean", layer.mean_),
+        cereal::make_nvp("variance", layer.variance_));
+}
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::concat_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(layer.in_shapes_);
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::convolutional_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    auto& params_ = layer.params_;
+    ar(cereal::make_nvp("in_size", params_.in),
+       cereal::make_nvp("window_width", params_.weight.width_),
+       cereal::make_nvp("window_height", params_.weight.height_),
+       cereal::make_nvp("out_channels", params_.out.depth_),
+       cereal::make_nvp("connection_table", params_.tbl),
+       cereal::make_nvp("pad_type", params_.pad_type),
+       cereal::make_nvp("has_bias", params_.has_bias),
+       cereal::make_nvp("w_stride", params_.w_stride),
+       cereal::make_nvp("h_stride", params_.h_stride));
+}
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::dropout_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_size_),
+       cereal::make_nvp("dropout_rate", layer.dropout_rate_),
+       cereal::make_nvp("phase", layer.phase_));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::fully_connected_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    auto& params_ = layer.params_;
+    ar(cereal::make_nvp("in_size", params_.in_size_),
+        cereal::make_nvp("out_size", params_.out_size_),
+        cereal::make_nvp("has_bias", params_.has_bias_));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::linear_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.dim_),
+       cereal::make_nvp("scale", layer.scale_),
+       cereal::make_nvp("bias", layer.bias_));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::lrn_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_shape", layer.in_shape_),
+       cereal::make_nvp("size",     layer.size_),
+       cereal::make_nvp("alpha",    layer.alpha_),
+       cereal::make_nvp("beta",     layer.beta_),
+       cereal::make_nvp("region",   layer.region_));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::max_pooling_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    auto& params_ = layer.params_;
+    ar(cereal::make_nvp("in_size", params_.in),
+       cereal::make_nvp("pool_size_x", params_.pool_size_x),
+       cereal::make_nvp("pool_size_y", params_.pool_size_y),
+       cereal::make_nvp("stride_x", params_.stride_x),
+       cereal::make_nvp("stride_y", params_.stride_y),
+       cereal::make_nvp("pad_type", params_.pad_type));
+}
+
+template <class Archive, typename Activation>
+void serialize(Archive& ar,
+               tiny_dnn::max_unpooling_layer<Activation>& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size",     layer.in_),
+       cereal::make_nvp("unpool_size", layer.unpool_size_),
+       cereal::make_nvp("stride",      layer.stride_));
+}
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::power_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape_),
+       cereal::make_nvp("factor", layer.factor_),
+       cereal::make_nvp("scale", layer.scale_));
+}
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::slice_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape_),
+       cereal::make_nvp("slice_type", layer.slice_type_),
+       cereal::make_nvp("num_outputs", layer.num_outputs_));
+}
+
+} // namespace tiny_dnn

--- a/tiny_dnn/util/serialization_helper.h
+++ b/tiny_dnn/util/serialization_helper.h
@@ -36,6 +36,7 @@
 
 #include "tiny_dnn/util/nn_error.h"
 #include "tiny_dnn/util/macro.h"
+#include "tiny_dnn/util/serialization_functions.h"
 #include "tiny_dnn/layers/layers.h"
 
 namespace tiny_dnn {


### PR DESCRIPTION
Hi, this PR externalizes some serialization functions in layer classes.

Friend declarations are still needed to access private members so it makes this less appealing.
I never thought implementing external serialization functions would be this difficult... 
There are still other classes that still have serialization methods such as `nodes`, `sequential`, `graph`, `core::connection_table`, `index3d`. So this PR is not a complete work.
