### PR TITLE
Serialization of activation layers.

### DIFF
--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -317,14 +317,39 @@ TEST(serialization, serialize_slice) {
   EXPECT_EQ(net[0]->out_shape()[1], shape3d(3, 2, 1));
 }
 
-TEST(serialization, serialize_relu) {
+TEST(serialization, serialize_sigmoid) {
   network<sequential> net;
 
   std::string json = R"(
     {
         "nodes": [
             {
-                "type": "relu",
+                "type": "sigmoid",
+                "in_size" : {
+                    "width": 3,
+                    "height" : 2,
+                    "depth" : 1
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "sigmoid-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(3, 2, 1));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(3, 2, 1));
+}
+
+TEST(serialization, serialize_tanh) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "tanh",
                 "in_size" : {
                     "width": 20,
                     "height" : 20,
@@ -337,9 +362,109 @@ TEST(serialization, serialize_relu) {
 
   net.from_json(json);
 
-  EXPECT_EQ(net[0]->layer_type(), "relu-activation");
+  EXPECT_EQ(net[0]->layer_type(), "tanh-activation");
   EXPECT_EQ(net[0]->in_shape()[0], shape3d(20, 20, 10));
   EXPECT_EQ(net[0]->out_shape()[0], shape3d(20, 20, 10));
+}
+
+TEST(serialization, serialize_softmax) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "softmax",
+                "in_size" : {
+                    "width": 1000,
+                    "height" : 1,
+                    "depth" : 1
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "softmax-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(1000, 1, 1));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(1000, 1, 1));
+}
+
+TEST(serialization, serialize_leaky_relu) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "leaky_relu",
+                "in_size" : {
+                    "width": 256,
+                    "height" : 256,
+                    "depth" : 1
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "leaky-relu-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(256, 256, 1));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(256, 256, 1));
+}
+
+TEST(serialization, serialize_elu) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "elu",
+                "in_size" : {
+                    "width": 10,
+                    "height" : 10,
+                    "depth" : 3
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "elu-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(10, 10, 3));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(10, 10, 3));
+}
+
+TEST(serialization, serialize_tanh_p1m2) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "tanh_scaled",
+                "in_size" : {
+                    "width": 5,
+                    "height" : 10,
+                    "depth" : 1
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "tanh-scaled-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(5, 10, 1));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(5, 10, 1));
 }
 
 TEST(serialization, sequential_to_json) {

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -317,6 +317,31 @@ TEST(serialization, serialize_slice) {
   EXPECT_EQ(net[0]->out_shape()[1], shape3d(3, 2, 1));
 }
 
+TEST(serialization, serialize_relu) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "relu",
+                "in_size" : {
+                    "width": 20,
+                    "height" : 20,
+                    "depth" : 10
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "relu-activation");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(20, 20, 10));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(20, 20, 10));
+}
+
 TEST(serialization, sequential_to_json) {
   network<sequential> net1, net2;
 

--- a/tiny_dnn/activations/elu_layer.h
+++ b/tiny_dnn/activations/elu_layer.h
@@ -36,5 +36,9 @@ class elu_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0.1), float_t(0.9));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/leaky_relu_layer.h
+++ b/tiny_dnn/activations/leaky_relu_layer.h
@@ -36,5 +36,9 @@ class leaky_relu_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0.1), float_t(0.9));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/relu_layer.h
+++ b/tiny_dnn/activations/relu_layer.h
@@ -36,5 +36,9 @@ class relu_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0.1), float_t(0.9));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/sigmoid_layer.h
+++ b/tiny_dnn/activations/sigmoid_layer.h
@@ -36,5 +36,9 @@ class sigmoid_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0.1), float_t(0.9));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/softmax_layer.h
+++ b/tiny_dnn/activations/softmax_layer.h
@@ -53,5 +53,9 @@ class softmax_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0), float_t(1));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/tanh_layer.h
+++ b/tiny_dnn/activations/tanh_layer.h
@@ -36,5 +36,9 @@ class tanh_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(-0.8), float_t(0.8));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/activations/tanh_p1m2_layer.h
+++ b/tiny_dnn/activations/tanh_p1m2_layer.h
@@ -38,5 +38,9 @@ class tanh_p1m2_layer : public activation_layer {
   std::pair<float_t, float_t> scale() const override {
     return std::make_pair(float_t(0.1), float_t(0.9));
   }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -243,10 +243,82 @@ struct LoadAndConstruct<tiny_dnn::slice_layer> {
 };
 
 template <>
+struct LoadAndConstruct<tiny_dnn::sigmoid_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::sigmoid_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
+struct LoadAndConstruct<tiny_dnn::tanh_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::tanh_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
 struct LoadAndConstruct<tiny_dnn::relu_layer> {
   template <class Archive>
   static void load_and_construct(
     Archive& ar, cereal::construct<tiny_dnn::relu_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
+struct LoadAndConstruct<tiny_dnn::softmax_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::softmax_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
+struct LoadAndConstruct<tiny_dnn::leaky_relu_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::leaky_relu_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
+struct LoadAndConstruct<tiny_dnn::elu_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::elu_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
+template <>
+struct LoadAndConstruct<tiny_dnn::tanh_p1m2_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::tanh_p1m2_layer>& construct) {
     tiny_dnn::shape3d in_shape;
 
     ar(cereal::make_nvp("in_size", in_shape));
@@ -321,7 +393,37 @@ struct specialize<Archive,
 
 template <class Archive>
 struct specialize<Archive,
+                  tiny_dnn::sigmoid_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::tanh_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
                   tiny_dnn::relu_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::softmax_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::leaky_relu_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::elu_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::tanh_p1m2_layer,
                   cereal::specialization::non_member_serialize> {};
 
 }  // namespace cereal
@@ -461,7 +563,43 @@ struct serialization_buddy {
   }
 
   template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::sigmoid_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::tanh_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
   static inline void serialize(Archive& ar, tiny_dnn::relu_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::softmax_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::leaky_relu_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::elu_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::tanh_p1m2_layer& layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
   }
@@ -534,10 +672,38 @@ void serialize(Archive& ar, tiny_dnn::slice_layer& layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-// SERIALIZATION FUNCTIONS FOR ACTIVATION LAYERS -----------------------------
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::sigmoid_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::tanh_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
 
 template <class Archive>
 void serialize(Archive& ar, tiny_dnn::relu_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::softmax_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::leaky_relu_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::elu_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::tanh_p1m2_layer& layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -242,6 +242,18 @@ struct LoadAndConstruct<tiny_dnn::slice_layer> {
   }
 };
 
+template <>
+struct LoadAndConstruct<tiny_dnn::relu_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive& ar, cereal::construct<tiny_dnn::relu_layer>& construct) {
+    tiny_dnn::shape3d in_shape;
+
+    ar(cereal::make_nvp("in_size", in_shape));
+    construct(in_shape);
+  }
+};
+
 template <class Archive>
 struct specialize<Archive,
                   tiny_dnn::elementwise_add_layer,
@@ -305,6 +317,11 @@ struct specialize<Archive,
 template <class Archive>
 struct specialize<Archive,
                   tiny_dnn::slice_layer,
+                  cereal::specialization::non_member_serialize> {};
+
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::relu_layer,
                   cereal::specialization::non_member_serialize> {};
 
 }  // namespace cereal
@@ -442,6 +459,12 @@ struct serialization_buddy {
        cereal::make_nvp("slice_type", layer.slice_type_),
        cereal::make_nvp("num_outputs", layer.num_outputs_));
   }
+
+  template <class Archive>
+  static inline void serialize(Archive& ar, tiny_dnn::relu_layer& layer) {
+    layer.serialize_prolog(ar);
+    ar(cereal::make_nvp("in_size", layer.in_shape()[0]));
+  }
 };
 
 template <class Archive>
@@ -508,6 +531,13 @@ void serialize(Archive& ar, tiny_dnn::power_layer& layer) {
 
 template <class Archive>
 void serialize(Archive& ar, tiny_dnn::slice_layer& layer) {
+  serialization_buddy::serialize(ar, layer);
+}
+
+// SERIALIZATION FUNCTIONS FOR ACTIVATION LAYERS -----------------------------
+
+template <class Archive>
+void serialize(Archive& ar, tiny_dnn::relu_layer& layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -15,4 +15,6 @@ CNN_REGISTER_LAYER(power_layer, power);
 CNN_REGISTER_LAYER(slice_layer, slice);
 CNN_REGISTER_LAYER(elementwise_add_layer, elementwise_add);
 
+CNN_REGISTER_LAYER(relu_layer, relu);
+
 #endif

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -15,6 +15,12 @@ CNN_REGISTER_LAYER(power_layer, power);
 CNN_REGISTER_LAYER(slice_layer, slice);
 CNN_REGISTER_LAYER(elementwise_add_layer, elementwise_add);
 
+CNN_REGISTER_LAYER(sigmoid_layer, sigmoid);
+CNN_REGISTER_LAYER(tanh_layer, tanh);
 CNN_REGISTER_LAYER(relu_layer, relu);
+CNN_REGISTER_LAYER(softmax_layer, softmax);
+CNN_REGISTER_LAYER(leaky_relu_layer, leaky_relu);
+CNN_REGISTER_LAYER(elu_layer, elu);
+CNN_REGISTER_LAYER(tanh_p1m2_layer, tanh_scaled);
 
 #endif


### PR DESCRIPTION
This PR is a part of series of PRs made for decoupling activation templates and layers. It is a succession of unmerged #573 but is meant to be merged before #573 for that to work smoothly.

### Scope of this PR:

* Serialize existing activation layers. An example of JSON output of an activation layer looks like this:
```json
"type": "tanh"
"in_size": {
    "width": 256,
    "height": 256,
    "depth": 3
}
```

* Appropriate functions have been added in a friend struct named `serialization_buddy` and these new activation layers have been registered in **serialization_layer_list.h** using `CNN_REGISTER_LAYER` macro.
* Corresponding tests have been added.

### Further Work:

* Cereal docs are a little bit complicated, but they mention on serializing objects from classes having supporting polymorphic relationship. This may help in reducing the code duplication, but it time consuming so can be taken up after decoupling, as the serialization code is yet to be changed a lot.

* Once this is in place, get #573 merged.