### PR TITLE
Measuring unit of elapsed benchmark time should be second

### DIFF
--- a/examples/benchmarks/main.cpp
+++ b/examples/benchmarks/main.cpp
@@ -54,10 +54,10 @@ int  main(int argc, char** argv) {
     // predict
     auto res = nn.predict(in);
 
-    double elapsed_ms = t.elapsed();
+    double elapsed_s = t.elapsed();
     t.stop();
 
-    cout << "Elapsed time(ms): " << elapsed_ms << endl;
+    cout << "Elapsed time(s): " << elapsed_s << endl;
 }
 
 


### PR DESCRIPTION
Measuring unit of elapsed time of AlexNet forward benchmark should be second instead of millisecond.