### PR TITLE
Add an optional implementation of parallel_for using Grand Central Dispatch

### DIFF
--- a/tiny_dnn/config.h
+++ b/tiny_dnn/config.h
@@ -31,6 +31,11 @@
 // #define CNN_USE_OMP
 
 /**
+ * define to enable Grand Central Dispatch parallelization
+ */
+//#define CNN_USE_GCD
+
+/**
  * define to use exceptions
  */
 #define CNN_USE_EXCEPTIONS

--- a/tiny_dnn/util/parallel_for.h
+++ b/tiny_dnn/util/parallel_for.h
@@ -31,6 +31,10 @@
 #include <thread>
 #endif
 
+#if defined(CNN_USE_GCD) && !defined(CNN_SINGLE_THREAD)
+#include <dispatch/dispatch.h>
+#endif
+
 namespace tiny_dnn {
 
 #ifdef CNN_USE_TBB
@@ -80,6 +84,30 @@ template <typename Func>
 void parallel_for(int begin, int end, const Func &f, int /*grainsize*/) {
 #pragma omp parallel for
   for (int i = begin; i < end; ++i) f(blocked_range(i, i + 1));
+}
+
+#elif defined(CNN_USE_GCD)
+
+template<typename Func>
+void parallel_for(int begin, int end, const Func& f, int grainsize) {
+    int count = end - begin;
+    int blockSize = grainsize;
+    if (count < blockSize || blockSize == 0) {
+        blockSize = 1;
+    }
+    int blockCount = (count + blockSize - 1) / blockSize;
+    assert(blockCount > 0);
+    
+    dispatch_apply(blockCount, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^(size_t block) {
+        int blockStart = static_cast<int>(block*blockSize);
+        int blockEnd = blockStart + blockSize;
+        if (blockEnd > end) {
+            blockEnd = end;
+        }
+        assert(blockStart < blockEnd);
+        
+        f(blocked_range(blockStart,blockEnd));
+    });
 }
 
 #elif defined(CNN_SINGLE_THREAD)

--- a/tiny_dnn/util/parallel_for.h
+++ b/tiny_dnn/util/parallel_for.h
@@ -88,26 +88,27 @@ void parallel_for(int begin, int end, const Func &f, int /*grainsize*/) {
 
 #elif defined(CNN_USE_GCD)
 
-template<typename Func>
-void parallel_for(int begin, int end, const Func& f, int grainsize) {
-    int count = end - begin;
-    int blockSize = grainsize;
-    if (count < blockSize || blockSize == 0) {
-        blockSize = 1;
-    }
-    int blockCount = (count + blockSize - 1) / blockSize;
-    assert(blockCount > 0);
-    
-    dispatch_apply(blockCount, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0), ^(size_t block) {
-        int blockStart = static_cast<int>(block*blockSize);
-        int blockEnd = blockStart + blockSize;
-        if (blockEnd > end) {
-            blockEnd = end;
-        }
-        assert(blockStart < blockEnd);
-        
-        f(blocked_range(blockStart,blockEnd));
-    });
+template <typename Func>
+void parallel_for(int begin, int end, const Func &f, int grainsize) {
+  int count     = end - begin;
+  int blockSize = grainsize;
+  if (count < blockSize || blockSize == 0) {
+    blockSize = 1;
+  }
+  int blockCount = (count + blockSize - 1) / blockSize;
+  assert(blockCount > 0);
+
+  dispatch_apply(blockCount, dispatch_get_global_queue(QOS_CLASS_DEFAULT, 0),
+                 ^(size_t block) {
+                   int blockStart = static_cast<int>(block * blockSize);
+                   int blockEnd   = blockStart + blockSize;
+                   if (blockEnd > end) {
+                     blockEnd = end;
+                   }
+                   assert(blockStart < blockEnd);
+
+                   f(blocked_range(blockStart, blockEnd));
+                 });
 }
 
 #elif defined(CNN_SINGLE_THREAD)


### PR DESCRIPTION
This change adds a configurable option CNN_USE_GCD which if defined enables a version of parallel_for implemented by using Grand Central Dispatch. This runs a lot faster than the default implementation of parallel_for that uses std::async. 

I spend a lot of time training and experimenting with tiny-dnn on a Mac and being able to do the training more than twice as fast is quite valuable.

Some numbers from my machine (MacBook Pro 15-inch, 2016 2,9 GHz Intel Core i7)

examples/example_mnist_train data
GCD 		5 minutes 19 seconds
std::async      13 minutes 49 seconds

test/tiny_dnn_test
GCD		14.5 seconds
std::async	2 minutes 47 seconds
