### PR TITLE
fix broken caffe_converter

### DIFF
--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -768,6 +768,17 @@ inline bool layer_skipped(const std::string& type) {
     return false;
 }
 
+inline bool layer_has_weights(const std::string& type) {
+    static const char* activations[] = {
+        "SoftmaxWithLoss", "SigmoidCrossEntropyLoss", "LRN", "Dropout",
+        "ReLU", "Sigmoid", "TanH", "Softmax"
+    };
+    for (unsigned int i = 0; i < sizeof(activations) / sizeof(activations[0]); i++) {
+        if (activations[i] == type) return false;
+    }
+    return true;
+}
+
 inline bool layer_supported(const std::string& type) {
     static const char* supported[] = {
         "InnerProduct", "Convolution", "Deconvolution", "Pooling",


### PR DESCRIPTION
In this PR the broken Caffe converter is fixed due to the fact that some users reported in https://github.com/tiny-dnn/tiny-dnn/issues/429 the bug in 5c2ab5b99abe4c283b290d9338aea080430261d7.