### PR TITLE
Fixes Cifar-10 readme.md dimensionality.

### DIFF
--- a/examples/cifar10/readme.md
+++ b/examples/cifar10/readme.md
@@ -1,7 +1,7 @@
 # Cifar-10 Classification Example
 
 [Cifar-10](http://www.cs.toronto.edu/~kriz/cifar.html) is a common dataset for object classification.
-The problem is to classify 32x32 RGB (thus 32x32x3=1024 dimensions) image into 10 classes:
+The problem is to classify 32x32 RGB (thus 32x32x3=3072 dimensions) image into 10 classes:
 airplane, automobile, bird, cat, deer, dog, frog, horse, ship, and truck. 
 
 This problem is more complex than [MNIST](http://yann.lecun.com/exdb/mnist/) classification task.


### PR DESCRIPTION
The input size for this problem are 32x32 pixels frames of depth 3 (RGB).
Fixes the calculation of dimensions in this problem from 1024 to 32x32x3=3072.
The formula 32x32x3 is correct but the result is not.

Thanks.