### PR TITLE
Use pass-by-reference instead of pass-by-value in backward_activation.

### DIFF
--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -96,7 +96,7 @@ class activation_layer : public layer {
    * @param dx gradient of input vectors (i-th element correspond with x[i])
    * @param dy gradient of output vectors (i-th element correspond with y[i])
    **/
-  virtual void backward_activation(const vec_t x,
+  virtual void backward_activation(const vec_t &x,
                                    const vec_t &y,
                                    vec_t &dx,
                                    const vec_t &dy) = 0;

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -23,7 +23,7 @@ class relu_layer : public activation_layer {
     }
   }
 
-  void backward_activation(const vec_t x,
+  void backward_activation(const vec_t &x,
                            const vec_t &y,
                            vec_t &dx,
                            const vec_t &dy) {


### PR DESCRIPTION
Quickfix PR following #529. I passed a `vec_t` by value instead of reference in `activation_layer::backward_activation`. That hurts performance, hence rectified it.