### PR TITLE
Caffe converter: support ELU activation, skip HDF5Data layers

### DIFF
--- a/examples/caffe_converter/caffe_converter.cpp
+++ b/examples/caffe_converter/caffe_converter.cpp
@@ -31,6 +31,7 @@ SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include <memory>
 #define NO_STRICT
 #define CNN_USE_CAFFE_CONVERTER
+#define DNN_USE_IMAGE_API
 #include "tiny_dnn/tiny_dnn.h"
 
 using namespace tiny_dnn;

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -286,6 +286,14 @@ inline std::shared_ptr<layer> create_relu(const caffe::LayerParameter &layer,
   return relu;
 }
 
+inline std::shared_ptr<layer> create_elu(const caffe::LayerParameter &layer,
+                                          const shape_t &bottom_shape,
+                                          shape_t *) {
+  auto elu =
+    std::make_shared<linear_layer<activation::elu>>(bottom_shape.size());
+  return elu;
+}
+
 inline std::shared_ptr<layer> create_batchnorm(
   const caffe::LayerParameter &layer,
   const shape_t &bottom_shape,
@@ -725,7 +733,7 @@ inline std::shared_ptr<layer> create_deconvlayer(
 }
 
 inline bool layer_skipped(const std::string &type) {
-  if (type == "Data" || type == "EuclideanLoss" || type == "Input") return true;
+  if (type == "Data" || type == "EuclideanLoss" || type == "Input" || type == "HDF5Data") return true;
   return false;
 }
 
@@ -735,6 +743,7 @@ inline bool layer_has_weights(const std::string &type) {
                                       "LRN",
                                       "Dropout",
                                       "ReLU",
+                                      "ELU",
                                       "Sigmoid",
                                       "TanH",
                                       "Softmax"};
@@ -755,6 +764,7 @@ inline bool layer_supported(const std::string &type) {
                                     "SoftmaxWithLoss",
                                     "SigmoidCrossEntropyLoss",
                                     "ReLU",
+                                    "ELU",
                                     "Sigmoid",
                                     "TanH",
                                     "Softmax",
@@ -825,6 +835,10 @@ inline std::shared_ptr<layer> create(const caffe::LayerParameter &layer,
 
   if (layer_type == "ReLU") {
     return detail::create_relu(layer, in_shape, out_shape);
+  }
+
+  if (layer_type == "ELU") {
+    return detail::create_elu(layer, in_shape, out_shape);
   }
 
   if (layer_type == "TanH") {

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -287,8 +287,8 @@ inline std::shared_ptr<layer> create_relu(const caffe::LayerParameter &layer,
 }
 
 inline std::shared_ptr<layer> create_elu(const caffe::LayerParameter &layer,
-                                          const shape_t &bottom_shape,
-                                          shape_t *) {
+                                         const shape_t &bottom_shape,
+                                         shape_t *) {
   auto elu =
     std::make_shared<linear_layer<activation::elu>>(bottom_shape.size());
   return elu;
@@ -733,7 +733,9 @@ inline std::shared_ptr<layer> create_deconvlayer(
 }
 
 inline bool layer_skipped(const std::string &type) {
-  if (type == "Data" || type == "EuclideanLoss" || type == "Input" || type == "HDF5Data") return true;
+  if (type == "Data" || type == "EuclideanLoss" || type == "Input" ||
+      type == "HDF5Data")
+    return true;
   return false;
 }
 


### PR DESCRIPTION
This PR adds ELU activation support and skips HDF5Data layers when importing caffe model.
It also fixes a build failure (using image functions required DNN_USE_IMAGE_API).
