### PR TITLE
caffe converter: add support for loading BatchNorm from trained model

### DIFF
--- a/test/test_caffe_converter.h
+++ b/test/test_caffe_converter.h
@@ -6,6 +6,7 @@
     in the LICENSE file.
 */
 #pragma once
+#include <sstream>
 #include "gtest/gtest.h"
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
@@ -908,6 +909,121 @@ TEST(caffe_converter, fully_with_weights) {
   EXPECT_EQ(b->size(), size_t(2));
   EXPECT_FLOAT_EQ(b->at(0), 8.0f);
   EXPECT_FLOAT_EQ(b->at(1), 9.0f);
+}
+
+TEST(caffe_converter, load_weights_batchnorm) {
+  /*
+   * This test case tests detail::load_weights_batchnorm which is a low-level
+   * function that loads weights from caffe batchnorm layer into tiny_dnn bn
+   * layer
+   *
+   * caffe stores batch normalization statistics as three blobs/arrays
+   * 0: mean (size = num-channels)
+   * 1: variance (size = num-channels)
+   * 2: inverse of scale factor (size = 1)
+   *
+   * This test case tests 3 channel input layer
+   */
+
+  caffe::LayerParameter lp;
+  caffe::BlobProto *mb = lp.add_blobs();  // mean blob
+  mb->add_data(0.0f);
+  mb->add_data(-1.0f);
+  mb->add_data(1.0f);
+
+  caffe::BlobProto *vb = lp.add_blobs();  // variance blob
+  vb->add_data(0.0f);
+  vb->add_data(1.0f);
+  vb->add_data(1.0f);
+
+  caffe::BlobProto *sf = lp.add_blobs();  // scale factor
+  sf->add_data(1.0f);
+
+  // create tiny-dnn layer
+  batch_normalization_layer dst_layer(1, 3);
+
+  // load weights for dst_layer from caffe layer
+  detail::load_weights_batchnorm(lp, &dst_layer);
+
+  // easiest way to access the weights of batchnorm layer seems to be save()
+  std::ostringstream ser_buf;
+  dst_layer.save(ser_buf);
+
+  EXPECT_EQ(ser_buf.str(), "0 -1 1 0 1 1 ");
+}
+
+TEST(caffe_converter, batchnorm_load_weight_from_caffe_protobinary) {
+  /**
+   * This test case verifies that given caffe model and matching protobinary
+   * weights, the resulting tiny_dnn batchnorm layer has loaded the weights.
+   */
+  std::string json = R"(
+    name: "BNNet"
+    input: "data"
+    input_shape {
+      dim: 1
+      dim: 1
+      dim: 10
+      dim: 10
+    }
+    layer {
+      name: "conv1"
+      type: "Convolution"
+      bottom: "data"
+      top: "conv1"
+      convolution_param {
+        num_output: 3
+        kernel_size: 3
+      }
+    }
+    layer {
+      name: "bn1"
+      type: "BatchNorm"
+      bottom: "conv1"
+      top: "bn1"
+    }
+)";
+  auto model       = create_net_from_json(json);
+
+  // there should be two tiny_dnn layers
+  EXPECT_EQ(model->depth(), 2);
+
+  EXPECT_EQ((*model)[0]->layer_type(), "conv");
+  EXPECT_EQ((*model)[1]->layer_type(), "batch-norm");
+  // construct caffe network
+  caffe::NetParameter np;
+  // create BN layer
+  caffe::LayerParameter *lp = np.add_layer();
+  lp->set_type("BatchNorm");
+  // assign batchnorm statistics
+  caffe::BlobProto *mb = lp->add_blobs();  // mean blob
+  mb->add_data(0.0f);
+  mb->add_data(-1.0f);
+  mb->add_data(1.0f);
+
+  caffe::BlobProto *vb = lp->add_blobs();  // variance blob
+  vb->add_data(0.0f);
+  vb->add_data(1.0f);
+  vb->add_data(1.0f);
+
+  caffe::BlobProto *sf = lp->add_blobs();  // scale factor
+  sf->add_data(1.0f);
+
+  // serialize it to protobinary format (tmp file)
+  std::string tmp_file_path = unique_path();
+  {
+    std::ofstream ofs(tmp_file_path.c_str());
+    np.SerializeToOstream(&ofs);
+  }
+
+  // load weights from protobinary file to model
+  reload_weight_from_caffe_protobinary(tmp_file_path, model.get());
+  // remove tmp file
+  std::remove(tmp_file_path.c_str());
+  // easiest way to access the weights of batchnorm layer seems to be save()
+  std::ostringstream ser_buf;
+  (*model)[1]->save(ser_buf);
+  EXPECT_EQ(ser_buf.str(), "0 -1 1 0 1 1 ");
 }
 
 }  // namespace tiny-dnn


### PR DESCRIPTION
Currently caffe converter supports creating BatchNorm layer from prototxt file. However, it did not support loading this weights for this layer from protobinary file.

This PR adds the missing support.

Also, it adds Accuracy and Split layer types to be ignored- they are present in the protobinary file but are not relevant for reconstructing the net.