### PR TITLE
Fixes loading weights when built with MinGW-w64 on Windows.

### DIFF
--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -27,7 +27,7 @@
 
 typedef tiny_dnn::shape3d shape_t;
 
-#ifdef _MSC_VER
+#if defined(_MSC_VER) || defined(WIN32)
 #define _NOMINMAX
 #include <fcntl.h>
 #include <io.h>


### PR DESCRIPTION
This PR fixes a specific issue with caffe converter which I was having when deploying my model to Windows (building with MinGW). The code worked fine on Linux, yet the inference failed with zero output vector on Windows (on same input).

I debugged it to almost empty protobuf::caffe::NetParameter and (after trying out different protobuf versions) I realized that only part of the weights file is being read. I traced it back to O_BINARY not being passed to open().