### PR TITLE
MNIST enhanced performance. Faster convergence, better score

### DIFF
--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -79,7 +79,7 @@ static void train_lenet(const std::string& data_dir_path) {
 
   progress_display disp(static_cast<unsigned long>(train_images.size()));
   timer t;
-  int minibatch_size = 10;
+  int minibatch_size = 16;
   int num_epochs     = 30;
 
   optimizer.alpha *= static_cast<tiny_dnn::float_t>(std::sqrt(minibatch_size));

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -82,7 +82,9 @@ static void train_lenet(const std::string& data_dir_path) {
   int minibatch_size = 16;
   int num_epochs     = 30;
 
-  optimizer.alpha *= static_cast<tiny_dnn::float_t>(std::sqrt(minibatch_size));
+  optimizer.alpha *=
+    std::min(tiny_dnn::float_t(4),
+             static_cast<tiny_dnn::float_t>(std::sqrt(minibatch_size)));
 
   // create callback
   auto on_enumerate_epoch = [&]() {


### PR DESCRIPTION
This patch credit goes to @beru in my experiments with the activation function in the last layer of the network. This is just a one line patch in the training file for the MNIST example that does not touch the network configuration. It only changes the batch size from 10 to 16. 

Convergence is at least 10% faster in my AMD Quad-Core A6 with SSE and TBB enabled.
Final classification accuracy is 99.11%. Results attached.

It appears that AVX must be disabled in order to achieve the above classification  accuracy. Thanks.

[mninst-train-batch16.txt](https://github.com/tiny-dnn/tiny-dnn/files/769672/mninst-train-batch16.txt)

Added one more patch to address the issue of users testing larger mini-batch sizes #538 
The current training code for MNIST example scales the learning rate of the optimizer by the
square root of the mini-batch size. This negatively impacts the convergence if the batch size is large. The first patch in this pull changed the batch size to 16 with positive results. Hence 
the limiting factor has been changed to the minimum of sqrt(16)=4 and the square root of the mini-batch size. Thanks.