### PR TITLE
Changes MNIST example output layer to softmax

### DIFF
--- a/examples/cifar10/train.cpp
+++ b/examples/cifar10/train.cpp
@@ -116,8 +116,8 @@ void train_cifar10(string data_dir_path, double learning_rate, ostream &log) {
 
 int main(int argc, char **argv) {
   if (argc != 3) {
-    cerr << "Usage : " << argv[0] << "arg[0]: path_to_data (example:../data)"
-         << "arg[1]: learning rate (example:0.01)" << endl;
+    cerr << "Usage : " << argv[0] << " path_to_data (example:../data)"
+         << " learning rate (example:0.01)" << endl;
     return -1;
   }
   train_cifar10(argv[1], stod(argv[2]), cout);

--- a/examples/mnist/test.cpp
+++ b/examples/mnist/test.cpp
@@ -47,7 +47,7 @@ void recognize(const std::string &dictionary, const std::string &src_filename) {
   vector<pair<double, int>> scores;
 
   // sort & print top-3
-  for (int i = 0; i < 10; i++) scores.emplace_back(rescale<tan_h>(res[i]), i);
+  for (int i = 0; i < 10; i++) scores.emplace_back(rescale<softmax>(res[i]), i);
 
   sort(scores.begin(), scores.end(), greater<pair<double, int>>());
 

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -51,7 +51,7 @@ static void construct_net(network<sequential>& nn) {
      << convolutional_layer<tan_h>(5, 5, 5, 16,
                                    120,  // C5, 16@5x5-in, 120@1x1-out
                                    padding::valid, true, 1, 1, backend_type)
-     << fully_connected_layer<tan_h>(120, 10,  // F6, 120-in, 10-out
+     << fully_connected_layer<softmax>(120, 10,  // F6, 120-in, 10-out
                                      true, backend_type);
 }
 


### PR DESCRIPTION
This changes the activation function of the last layer in the mnist example from tan_h to softmax.
The output of test results become more intuitive this way. Result accuracy verified in simulations.
Testing with bitmap sample verified as well. Complete test results attached.

accuracy:98.69% (9869/10000)
    *     0     1     2     3     4     5     6     7     8     9 
    0   973     0     0     0     0     3     4     0     5     0 
    1     0  1129     3     0     0     0     2     2     0     2 
    2     0     0  1021     2     2     0     1     7     1     1 
    3     0     0     0   998     0     5     1     1     2     2 
    4     0     0     1     0   973     0     3     0     2    11 
    5     1     1     0     4     0   882     4     0     1     4 
    6     2     2     1     0     2     2   941     0     0     1 
    7     1     0     1     4     1     0     0  1015     2     8 
    8     2     3     5     2     0     0     2     0   960     3 
    9     1     0     0     0     4     0     0     3     1   977 
./example_minist_test 4.bmp 
4,99.4535
7,0.23164
2,0.173432

[mnist_train_upstream.txt](https://github.com/tiny-dnn/tiny-dnn/files/769009/mnist_train_upstream.txt)
