### PR TITLE
Add serialization_buddy class to simplify friend declarations

### DIFF
--- a/tiny_dnn/core/params/conv_params.h
+++ b/tiny_dnn/core/params/conv_params.h
@@ -76,22 +76,6 @@ struct connection_table {
         return rows_ == 0 && cols_ == 0;
     }
 
-    template <typename Archive>
-    void serialize(Archive& ar) {
-#ifndef CNN_NO_SERIALIZATION
-        ar(cereal::make_nvp("rows", rows_),
-           cereal::make_nvp("cols", cols_));
-
-        if (is_empty()) {
-            ar(cereal::make_nvp("connection", std::string("all")));
-        } else {
-            ar(cereal::make_nvp("connection", connected_));
-        }
-#else
-        throw nn_error("TinyDNN was not built with Serialization support");
-#endif  // CNN_NO_SERIALIZATION
-    }
-
     std::deque<bool> connected_;
     serial_size_t rows_;
     serial_size_t cols_;

--- a/tiny_dnn/layers/arithmetic_layer.h
+++ b/tiny_dnn/layers/arithmetic_layer.h
@@ -86,9 +86,7 @@ class elementwise_add_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, elementwise_add_layer& layer);
-
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -264,8 +264,7 @@ class average_pooling_layer : public partial_connected_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, average_pooling_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
     std::pair<serial_size_t, serial_size_t> pool_size() const { return std::make_pair(pool_size_x_, pool_size_y_); }

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -232,8 +232,7 @@ class batch_normalization_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, batch_normalization_layer& layer);
+    friend struct serialization_buddy;
 #endif
 
     float_t epsilon() const {

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -120,8 +120,7 @@ class concat_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, concat_layer& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -374,8 +374,7 @@ class convolutional_layer : public feedforward_layer<Activation> {
 #endif  // DNN_USE_IMAGE_API
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, convolutional_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -160,8 +160,7 @@ class dropout_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, dropout_layer& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -125,8 +125,7 @@ class fully_connected_layer : public feedforward_layer<Activation> {
     std::string layer_type() const override { return "fully-connected"; }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, fully_connected_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  protected:

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -100,8 +100,7 @@ class linear_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, linear_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  protected:

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -143,8 +143,7 @@ class lrn_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, lrn_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -193,8 +193,7 @@ class max_pooling_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, max_pooling_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -154,8 +154,7 @@ class max_unpooling_layer : public feedforward_layer<Activation> {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive, typename Activation2>
-    friend void serialize(Archive& ar, max_unpooling_layer<Activation2>& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/layers/power_layer.h
+++ b/tiny_dnn/layers/power_layer.h
@@ -111,8 +111,7 @@ class power_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, power_layer& layer);
+    friend struct serialization_buddy;
 #endif
 
     float_t factor() const {

--- a/tiny_dnn/layers/slice_layer.h
+++ b/tiny_dnn/layers/slice_layer.h
@@ -128,8 +128,7 @@ class slice_layer : public layer {
     }
 
 #ifndef CNN_NO_SERIALIZATION
-    template <class Archive>
-    friend void serialize(Archive& ar, slice_layer& layer);
+    friend struct serialization_buddy;
 #endif
 
  private:

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -295,139 +295,255 @@ struct specialize<Archive, tiny_dnn::slice_layer, cereal::specialization::non_me
 
 namespace tiny_dnn {
 
+struct serialization_buddy {
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::elementwise_add_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("num_args", layer.num_args_),
+           cereal::make_nvp("dim", layer.dim_));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::average_pooling_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size", layer.in_),
+           cereal::make_nvp("pool_size_x", layer.pool_size_x_),
+           cereal::make_nvp("pool_size_y", layer.pool_size_y_),
+           cereal::make_nvp("stride_x", layer.stride_x_),
+           cereal::make_nvp("stride_y", layer.stride_y_),
+           cereal::make_nvp("pad_type", layer.pad_type_));
+    }
+
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::batch_normalization_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_spatial_size", layer.in_spatial_size_),
+           cereal::make_nvp("in_channels", layer.in_channels_),
+           cereal::make_nvp("epsilon", layer.eps_),
+           cereal::make_nvp("momentum", layer.momentum_),
+           cereal::make_nvp("phase", layer.phase_),
+           cereal::make_nvp("mean", layer.mean_),
+           cereal::make_nvp("variance", layer.variance_));
+    }
+
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::concat_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(layer.in_shapes_);
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::convolutional_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        auto& params_ = layer.params_;
+        ar(cereal::make_nvp("in_size", params_.in),
+           cereal::make_nvp("window_width", params_.weight.width_),
+           cereal::make_nvp("window_height", params_.weight.height_),
+           cereal::make_nvp("out_channels", params_.out.depth_),
+           cereal::make_nvp("connection_table", params_.tbl),
+           cereal::make_nvp("pad_type", params_.pad_type),
+           cereal::make_nvp("has_bias", params_.has_bias),
+           cereal::make_nvp("w_stride", params_.w_stride),
+           cereal::make_nvp("h_stride", params_.h_stride));
+    }
+
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::dropout_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size", layer.in_size_),
+           cereal::make_nvp("dropout_rate", layer.dropout_rate_),
+           cereal::make_nvp("phase", layer.phase_));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::fully_connected_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        auto& params_ = layer.params_;
+        ar(cereal::make_nvp("in_size", params_.in_size_),
+           cereal::make_nvp("out_size", params_.out_size_),
+           cereal::make_nvp("has_bias", params_.has_bias_));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::linear_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size", layer.dim_),
+           cereal::make_nvp("scale", layer.scale_),
+           cereal::make_nvp("bias", layer.bias_));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::lrn_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_shape", layer.in_shape_),
+           cereal::make_nvp("size",     layer.size_),
+           cereal::make_nvp("alpha",    layer.alpha_),
+           cereal::make_nvp("beta",     layer.beta_),
+           cereal::make_nvp("region",   layer.region_));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::max_pooling_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        auto& params_ = layer.params_;
+        ar(cereal::make_nvp("in_size", params_.in),
+           cereal::make_nvp("pool_size_x", params_.pool_size_x),
+           cereal::make_nvp("pool_size_y", params_.pool_size_y),
+           cereal::make_nvp("stride_x", params_.stride_x),
+           cereal::make_nvp("stride_y", params_.stride_y),
+           cereal::make_nvp("pad_type", params_.pad_type));
+    }
+
+    template <class Archive, typename Activation>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::max_unpooling_layer<Activation>& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size",     layer.in_),
+           cereal::make_nvp("unpool_size", layer.unpool_size_),
+           cereal::make_nvp("stride",      layer.stride_));
+    }
+
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::power_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size", layer.in_shape_),
+           cereal::make_nvp("factor", layer.factor_),
+           cereal::make_nvp("scale", layer.scale_));
+    }
+
+    template <class Archive>
+    static inline void
+    serialize(Archive& ar,
+              tiny_dnn::slice_layer& layer) {
+        layer.serialize_prolog(ar);
+        ar(cereal::make_nvp("in_size", layer.in_shape_),
+           cereal::make_nvp("slice_type", layer.slice_type_),
+           cereal::make_nvp("num_outputs", layer.num_outputs_));
+    }
+};
+
 template <class Archive>
-void serialize(Archive& ar,
-               tiny_dnn::elementwise_add_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("num_args", layer.num_args_),
-       cereal::make_nvp("dim", layer.dim_));
+void serialize(Archive& ar, tiny_dnn::elementwise_add_layer& layer) {
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::average_pooling_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size", layer.in_),
-       cereal::make_nvp("pool_size_x", layer.pool_size_x_),
-       cereal::make_nvp("pool_size_y", layer.pool_size_y_),
-       cereal::make_nvp("stride_x", layer.stride_x_),
-       cereal::make_nvp("stride_y", layer.stride_y_),
-       cereal::make_nvp("pad_type", layer.pad_type_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive>
 void serialize(Archive& ar,
                tiny_dnn::batch_normalization_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_spatial_size", layer.in_spatial_size_),
-       cereal::make_nvp("in_channels", layer.in_channels_),
-       cereal::make_nvp("epsilon", layer.eps_),
-       cereal::make_nvp("momentum", layer.momentum_),
-       cereal::make_nvp("phase", layer.phase_),
-       cereal::make_nvp("mean", layer.mean_),
-       cereal::make_nvp("variance", layer.variance_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive>
 void serialize(Archive& ar,
                tiny_dnn::concat_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(layer.in_shapes_);
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::convolutional_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    auto& params_ = layer.params_;
-    ar(cereal::make_nvp("in_size", params_.in),
-       cereal::make_nvp("window_width", params_.weight.width_),
-       cereal::make_nvp("window_height", params_.weight.height_),
-       cereal::make_nvp("out_channels", params_.out.depth_),
-       cereal::make_nvp("connection_table", params_.tbl),
-       cereal::make_nvp("pad_type", params_.pad_type),
-       cereal::make_nvp("has_bias", params_.has_bias),
-       cereal::make_nvp("w_stride", params_.w_stride),
-       cereal::make_nvp("h_stride", params_.h_stride));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive>
 void serialize(Archive& ar,
                tiny_dnn::dropout_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size", layer.in_size_),
-       cereal::make_nvp("dropout_rate", layer.dropout_rate_),
-       cereal::make_nvp("phase", layer.phase_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::fully_connected_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    auto& params_ = layer.params_;
-    ar(cereal::make_nvp("in_size", params_.in_size_),
-       cereal::make_nvp("out_size", params_.out_size_),
-       cereal::make_nvp("has_bias", params_.has_bias_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::linear_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size", layer.dim_),
-       cereal::make_nvp("scale", layer.scale_),
-       cereal::make_nvp("bias", layer.bias_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::lrn_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_shape", layer.in_shape_),
-       cereal::make_nvp("size",     layer.size_),
-       cereal::make_nvp("alpha",    layer.alpha_),
-       cereal::make_nvp("beta",     layer.beta_),
-       cereal::make_nvp("region",   layer.region_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::max_pooling_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    auto& params_ = layer.params_;
-    ar(cereal::make_nvp("in_size", params_.in),
-       cereal::make_nvp("pool_size_x", params_.pool_size_x),
-       cereal::make_nvp("pool_size_y", params_.pool_size_y),
-       cereal::make_nvp("stride_x", params_.stride_x),
-       cereal::make_nvp("stride_y", params_.stride_y),
-       cereal::make_nvp("pad_type", params_.pad_type));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive, typename Activation>
 void serialize(Archive& ar,
                tiny_dnn::max_unpooling_layer<Activation>& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size",     layer.in_),
-       cereal::make_nvp("unpool_size", layer.unpool_size_),
-       cereal::make_nvp("stride",      layer.stride_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive>
 void serialize(Archive& ar,
                tiny_dnn::power_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size", layer.in_shape_),
-       cereal::make_nvp("factor", layer.factor_),
-       cereal::make_nvp("scale", layer.scale_));
+    serialization_buddy::serialize(ar, layer);
 }
 
 template <class Archive>
 void serialize(Archive& ar,
                tiny_dnn::slice_layer& layer) {
-    layer.serialize_prolog(ar);
-    ar(cereal::make_nvp("in_size", layer.in_shape_),
-       cereal::make_nvp("slice_type", layer.slice_type_),
-       cereal::make_nvp("num_outputs", layer.num_outputs_));
+    serialization_buddy::serialize(ar, layer);
 }
+
+template <class Archive, typename T>
+void serialize(Archive& ar,
+               tiny_dnn::index3d<T>& idx) {
+    ar(cereal::make_nvp("width",  idx.width_),
+       cereal::make_nvp("height", idx.height_),
+       cereal::make_nvp("depth",  idx.depth_));
+}
+
+namespace core {
+
+template <class Archive>
+void serialize(Archive& ar,
+               tiny_dnn::core::connection_table& tbl) {
+    ar(cereal::make_nvp("rows", tbl.rows_),
+       cereal::make_nvp("cols", tbl.cols_));
+    if (tbl.is_empty()) {
+        ar(cereal::make_nvp("connection", std::string("all")));
+    } else {
+        ar(cereal::make_nvp("connection", tbl.connected_));
+    }
+}
+
+} // namespace core
 
 } // namespace tiny_dnn

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -182,17 +182,6 @@ struct index3d {
         return width_ * height_ * depth_;
     }
 
-    template <class Archive>
-    void serialize(Archive & ar) {
-#ifndef CNN_NO_SERIALIZATION
-        ar(cereal::make_nvp("width",  width_),
-           cereal::make_nvp("height", height_),
-           cereal::make_nvp("depth",  depth_));
-#else
-        throw nn_error("TinyDNN was not built with Serialization support");
-#endif  // CNN_NO_SERIALIZATION
-    }
-
     T width_;
     T height_;
     T depth_;


### PR DESCRIPTION
Hi, this PR simplifies friend declarations in layer classes and it also externalizes serialization functions of `tiny_dnn::index3d` and `tiny_dnn::core::connection_table` classes.