### PR TITLE
Remove dead code and add missing refs for loops

### DIFF
--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -279,13 +279,6 @@ inline void tiny_quantized_deconv2d_back_kernel(const deconv_params &params,
     &min_prev_delta_requantized, &max_prev_delta_requantized,
     &prev_delta_requantized);
 
-  // dequantize to flaot, this could be removed within concatenated quantized
-  // network
-  vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(
-    prev_delta_requantized, min_prev_delta_requantized,
-    max_prev_delta_requantized);
-  prev_delta = &prev_delta_vec;
-
   // Accumulate dw
   for_i(params.in.depth_, [&](int inc) {
     for (serial_size_t outc = 0; outc < params.out.depth_; outc++) {
@@ -363,15 +356,6 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
   if (W_r[0] == W_r[1]) {
     max_filter = W_r[1] + 1e-3f;
     min_filter = W_r[0] - 1e-3f;
-  }
-  // bias range
-  float_t min_bias(b_r[0]);
-  float_t max_bias(b_r[1]);
-  if (params.has_bias) {
-    if (min_bias == max_bias) {
-      max_bias = b_r[1] + 1e-3f;
-      min_bias = b_r[0] - 1e-3f;
-    }
   }
   // output range
   float_t min_output_value;

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -891,7 +891,7 @@ void graph_traverse(layer *root_node, T &&node_callback, U &&edge_callback) {
     node_callback(*curr);
 
     auto edges = curr->next();
-    for (auto e : edges) {
+    for (auto& e : edges) {
       if (e != nullptr) edge_callback(*e);
     }
 

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -74,7 +74,7 @@ struct result {
 
   std::set<label_t> labels() const {
     std::set<label_t> all_labels;
-    for (auto r : confusion_matrix) {
+    for (auto& r : confusion_matrix) {
       all_labels.insert(r.first);
       for (auto c : r.second) all_labels.insert(c.first);
     }


### PR DESCRIPTION
These things were found by Clang Static Analyzer and Clazy. After removing these codes, I see 2-5 % speedup with 1D convolution layer, depending on the network topology.