### PR TITLE
Add a missing include

### DIFF
--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -7,6 +7,9 @@
 */
 #pragma once
 
+#ifndef CNN_NO_SERIALIZATION
+#include <fstream>
+#endif
 #include <algorithm>
 #include <iomanip>
 #include <iostream>


### PR DESCRIPTION
Fixes issue "invalid use of incomplete type std::ifstream"
https://github.com/tiny-dnn/tiny-dnn/issues/519