### PR TITLE
Problem: Can't import DetectNet model from DIGITS. (#459)

### DIFF
--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -244,19 +244,23 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
   }
 
   if (w_pad != 0) {
-    if (w_pad == pool_size_w - 1 || w_pad == (pool_size_w - 1) / 2) {
+    if (w_pad == (pool_size_w - 1) / 2) {
       pad_type = padding::same;
     } else {
       throw nn_error("unsupported padding type");
     }
+    // NB: w_pad == pool_size_w - 1 could lead to pad_type = padding::full,
+    //     if such a type existed
   }
 
   if (h_pad != 0) {
-    if (h_pad == pool_size_h - 1 || h_pad == (pool_size_h - 1) / 2) {
+    if (h_pad == (pool_size_h - 1) / 2) {
       pad_type = padding::same;
     } else {
       throw nn_error("unsupported padding type");
     }
+    // NB: h_pad == pool_size_h - 1 could lead to pad_type = padding::full,
+    //     if such a type existed
   }
 
   if (pool_param.has_pool()) {

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -244,7 +244,7 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
   }
 
   if (w_pad != 0) {
-    if (w_pad == pool_size_w - 1) {
+    if (w_pad == pool_size_w - 1 || w_pad == (pool_size_w - 1) / 2) {
       pad_type = padding::same;
     } else {
       throw nn_error("unsupported padding type");
@@ -252,7 +252,7 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
   }
 
   if (h_pad != 0) {
-    if (h_pad == pool_size_h - 1) {
+    if (h_pad == pool_size_h - 1 || h_pad == (pool_size_h - 1) / 2) {
       pad_type = padding::same;
     } else {
       throw nn_error("unsupported padding type");


### PR DESCRIPTION
Solution: Relax the checks for padding::same.

No clue if this creates more problems than it fixes. That said, now the model can at least be imported.

I didn't really want to create a PR when I have barely tested at all, but then @bhack [encouraged](https://github.com/tiny-dnn/tiny-dnn/issues/459#issuecomment-278607710) me to do it nevertheless, so here we go.