### PR TITLE
Initial playground: activation_layer base class with relu_layer inheriting it.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -40,6 +40,8 @@ branches:
   only:
     - master
     - feat/tensor_integration
+    - feat/decouple_activations
+
 env:
   global:
     - USE_TBB=ON

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -420,10 +420,12 @@ TEST(network, gradient_check3) {  // mixture - mse
   typedef mse loss_func;
   typedef network<sequential> network;
 
+  // TODO: (karandesai) adopt this in all the tests gradually
   network nn;
   nn << fully_connected_layer<tan_h>(10, 14 * 14 * 3)
      << convolutional_layer<sigmoid>(14, 14, 5, 3, 6)
-     << average_pooling_layer<rectified_linear>(10, 10, 6, 2)
+     << average_pooling_layer<identity>(10, 10, 6, 2)
+     << relu_layer(shape3d(5, 5, 6))
      << fully_connected_layer<identity>(5 * 5 * 6, 3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -1,6 +1,6 @@
 #pragma once
 
-#include "tiny_dnn/layer/layer.h"
+#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
@@ -36,7 +36,7 @@ public:
 
     void back_propagation(const std::vector<tensor_t *> &in_data,
                           const std::vector<tensor_t *> &out_data,
-                          const std::vector<tensor_t *> &out_grad,
+                          std::vector<tensor_t *> &out_grad,
                           std::vector<tensor_t *> &in_grad) override {
         tensor_t &dx       = *in_grad[0];
         const tensor_t &dy = *out_grad[0];
@@ -45,7 +45,7 @@ public:
 
         for (serial_size_t i = 0; i < x.size(); i++) {
             for (serial_size_t j = 0; j < x[i].size(); j++) {
-                backward_activation(x, y, dx, dy);
+                backward_activation(x[i][j], y[i][j], dx[i][j], dy[i][j]);
             }
         }
     }
@@ -56,8 +56,8 @@ public:
                                     float_t &y) = 0;
 
     virtual void backward_activation(const float_t x,
-                                     float_t &dx,
                                      const float_t &y,
+                                     float_t &dx,
                                      const float_t &dy) = 0;
 
 private:

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -20,14 +20,29 @@ class activation_layer : public layer {
   activation_layer(const shape3d &in_shape)
     : layer({vector_type::data}, {vector_type::data}), in_shape_(in_shape) {}
 
+  /**
+   * This constructor is suitable for adding an activation layer after
+   * 3D layers such as convolution / pooling layers.
+   *
+   * @param in_width    [in] number of input elements along width
+   * @param in_height   [in] number of input elements along height
+   * @param in_channels [in] number of channels (input elements along depth)
+   */
   activation_layer(serial_size_t in_width,
                    serial_size_t in_height,
                    serial_size_t in_channels)
     : layer({vector_type::data}, {vector_type::data}),
       in_shape_(in_width, in_height, in_channels) {}
 
-  activation_layer(serial_size_t dim)
-    : layer({vector_type::data}, {vector_type::data}), in_shape_(dim, 1, 1) {}
+  /**
+   * This constructor is suitable for adding an activation layer after
+   * 1D layers such as fully connected layers.
+   *
+   * @param in_dim      [in] number of elements of the input
+   */
+  activation_layer(serial_size_t in_dim)
+    : layer({vector_type::data}, {vector_type::data}),
+      in_shape_(in_dim, 1, 1) {}
 
   activation_layer(const layer &prev_layer)
     : layer({vector_type::data}, {vector_type::data}),
@@ -63,8 +78,24 @@ class activation_layer : public layer {
 
   virtual std::string layer_type() const = 0;
 
+  /**
+   * Populate vec_t of elements 'y' according to activation y = f(x).
+   * Child classes must override this method, apply activation function
+   * element wise over a vec_t of elements.
+   *
+   * @param x  input vector
+   * @param y  output vector (values to be assigned based on input)
+   **/
   virtual void forward_activation(const vec_t &x, vec_t &y) = 0;
 
+  /**
+   * Populate vec_t of elements 'dx' according to gradient of activation.
+   *
+   * @param x  input vector of current layer (same as forward_activation)
+   * @param y  output vector of current layer (same as forward_activation)
+   * @param dx gradient of input vectors (i-th element correspond with x[i])
+   * @param dy gradient of output vectors (i-th element correspond with y[i])
+   **/
   virtual void backward_activation(const vec_t x,
                                    const vec_t &y,
                                    vec_t &dx,

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include "tiny_dnn/layer/layer.h"
+#include "tiny_dnn/util/util.h"
+
+namespace tiny_dnn {
+
+class activation_layer : public layer {
+public:
+    /**
+     * @param in_shape [in] shape of input tensor
+     */
+    activation_layer(const shape3d &in_shape)
+            : layer({vector_type::data}, {vector_type::data}),
+              in_shape_(in_shape) {}
+
+    std::vector<shape3d> in_shape() const override {
+        return {in_shape_};
+    }
+
+    std::vector<shape3d> out_shape() const override {
+        return {in_shape_};
+    }
+
+    void forward_propagation(const std::vector<tensor_t *> &in_data,
+                             std::vector<tensor_t *> &out_data) {
+        const tensor_t &x = *in_data[0];
+        tensor_t &y       = *out_data[0];
+
+        for (serial_size_t i = 0; i < x.size(); i++) {
+            for (serial_size_t j = 0; j < x[i].size(); j++) {
+                forward_activation(x[i][j], y[i][j]);
+            }
+        }
+    }
+
+    void back_propagation(const std::vector<tensor_t *> &in_data,
+                          const std::vector<tensor_t *> &out_data,
+                          const std::vector<tensor_t *> &out_grad,
+                          std::vector<tensor_t *> &in_grad) override {
+        tensor_t &dx       = *in_grad[0];
+        const tensor_t &dy = *out_grad[0];
+        const tensor_t &x  = *in_data[0];
+        const tensor_t &y  = *out_data[0];
+
+        for (serial_size_t i = 0; i < x.size(); i++) {
+            for (serial_size_t j = 0; j < x[i].size(); j++) {
+                backward_activation(x, y, dx, dy);
+            }
+        }
+    }
+
+    virtual std::string layer_type() const = 0;
+
+    virtual void forward_activation(const float_t &x,
+                                    float_t &y) = 0;
+
+    virtual void backward_activation(const float_t x,
+                                     float_t &dx,
+                                     const float_t &y,
+                                     const float_t &dy) = 0;
+
+private:
+    shape3d in_shape_;
+
+};
+}  // namespace tiny_dnn

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -6,62 +6,51 @@
 namespace tiny_dnn {
 
 class activation_layer : public layer {
-public:
-    /**
-     * @param in_shape [in] shape of input tensor
-     */
-    activation_layer(const shape3d &in_shape)
-            : layer({vector_type::data}, {vector_type::data}),
-              in_shape_(in_shape) {}
+ public:
+  /**
+   * @param in_shape [in] shape of input tensor
+   */
+  activation_layer(const shape3d &in_shape)
+    : layer({vector_type::data}, {vector_type::data}), in_shape_(in_shape) {}
 
-    std::vector<shape3d> in_shape() const override {
-        return {in_shape_};
+  std::vector<shape3d> in_shape() const override { return {in_shape_}; }
+
+  std::vector<shape3d> out_shape() const override { return {in_shape_}; }
+
+  void forward_propagation(const std::vector<tensor_t *> &in_data,
+                           std::vector<tensor_t *> &out_data) {
+    const tensor_t &x = *in_data[0];
+    tensor_t &y       = *out_data[0];
+
+    for (serial_size_t i = 0; i < x.size(); i++) {
+      forward_activation(x[i], y[i]);
     }
+  }
 
-    std::vector<shape3d> out_shape() const override {
-        return {in_shape_};
+  void back_propagation(const std::vector<tensor_t *> &in_data,
+                        const std::vector<tensor_t *> &out_data,
+                        std::vector<tensor_t *> &out_grad,
+                        std::vector<tensor_t *> &in_grad) override {
+    tensor_t &dx       = *in_grad[0];
+    const tensor_t &dy = *out_grad[0];
+    const tensor_t &x  = *in_data[0];
+    const tensor_t &y  = *out_data[0];
+
+    for (serial_size_t i = 0; i < x.size(); i++) {
+      backward_activation(x[i], y[i], dx[i], dy[i]);
     }
+  }
 
-    void forward_propagation(const std::vector<tensor_t *> &in_data,
-                             std::vector<tensor_t *> &out_data) {
-        const tensor_t &x = *in_data[0];
-        tensor_t &y       = *out_data[0];
+  virtual std::string layer_type() const = 0;
 
-        for (serial_size_t i = 0; i < x.size(); i++) {
-            for (serial_size_t j = 0; j < x[i].size(); j++) {
-                forward_activation(x[i][j], y[i][j]);
-            }
-        }
-    }
+  virtual void forward_activation(const vec_t &x, vec_t &y) = 0;
 
-    void back_propagation(const std::vector<tensor_t *> &in_data,
-                          const std::vector<tensor_t *> &out_data,
-                          std::vector<tensor_t *> &out_grad,
-                          std::vector<tensor_t *> &in_grad) override {
-        tensor_t &dx       = *in_grad[0];
-        const tensor_t &dy = *out_grad[0];
-        const tensor_t &x  = *in_data[0];
-        const tensor_t &y  = *out_data[0];
+  virtual void backward_activation(const vec_t x,
+                                   const vec_t &y,
+                                   vec_t &dx,
+                                   const vec_t &dy) = 0;
 
-        for (serial_size_t i = 0; i < x.size(); i++) {
-            for (serial_size_t j = 0; j < x[i].size(); j++) {
-                backward_activation(x[i][j], y[i][j], dx[i][j], dy[i][j]);
-            }
-        }
-    }
-
-    virtual std::string layer_type() const = 0;
-
-    virtual void forward_activation(const float_t &x,
-                                    float_t &y) = 0;
-
-    virtual void backward_activation(const float_t x,
-                                     const float_t &y,
-                                     float_t &dx,
-                                     const float_t &dy) = 0;
-
-private:
-    shape3d in_shape_;
-
+ private:
+  shape3d in_shape_;
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -1,3 +1,10 @@
+/*
+    Copyright (c) 2017, Taiga Nomi, Karan Desai
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
 #pragma once
 
 #include "tiny_dnn/layers/layer.h"
@@ -12,6 +19,19 @@ class activation_layer : public layer {
    */
   activation_layer(const shape3d &in_shape)
     : layer({vector_type::data}, {vector_type::data}), in_shape_(in_shape) {}
+
+  activation_layer(serial_size_t in_width,
+                   serial_size_t in_height,
+                   serial_size_t in_channels)
+    : layer({vector_type::data}, {vector_type::data}),
+      in_shape_(in_width, in_height, in_channels) {}
+
+  activation_layer(serial_size_t dim)
+    : layer({vector_type::data}, {vector_type::data}), in_shape_(dim, 1, 1) {}
+
+  activation_layer(const layer &prev_layer)
+    : layer({vector_type::data}, {vector_type::data}),
+      in_shape_(prev_layer.out_shape()[0]) {}
 
   std::vector<shape3d> in_shape() const override { return {in_shape_}; }
 

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -1,3 +1,10 @@
+/*
+    Copyright (c) 2017, Taiga Nomi, Karan Desai
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
 #pragma once
 #include "tiny_dnn/activations/activation_layer.h"
 #include "tiny_dnn/layers/layer.h"

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -28,8 +28,8 @@ class relu_layer : public activation_layer {
                            vec_t &dx,
                            const vec_t &dy) {
     for (serial_size_t j = 0; j < x.size(); j++) {
-      float_t relu_grad = y[j] > float_t(0) ? float_t(1) : float_t(0);
-      dx[j]             = dy[j] * relu_grad;
+      // dx = dy * (gradient of relu)
+      dx[j] = dy[j] * (y[j] > float_t(0) ? float_t(1) : float_t(0));
     }
   }
 };

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -1,25 +1,29 @@
 #pragma once
-#include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/activations/activation_layer.h"
+#include "tiny_dnn/layers/layer.h"
 
 namespace tiny_dnn {
 
 class relu_layer : public activation_layer {
-public:
-    using activation_layer::activation_layer;
+ public:
+  using activation_layer::activation_layer;
 
-    std::string layer_type() const override {
-        return "relu-activation";
-    }
+  std::string layer_type() const override { return "relu-activation"; }
 
-    void forward_activation(const float_t &x, float_t &y) {
-        y = std::max(float_t(0), x);
+  void forward_activation(const vec_t &x, vec_t &y) {
+    for (serial_size_t j = 0; j < x.size(); j++) {
+      y[j] = std::max(float_t(0), x[j]);
     }
+  }
 
-    void backward_activation(const float_t x, const float_t &y,
-                             float_t &dx, const float_t &dy) {
-        float_t relu_grad = y > float_t(0) ? float_t(1) : float_t(0);
-        dx = dy * relu_grad;
+  void backward_activation(const vec_t x,
+                           const vec_t &y,
+                           vec_t &dx,
+                           const vec_t &dy) {
+    for (serial_size_t j = 0; j < x.size(); j++) {
+      float_t relu_grad = y[j] > float_t(0) ? float_t(1) : float_t(0);
+      dx[j]             = dy[j] * relu_grad;
     }
+  }
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -6,12 +6,7 @@ namespace tiny_dnn {
 
 class relu_layer : public activation_layer {
 public:
-    /**
-     * @param in_shape [in] shape of input tensor
-     */
-    relu_layer(const shape3d &in_shape)
-            : activation_layer(in_shape) {}
-
+    using activation_layer::activation_layer;
 
     std::string layer_type() const override {
         return "relu-activation";

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -1,4 +1,6 @@
-#include "tiny_dnn/layer/layer.h"
+#pragma once
+#include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/activations/activation_layer.h"
 
 namespace tiny_dnn {
 
@@ -19,8 +21,8 @@ public:
         y = std::max(float_t(0), x);
     }
 
-    void backward_activation(const float_t x, float_t &dx,
-                             const float_t &y, const float_t &dy) {
+    void backward_activation(const float_t x, const float_t &y,
+                             float_t &dx, const float_t &dy) {
         float_t relu_grad = y > float_t(0) ? float_t(1) : float_t(0);
         dx = dy * relu_grad;
     }

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -1,0 +1,28 @@
+#include "tiny_dnn/layer/layer.h"
+
+namespace tiny_dnn {
+
+class relu_layer : public activation_layer {
+public:
+    /**
+     * @param in_shape [in] shape of input tensor
+     */
+    relu_layer(const shape3d &in_shape)
+            : activation_layer(in_shape) {}
+
+
+    std::string layer_type() const override {
+        return "relu-activation";
+    }
+
+    void forward_activation(const float_t &x, float_t &y) {
+        y = std::max(float_t(0), x);
+    }
+
+    void backward_activation(const float_t x, float_t &dx,
+                             const float_t &y, const float_t &dy) {
+        float_t relu_grad = y > float_t(0) ? float_t(1) : float_t(0);
+        dx = dy * relu_grad;
+    }
+};
+}  // namespace tiny_dnn

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -36,6 +36,8 @@
 #include "tiny_dnn/layers/quantized_deconvolutional_layer.h"
 #include "tiny_dnn/layers/slice_layer.h"
 
+#include "tiny_dnn/activations/relu_layer.h"
+
 #ifdef CNN_USE_GEMMLOWP
 #include "tiny_dnn/layers/quantized_fully_connected_layer.h"
 #endif  // CNN_USE_GEMMLOWP


### PR DESCRIPTION
This PR sets up an initial playground for performing the decoupling of layers and activations. Passing tests on this PR give a green signal to build upwards on this piece of code.

### Scope of this PR:

1. `tiny_dnn::activation_layer` inheriting from `tiny_dnn::layer`. This class resides in **tiny_dnn/activations/activation_layer.h**.
2. `tiny_dnn::relu_layer` which inherits `tiny_dnn::activation_layer`.
3. Usage of this `relu_layer` in atleast one of the existing `gradient_check` tests of network, to see whether it fits in properly with other layers.

### About the design of activations as layers:

I have made a `class activation_layer : public layer`, which will be abstract base class for other activation classes - it has three virtual methods to override:
1. `layer_type` - that's the usual layer name.
2. `forward_activation` - this one takes in `vec_t` of input data (x) and `vec_t` of output data (y) as pass by references and fills in output data (y) by applying element wise activation function.
3. `backward_activation` - Same as `forward_activation`, but this one takes four `vec_t`s - input and output data, and their gradients. All will be of same length. This method uses gradients of output data (dy) and output data (y) to fill in gradients of input data (dx).

#### Note:
* `forward_activation` is similar to `tiny_dnn::activation::function::itef` method.
* `backward_activation` is similar to `tiny_dnn::activation::function::itedf` method.

After decoupling is complete, current classes in **tiny_dnn/activations/activation_function.h** can be removed safely.

Child classes (such as sigmoid, relu layers...) must override these three functions. Constructors, `in_shape`, `out_shape`, `forward_propagation` and `backward_propagation` are common for all kinds of "activation" layers only.

### After this PR:

1. Drop the activation templating from `fully_connected_layer` and make the tests pass with decoupled layers. (Might get tricky in terms of serialization code and backward compatibility.)
2. Later complete making all the current activations as layers.
3. Gradually start dropping templating from other existing layers. (Should be doable properly if (1) gave no pain!)
