### PR TITLE
Drop activation template from max_pooling_layer.

### DIFF
--- a/examples/cifar10/readme.md
+++ b/examples/cifar10/readme.md
@@ -20,7 +20,7 @@ This means network architecture for Cifar-10 tends to be larger (or/and deeper) 
 network<cross_entropy, adam> nn;
 
 using conv    = convolutional_layer;
-using pool    = max_pooling_layer<identity>;
+using pool    = max_pooling_layer;
 using fc      = fully_connected_layer;
 using relu    = relu_layer;
 using softmax = softmax_layer;
@@ -79,7 +79,7 @@ using namespace tiny_dnn::activation;
 template <typename N>
 void construct_net(N& nn, core::backend_t backend_type) {
     using conv = convolutional_layer;
-    using pool = max_pooling_layer<identity>;
+    using pool = max_pooling_layer;
     using fc = fully_connected_layer;
     using relu = relu_layer;
     using softmax = softmax_layer;

--- a/examples/cifar10/test.cpp
+++ b/examples/cifar10/test.cpp
@@ -34,7 +34,7 @@ void convert_image(const std::string &imagefilename,
 template <typename N>
 void construct_net(N &nn) {
   using conv    = convolutional_layer;
-  using pool    = max_pooling_layer<identity>;
+  using pool    = max_pooling_layer;
   using fc      = fully_connected_layer;
   using relu    = relu_layer;
   using softmax = softmax_layer;

--- a/examples/cifar10/train.cpp
+++ b/examples/cifar10/train.cpp
@@ -37,7 +37,7 @@ using namespace tiny_dnn::activation;
 template <typename N>
 void construct_net(N &nn, core::backend_t backend_type) {
   using conv    = convolutional_layer;
-  using pool    = max_pooling_layer<identity>;
+  using pool    = max_pooling_layer;
   using fc      = fully_connected_layer;
   using relu    = relu_layer;
   using softmax = softmax_layer;

--- a/examples/deconv/train.cpp
+++ b/examples/deconv/train.cpp
@@ -141,7 +141,8 @@ void enet(network<graph> &nn,
   input_layer ii0(shape3d(32, 32, 1));
   convolutional_layer ic1(32, 32, 3, 1, 8, padding::same, true, 2, 2);
   tanh_layer ic1_tanh(16, 16, 8);
-  max_pooling_layer<tan_h> ip1(32, 32, 1, 2);
+  max_pooling_layer ip1(32, 32, 1, 2);
+  tanh_layer ip1_tanh(16, 16, 1);
   convolutional_layer ic2(16, 16, 1, 1, 8, padding::same);
   tanh_layer ic2_tanh(16, 16, 8);
   concat_layer icc1(2, 16 * 16 * 8);
@@ -149,13 +150,15 @@ void enet(network<graph> &nn,
   // connecting activation layers behind other layers
   ic1 << ic1_tanh;
   ic2 << ic2_tanh;
+  ip1 << ip1_tanh;
 
   ii0 << ip1 << ic2;
   ii0 << ic1;
   (ic2, ic1) << icc1;
 
   // bottle neck module 1
-  max_pooling_layer<tan_h> b1p1(16, 16, 16, 2);
+  max_pooling_layer b1p1(16, 16, 16, 2);
+  tanh_layer b1p1_tanh(8, 8, 16);
   convolutional_layer b1c2(8, 8, 1, 16, 32, padding::same);
   tanh_layer b1c2_tanh(8, 8, 32);
   convolutional_layer b1c1(16, 16, 1, 16, 32, padding::same);
@@ -167,6 +170,7 @@ void enet(network<graph> &nn,
   concat_layer b1cc1(2, 8 * 8 * 32);
 
   // connecting activation layers behind other layers
+  b1p1 << b1p1_tanh;
   b1c1 << b1c1_tanh;
   b1c2 << b1c2_tanh;
   b1c3 << b1c3_tanh;

--- a/test/test_core.h
+++ b/test/test_core.h
@@ -141,7 +141,7 @@ TEST(core, device_add_op) {
     convolutional_layer l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
                           backend_t::libdnn);
 
-    // max_pooling_layer<identity> l(4, 4, 1, 2, 2,
+    // max_pooling_layer l(4, 4, 1, 2, 2,
     // core::backend_t::opencl);
 
     ASSERT_EQ(ProgramManager::getInstance().num_programs(),

--- a/test/test_max_pooling_layer.h
+++ b/test/test_max_pooling_layer.h
@@ -16,8 +16,8 @@
 namespace tiny_dnn {
 
 TEST(max_pool, read_write) {
-  max_pooling_layer<tan_h> l1(100, 100, 5, 2);
-  max_pooling_layer<tan_h> l2(100, 100, 5, 2);
+  max_pooling_layer l1(100, 100, 5, 2);
+  max_pooling_layer l2(100, 100, 5, 2);
 
   l1.init_weight();
   l2.init_weight();
@@ -26,7 +26,7 @@ TEST(max_pool, read_write) {
 }
 
 TEST(max_pool, forward) {
-  max_pooling_layer<identity> l(4, 4, 1, 2);
+  max_pooling_layer l(4, 4, 1, 2);
   vec_t in = {0, 1, 2, 3, 8, 7, 5, 6, 4, 3, 1, 2, 0, -1, -2, -3};
 
   vec_t expected = {8, 6, 4, 2};
@@ -39,11 +39,11 @@ TEST(max_pool, forward) {
 }
 
 TEST(max_pool, setup_internal) {
-  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::internal);
+  max_pooling_layer l(4, 4, 1, 2, 2, core::backend_t::internal);
 
   EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
   EXPECT_EQ(l.in_channels(), serial_size_t(1));  // num of input tensors
-  EXPECT_EQ(l.out_channels(), serial_size_t(2));   // num of output tensors
+  EXPECT_EQ(l.out_channels(), serial_size_t(1));   // num of output tensors
   EXPECT_EQ(l.in_data_size(), serial_size_t(16));  // size of input tensors
   EXPECT_EQ(l.out_data_size(), serial_size_t(4));  // size of output tensors
   EXPECT_EQ(l.in_data_shape().size(),
@@ -54,17 +54,17 @@ TEST(max_pool, setup_internal) {
   EXPECT_EQ(l.weights_grads().size(),
             serial_size_t(0));                       // the wieghts vector size
   EXPECT_EQ(l.inputs().size(), serial_size_t(1));    // num of input edges
-  EXPECT_EQ(l.outputs().size(), serial_size_t(2));   // num of outpus edges
+  EXPECT_EQ(l.outputs().size(), serial_size_t(1));   // num of outpus edges
   EXPECT_EQ(l.in_types().size(), serial_size_t(1));  // num of input data types
   EXPECT_EQ(l.out_types().size(),
-            serial_size_t(2));                    // num of output data types
+            serial_size_t(1));                    // num of output data types
   EXPECT_EQ(l.fan_in_size(), serial_size_t(4));   // num of incoming connections
   EXPECT_EQ(l.fan_out_size(), serial_size_t(1));  // num of outgoing connections
   EXPECT_STREQ(l.layer_type().c_str(), "max-pool");  // string with layer type
 }
 
 TEST(max_pool, forward_stride_internal) {
-  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::internal);
+  max_pooling_layer l(4, 4, 1, 2, 2, core::backend_t::internal);
 
   // clang-format off
     vec_t in = {
@@ -88,8 +88,8 @@ TEST(max_pool, forward_stride_internal) {
 }
 
 TEST(max_pool, forward_padding_same) {
-  max_pooling_layer<identity> l(4, 4, 1, 2, 2, 1, 1, padding::same,
-                                core::backend_t::internal);
+  max_pooling_layer l(4, 4, 1, 2, 2, 1, 1, padding::same,
+                      core::backend_t::internal);
 
   // clang-format off
     vec_t in = {
@@ -115,7 +115,7 @@ TEST(max_pool, forward_padding_same) {
 }
 
 TEST(max_pool, forward_stride_x) {
-  max_pooling_layer<identity> l(4, 4, 1, 2, 1, 2, 1, padding::valid);
+  max_pooling_layer l(4, 4, 1, 2, 1, 2, 1, padding::valid);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -143,7 +143,7 @@ TEST(max_pool, forward_stride_x) {
 }
 
 TEST(max_pool, forward_stride_y) {
-  max_pooling_layer<identity> l(4, 4, 1, 1, 2, 1, 2, padding::valid);
+  max_pooling_layer l(4, 4, 1, 1, 2, 1, 2, padding::valid);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -171,7 +171,7 @@ TEST(max_pool, forward_stride_y) {
 #ifdef CNN_USE_NNPACK
 TEST(max_pool, forward_stride_nnp) {
   nnp_initialize();
-  max_pooling_layer<identity> l(4, 4, 1, 2, 2, core::backend_t::nnpack);
+  max_pooling_layer l(4, 4, 1, 2, 2, core::backend_t::nnpack);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -196,7 +196,7 @@ TEST(max_pool, forward_stride_nnp) {
 
 TEST(max_pool, forward_stride_nnp_not_2x2) {
   nnp_initialize();
-  max_pooling_layer<identity> l(4, 4, 1, 3, 1, core::backend_t::nnpack);
+  max_pooling_layer l(4, 4, 1, 3, 1, core::backend_t::nnpack);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -220,7 +220,7 @@ TEST(max_pool, forward_stride_nnp_not_2x2) {
 #endif
 
 TEST(max_pool, forward_stride) {
-  max_pooling_layer<identity> l(4, 4, 1, 2, 1);
+  max_pooling_layer l(4, 4, 1, 2, 1);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -244,7 +244,7 @@ TEST(max_pool, forward_stride) {
 }
 
 TEST(max_pool, backward) {
-  max_pooling_layer<identity> l(4, 4, 1, 2);
+  max_pooling_layer l(4, 4, 1, 2);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -276,7 +276,7 @@ TEST(max_pool, backward) {
 
 #ifndef CNN_NO_SERIALIZATION
 TEST(max_pool, serialization) {
-  max_pooling_layer<identity> src(4, 4, 1, 2);
+  max_pooling_layer src(4, 4, 1, 2);
 
   std::string str = layer_to_json(src);
 
@@ -303,7 +303,7 @@ TEST(max_pool, serialization) {
 }
 
 TEST(max_pool, serialization_stride) {
-  max_pooling_layer<identity> src(4, 4, 1, 2, 1, 1, 2, padding::valid);
+  max_pooling_layer src(4, 4, 1, 2, 1, 1, 2, padding::valid);
 
   std::string str = layer_to_json(src);
 
@@ -330,7 +330,7 @@ TEST(max_pool, serialization_stride) {
 }
 
 TEST(max_pool, serialization_padding) {
-  max_pooling_layer<identity> src(4, 4, 1, 2, 2, 1, 1, padding::same);
+  max_pooling_layer src(4, 4, 1, 2, 2, 1, 1, padding::same);
 
   std::string str = layer_to_json(src);
 

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -70,13 +70,14 @@ TEST(network, construct_multi_by_local_variables) {
   tanh_layer tanh1(32, 32, 6);
   conv conv2(32, 32, 7, 6, 12, padding::same);
   sigmoid_layer sgm2(32, 32, 12);
-  max_pool<relu> pool1(32, 32, 12, 2);
+  max_pool pool1(32, 32, 12, 2);
+  relu_layer relu1(16, 16, 12);
   lrn_layer<identity> lrn(16, 16, 4, 12);
   dropout dp(16 * 16 * 12, 0.5);
   fc full(16 * 16 * 12, 1);
   softmax_layer softmax(1);
 
-  net << conv1 << tanh1 << conv2 << sgm2 << pool1 << lrn << dp << full
+  net << conv1 << tanh1 << conv2 << sgm2 << pool1 << relu1 << lrn << dp << full
       << softmax;
 }
 
@@ -84,14 +85,15 @@ TEST(network, construct_multi_by_temporary_variables) {
   network<sequential> net;
   net << conv(32, 32, 5, 1, 6, padding::same) << tanh_layer(32, 32, 6)
       << conv(32, 32, 7, 6, 12, padding::same) << sigmoid_layer(32, 32, 12)
-      << max_pool<relu>(32, 32, 12, 2) << lrn_layer<identity>(16, 16, 4, 12)
-      << dropout(16 * 16 * 12, 0.5) << fc(16 * 16 * 12, 1) << softmax_layer(1);
+      << max_pool(32, 32, 12, 2) << relu_layer(16, 16, 12)
+      << lrn_layer<identity>(16, 16, 4, 12) << dropout(16 * 16 * 12, 0.5)
+      << fc(16 * 16 * 12, 1) << softmax_layer(1);
 }
 
 TEST(network, in_dim) {
   network<sequential> net;
   convolutional_layer c1(32, 32, 5, 3, 6, padding::same);
-  max_pooling_layer<identity> p1(32, 32, 6, 2);
+  max_pooling_layer p1(32, 32, 6, 2);
   net << c1 << p1;
 
   EXPECT_EQ(c1.in_data_size(), net.in_data_size());
@@ -100,7 +102,7 @@ TEST(network, in_dim) {
 TEST(network, out_dim) {
   network<sequential> net;
   convolutional_layer c1(32, 32, 5, 3, 6, padding::same);
-  max_pooling_layer<identity> p1(32, 32, 6, 2);
+  max_pooling_layer p1(32, 32, 6, 2);
   net << c1 << p1;
 
   EXPECT_EQ(p1.out_data_size(), net.out_data_size());

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -57,7 +57,7 @@ TEST(serialization, serialize_maxpool) {
     {
         "nodes": [
             {
-                "type": "maxpool<softmax>",
+                "type": "maxpool",
                 "in_size": {
                     "width": 10,
                     "height": 10,

--- a/tiny_dnn/core/backend_avx.h
+++ b/tiny_dnn/core/backend_avx.h
@@ -65,15 +65,12 @@ class avx_backend : public backend {
       backward_activation(f3) {}
 
   // maxpooling
-  avx_backend(
-    std::vector<std::vector<serial_size_t>> *out2in,
-    std::vector<serial_size_t> *in2out,
-    std::function<void(const tensor_t &, const tensor_t &, tensor_t &)> f,
-    max_pooling_layer_worker_specific_storage *ptr)
+  avx_backend(std::vector<std::vector<serial_size_t>> *out2in,
+              std::vector<serial_size_t> *in2out,
+              max_pooling_layer_worker_specific_storage *ptr)
     : max_pooling_layer_worker_storage_(ptr),
       out2in_(out2in),
-      in2out_(in2out),
-      backward_activation(f) {}
+      in2out_(in2out) {}
 
   // fully_connected
   avx_backend(fully_params *params) : params_f_(params) {}

--- a/tiny_dnn/core/kernels/maxpool_grad_op.h
+++ b/tiny_dnn/core/kernels/maxpool_grad_op.h
@@ -66,7 +66,7 @@ class MaxPoolGradOp : public core::OpKernel {
 
     // incoming/outcoming data
     tensor_t &prev_delta = context.input_grad(0);
-    tensor_t &curr_delta = context.output_grad(1);
+    tensor_t &curr_delta = context.output_grad(0);
 
     // initialize outputs
     fill_tensor(prev_delta, float_t{0});

--- a/tiny_dnn/core/kernels/maxpool_op.h
+++ b/tiny_dnn/core/kernels/maxpool_op.h
@@ -67,7 +67,7 @@ class MaxPoolOp : public core::OpKernel {
 
     // incomimg/outcoming data
     const tensor_t &in_data = context.input(0);
-    tensor_t &out_data      = context.output(1);
+    tensor_t &out_data      = context.output(0);
 
     // initialize outputs
     fill_tensor(out_data, float_t{0});

--- a/tiny_dnn/core/kernels/maxpool_op_internal.h
+++ b/tiny_dnn/core/kernels/maxpool_op_internal.h
@@ -18,7 +18,7 @@ inline void maxpool_op_internal(
   const bool layer_parallelize) {
   for_i(layer_parallelize, in_data.size(), [&](int sample) {
     const vec_t &in                 = in_data[sample];
-    vec_t &a                        = out_data[sample];
+    vec_t &out                      = out_data[sample];
     std::vector<serial_size_t> &max = max_idx[sample];
 
     for (serial_size_t i = 0; i < out2in.size(); i++) {
@@ -32,7 +32,7 @@ inline void maxpool_op_internal(
         }
       }
       max[i] = idx;
-      a[i]   = max_value;
+      out[i] = max_value;
     }
   });
 }

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -132,7 +132,7 @@ inline std::shared_ptr<layer> create_max_pool(layer_size_t pool_size_w,
                                               padding pad_type,
                                               const shape_t &bottom_shape,
                                               shape_t *top_shape) {
-  using max_pool = max_pooling_layer<activation::identity>;
+  using max_pool = max_pooling_layer;
   auto mp        = std::make_shared<max_pool>(
     bottom_shape.width_, bottom_shape.height_, bottom_shape.depth_, pool_size_w,
     pool_size_h, stride_w, stride_h, pad_type);

--- a/tiny_dnn/models/alexnet.h
+++ b/tiny_dnn/models/alexnet.h
@@ -23,17 +23,17 @@ class alexnet : public network<sequential> {
     using relu = relu_layer;
     *this << conv(224, 224, 11, 11, 3, 64, padding::valid, true, 4, 4);
     *this << relu(54, 54, 64);
-    *this << max_pool<activation::identity>(54, 54, 64, 2);
+    *this << max_pool(54, 54, 64, 2);
     *this << conv(27, 27, 5, 5, 64, 192, padding::valid, true, 1, 1);
     *this << relu(23, 23, 192);
-    *this << max_pool<activation::identity>(23, 23, 192, 1);
+    *this << max_pool(23, 23, 192, 1);
     *this << conv(23, 23, 3, 3, 192, 384, padding::valid, true, 1, 1);
     *this << relu(21, 21, 384);
     *this << conv(21, 21, 3, 3, 384, 256, padding::valid, true, 1, 1);
     *this << relu(19, 19, 256);
     *this << conv(19, 19, 3, 3, 256, 256, padding::valid, true, 1, 1);
     *this << relu(17, 17, 256);
-    *this << max_pool<activation::identity>(17, 17, 256, 1);
+    *this << max_pool(17, 17, 256, 1);
   }
 };
 

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -85,8 +85,7 @@ using conv = tiny_dnn::convolutional_layer;
 template <class T>
 using q_conv = tiny_dnn::quantized_convolutional_layer<T>;
 
-template <class T>
-using max_pool = tiny_dnn::max_pooling_layer<T>;
+using max_pool = tiny_dnn::max_pooling_layer;
 
 template <class T>
 using ave_pool = tiny_dnn::average_pooling_layer<T>;

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -173,12 +173,11 @@ struct LoadAndConstruct<tiny_dnn::lrn_layer<Activation>> {
   }
 };
 
-template <typename Activation>
-struct LoadAndConstruct<tiny_dnn::max_pooling_layer<Activation>> {
+template <>
+struct LoadAndConstruct<tiny_dnn::max_pooling_layer> {
   template <class Archive>
   static void load_and_construct(
-    Archive &ar,
-    cereal::construct<tiny_dnn::max_pooling_layer<Activation>> &construct) {
+    Archive &ar, cereal::construct<tiny_dnn::max_pooling_layer> &construct) {
     tiny_dnn::shape3d in;
     tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
     tiny_dnn::padding pad_type;
@@ -370,9 +369,9 @@ struct specialize<Archive,
                   tiny_dnn::lrn_layer<Activation>,
                   cereal::specialization::non_member_serialize> {};
 
-template <class Archive, typename Activation>
+template <class Archive>
 struct specialize<Archive,
-                  tiny_dnn::max_pooling_layer<Activation>,
+                  tiny_dnn::max_pooling_layer,
                   cereal::specialization::non_member_serialize> {};
 
 template <class Archive, typename Activation>
@@ -523,9 +522,9 @@ struct serialization_buddy {
        cereal::make_nvp("region", layer.region_));
   }
 
-  template <class Archive, typename Activation>
+  template <class Archive>
   static inline void serialize(Archive &ar,
-                               tiny_dnn::max_pooling_layer<Activation> &layer) {
+                               tiny_dnn::max_pooling_layer &layer) {
     layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     ar(cereal::make_nvp("in_size", params_.in),
@@ -650,8 +649,8 @@ void serialize(Archive &ar, tiny_dnn::lrn_layer<Activation> &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-template <class Archive, typename Activation>
-void serialize(Archive &ar, tiny_dnn::max_pooling_layer<Activation> &layer) {
+template <class Archive>
+void serialize(Archive &ar, tiny_dnn::max_pooling_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -2,7 +2,6 @@
 #ifndef CNN_NO_SERIALIZATION
 
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(average_pooling_layer, avepool);
-CNN_REGISTER_LAYER_WITH_ACTIVATIONS(max_pooling_layer, maxpool);
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(linear_layer, linear);
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(lrn_layer, lrn);
 
@@ -11,6 +10,7 @@ CNN_REGISTER_LAYER(concat_layer, concat);
 CNN_REGISTER_LAYER(convolutional_layer, conv);
 CNN_REGISTER_LAYER(dropout_layer, dropout);
 CNN_REGISTER_LAYER(fully_connected_layer, fully_connected);
+CNN_REGISTER_LAYER(max_pooling_layer, maxpool);
 CNN_REGISTER_LAYER(power_layer, power);
 CNN_REGISTER_LAYER(slice_layer, slice);
 CNN_REGISTER_LAYER(elementwise_add_layer, elementwise_add);


### PR DESCRIPTION
The `Activation` template parameter has been completely decoupled from `max_pooling_layer`. Changes are similar to those done in #600. 