### PR TITLE
Cifar-10 example. Removes OpenCV req. Add entry in CMakeLists…(#491)

### DIFF
--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -45,6 +45,10 @@ add_executable(example_cifar_train cifar10/train.cpp ${tiny_dnn_headers})
 target_link_libraries(example_cifar_train
     ${project_library_target_name} ${REQUIRED_LIBRARIES})
 
+add_executable(example_cifar_test cifar10/test.cpp ${tiny_dnn_headers})
+target_link_libraries(example_cifar_test
+    ${project_library_target_name} ${REQUIRED_LIBRARIES})
+
 if(PROTO_CPP_AVAILABLE)
     include_directories(${PROTOBUF_INCLUDE_DIRS})
     set_source_files_properties(${proto_file} PROPERTIES GENERATED TRUE)

--- a/examples/cifar10/test.cpp
+++ b/examples/cifar10/test.cpp
@@ -20,12 +20,12 @@ void convert_image(const std::string &imagefilename,
                    vec_t &data) {
   image<> img(imagefilename, image_type::rgb);
   image<> resized = resize_image(img, w, h);
-  data.resize(w * h * 3);
-  for (int c = 0; c < 3; ++c) {
-    for (int y = 0; y < w; ++y) {
-      for (int x = 0; x < h; ++x) {
-        data[c * w * h + y * w + x] =
-          (maxv - minv) * (resized[y * w + x + c]) / 255.0 + minv;
+  data.resize(resized.width() * resized.height() * resized.depth());
+  for (size_t c = 0; c < resized.depth(); ++c) {
+    for (size_t y = 0; y < resized.height(); ++y) {
+      for (size_t x = 0; x < resized.width(); ++x) {
+        data[c * resized.width() * resized.height() + y * resized.width() + x] =
+          (maxv - minv) * (resized[y * resized.width() + x + c]) / 255.0 + minv;
       }
     }
   }

--- a/examples/cifar10/test.cpp
+++ b/examples/cifar10/test.cpp
@@ -24,8 +24,8 @@ void convert_image(const std::string &imagefilename,
   for (int c = 0; c < 3; ++c) {
     for (int y = 0; y < w; ++y) {
       for (int x = 0; x < h; ++x) {
-        data[c * w * h + y * w + x] +=
-          (maxv - minv) * (data[y * w + x + c]) / 255.0 + minv;
+        data[c * w * h + y * w + x] =
+          (maxv - minv) * (resized[y * w + x + c]) / 255.0 + minv;
       }
     }
   }

--- a/examples/cifar10/test.cpp
+++ b/examples/cifar10/test.cpp
@@ -20,8 +20,15 @@ void convert_image(const std::string &imagefilename,
                    vec_t &data) {
   image<> img(imagefilename, image_type::rgb);
   image<> resized = resize_image(img, w, h);
-  std::transform(resized.begin(), resized.end(), std::back_inserter(data),
-                 [=](uint8_t c) { return c * (maxv - minv) / 255.0 + minv; });
+  data.resize(w * h * 3);
+  for (int c = 0; c < 3; ++c) {
+    for (int y = 0; y < w; ++y) {
+      for (int x = 0; x < h; ++x) {
+        data[c * w * h + y * w + x] +=
+          (maxv - minv) * (data[y * w + x + c]) / 255.0 + minv;
+      }
+    }
+  }
 }
 
 template <typename N>

--- a/examples/cifar10/test.cpp
+++ b/examples/cifar10/test.cpp
@@ -1,8 +1,4 @@
 #include <iostream>
-#include <opencv2/opencv.hpp>
-/*#include <opencv2/imgproc.hpp>
-#include <opencv2/highgui.hpp>*/
-#include <opencv2/imgcodecs.hpp>
 #include "tiny_dnn/tiny_dnn.h"
 
 using namespace tiny_dnn;
@@ -22,19 +18,10 @@ void convert_image(const std::string &imagefilename,
                    int w,
                    int h,
                    vec_t &data) {
-  cv::Mat img = cv::imread(imagefilename);
-  if (img.data == nullptr) return;  // cannot open, or it's not an image
-  cv::Mat resized;
-  cv::resize(img, resized, cv::Size(w, h), .0, .0);
-  data.resize(w * h * resized.channels(), minv);
-  for (int c = 0; c < resized.channels(); ++c) {
-    for (int y = 0; y < resized.rows; ++y) {
-      for (int x = 0; x < resized.cols; ++x) {
-        data[c * w * h + y * w + x] =
-          resized.data[y * resized.step[0] + x * resized.step[1] + c];
-      }
-    }
-  }
+  image<> img(imagefilename, image_type::rgb);
+  image<> resized = resize_image(img, w, h);
+  std::transform(resized.begin(), resized.end(), std::back_inserter(data),
+                 [=](uint8_t c) { return c * (maxv - minv) / 255.0 + minv; });
 }
 
 template <typename N>
@@ -55,7 +42,7 @@ void construct_net(N &nn) {
      << fully_connected_layer<softmax>(n_fc, 10);
 }
 
-void recognize(const std::string &dictionary, const std::string &filename) {
+void recognize(const std::string &dictionary, const std::string &src_filename) {
   network<sequential> nn;
 
   construct_net(nn);
@@ -66,7 +53,7 @@ void recognize(const std::string &dictionary, const std::string &filename) {
 
   // convert imagefile to vec_t
   vec_t data;
-  convert_image(filename, -1.0, 1.0, 32, 32, data);
+  convert_image(src_filename, -1.0, 1.0, 32, 32, data);
 
   // recognize
   auto res = nn.predict(data);


### PR DESCRIPTION
This patch addresses #491 

* It removes the requirement of OpenCV to build the test example for cifar10.
* It adds an entry in CMakesList.txt so that the executable is actually built (it wasn't before, at least on ubuntu).

OpenCV is used in the version prior this patch to convert images from the user input to tiny-dnn vector. The same functionality is present in MNIST test, which uses tiny-dnn native image converter. Therefore OpenCV was replaced by the native version. 

In addition:

* The input range is properly normalized. The previous version was discarding the maxv value. 
* Minor refactoring to make it consistent with MNIST test variables.

The resulting binary was tested and functional with arbitrary images given to it as input. <del> Needs additional tests after RGB deinterleaving.</del>

The attached image shows the output in the first layer when an arbitrary image of a horse from the web is given to the input. No typical signs of interlacing such as aliasing or other issues related to RGB deinterleaving is present.

![layer_0](https://cloud.githubusercontent.com/assets/23116478/23088414/1255d554-f531-11e6-9d38-28c4d28ea016.png)

Thanks.