### PR TITLE
Enhancement for MNIST test (Travis error #568)

### DIFF
--- a/examples/mnist/readme.md
+++ b/examples/mnist/readme.md
@@ -38,7 +38,7 @@ nn << convolutional_layer<tan_h>(32, 32, 5, 1, 6,  // C1, 1@32x32-in, 6@28x28-ou
    << average_pooling_layer<tan_h>(10, 10, 16, 2)  // S4, 16@10x10-in, 16@5x5-out
    << convolutional_layer<tan_h>(5, 5, 5, 16, 120, // C5, 16@5x5-in, 120@1x1-out
         padding::valid, true, 1, 1, backend_type)
-   << fully_connected_layer<tan_h>(120, 10,        // F6, 120-in, 10-out
+   << fully_connected_layer<softmax>(120, 10,        // F6, 120-in, 10-out
         true, backend_type)
 ```
 
@@ -145,7 +145,7 @@ static void construct_net(network<sequential>& nn) {
        << average_pooling_layer<tan_h>(10, 10, 16, 2)  // S4, 16@10x10-in, 16@5x5-out
        << convolutional_layer<tan_h>(5, 5, 5, 16, 120, // C5, 16@5x5-in, 120@1x1-out
             padding::valid, true, 1, 1, backend_type)
-       << fully_connected_layer<tan_h>(120, 10,        // F6, 120-in, 10-out
+       << fully_connected_layer<softmax>(120, 10,        // F6, 120-in, 10-out
             true, backend_type)
     ;
 }
@@ -274,7 +274,7 @@ void recognize(const std::string& dictionary, const std::string& filename) {
 
     // sort & print top-3
     for (int i = 0; i < 10; i++)
-        scores.emplace_back(rescale<tan_h>(res[i]), i);
+        scores.emplace_back(rescale<softmax>(res[i]), i);
 
     sort(scores.begin(), scores.end(), greater<pair<double, int>>());
 
@@ -313,9 +313,9 @@ Example image:
 Compile above code and try to pass 4.bmp, then you can get like:
 
 ```
-4,78.1403
-7,33.5718
-8,14.0017
+4,99.4535
+7,0.23164
+2,0.173432
 ```
 
 This means that the network predicted this image as "4", at confidence level of 78.1403%.

--- a/examples/mnist/readme.md
+++ b/examples/mnist/readme.md
@@ -318,7 +318,7 @@ Compile above code and try to pass 4.bmp, then you can get like:
 2,0.173432
 ```
 
-This means that the network predicted this image as "4", at confidence level of 78.1403%.
+This means that the network predicted this image as "4", at confidence level of 99.4535%.
 
 > Note:
 >

--- a/examples/mnist/test.cpp
+++ b/examples/mnist/test.cpp
@@ -47,7 +47,7 @@ void recognize(const std::string &dictionary, const std::string &src_filename) {
   vector<pair<double, int>> scores;
 
   // sort & print top-3
-  for (int i = 0; i < 10; i++) scores.emplace_back(rescale<tan_h>(res[i]), i);
+  for (int i = 0; i < 10; i++) scores.emplace_back(rescale<softmax>(res[i]), i);
 
   sort(scores.begin(), scores.end(), greater<pair<double, int>>());
 

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -52,7 +52,7 @@ static void construct_net(network<sequential>& nn) {
                                    120,  // C5, 16@5x5-in, 120@1x1-out
                                    padding::valid, true, 1, 1, backend_type)
      << fully_connected_layer<softmax>(120, 10,  // F6, 120-in, 10-out
-                                     true, backend_type);
+                                       true, backend_type);
 }
 
 static void train_lenet(const std::string& data_dir_path) {

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -51,7 +51,7 @@ static void construct_net(network<sequential>& nn) {
      << convolutional_layer<tan_h>(5, 5, 5, 16,
                                    120,  // C5, 16@5x5-in, 120@1x1-out
                                    padding::valid, true, 1, 1, backend_type)
-     << fully_connected_layer<tan_h>(120, 10,  // F6, 120-in, 10-out
+     << fully_connected_layer<softmax>(120, 10,  // F6, 120-in, 10-out
                                      true, backend_type);
 }
 


### PR DESCRIPTION
This changes the activation function of the last layer in the mnist example from tan_h to softmax.
The output of test results become more intuitive this way. Result accuracy verified in simulations.
Testing with bitmap sample verified as well. Complete test results attached.

accuracy:98.69% (9869/10000)
* 0 1 2 3 4 5 6 7 8 9
0 973 0 0 0 0 3 4 0 5 0
1 0 1129 3 0 0 0 2 2 0 2
2 0 0 1021 2 2 0 1 7 1 1
3 0 0 0 998 0 5 1 1 2 2
4 0 0 1 0 973 0 3 0 2 11
5 1 1 0 4 0 882 4 0 1 4
6 2 2 1 0 2 2 941 0 0 1
7 1 0 1 4 1 0 0 1015 2 8
8 2 3 5 2 0 0 2 0 960 3
9 1 0 0 0 4 0 0 3 1 977
./example_minist_test 4.bmp
4,99.4535
7,0.23164
2,0.173432

[mnist_train_upstream.txt](https://github.com/tiny-dnn/tiny-dnn/files/769026/mnist_train_upstream.txt)
#568