### PR TITLE
Drop activation template from average pool, unpool layers.

### DIFF
--- a/examples/deconv/train.cpp
+++ b/examples/deconv/train.cpp
@@ -39,10 +39,12 @@ void deconv_lanet(network<graph> &nn,
   input_layer i1(shape3d(32, 32, 1));
   convolutional_layer c1(32, 32, 5, 1, 6);
   tanh_layer c1_tanh(28, 28, 6);
-  average_pooling_layer<tan_h> p1(28, 28, 6, 2);
+  average_pooling_layer p1(28, 28, 6, 2);
+  tanh_layer p1_tanh(14, 14, 6);
   deconvolutional_layer d1(14, 14, 5, 6, 16, connection_table(tbl, 6, 16));
   tanh_layer d1_tanh(18, 18, 16);
-  average_pooling_layer<tan_h> p2(18, 18, 16, 2);
+  average_pooling_layer p2(18, 18, 16, 2);
+  tanh_layer p2_tanh(9, 9, 16);
   convolutional_layer c2(9, 9, 9, 16, 120);
   tanh_layer c2_tanh(1, 1, 120);
   fully_connected_layer fc1(120, 10);
@@ -50,8 +52,10 @@ void deconv_lanet(network<graph> &nn,
 
   // connecting activation layers behind other layers
   c1 << c1_tanh;
+  p1 << p1_tanh;
   d1 << d1_tanh;
   c2 << c2_tanh;
+  p2 << p2_tanh;
   fc1 << fc1_tanh;
 
   // connect them to graph
@@ -103,7 +107,7 @@ void deconv_ae(network<sequential> &nn,
                std::vector<vec_t> test_images) {
   // construct nets
   nn << convolutional_layer(32, 32, 5, 1, 6) << tanh_layer(28, 28, 6)
-     << average_pooling_layer<tan_h>(28, 28, 6, 2)
+     << average_pooling_layer(28, 28, 6, 2) << tanh_layer(14, 14, 6)
      << convolutional_layer(14, 14, 3, 6, 16) << tanh_layer(12, 12, 16)
      << deconvolutional_layer(12, 12, 3, 16, 6) << tanh_layer(14, 14, 6)
      << average_unpooling_layer<tan_h>(14, 14, 6, 2)

--- a/examples/deconv/train.cpp
+++ b/examples/deconv/train.cpp
@@ -110,7 +110,7 @@ void deconv_ae(network<sequential> &nn,
      << average_pooling_layer(28, 28, 6, 2) << tanh_layer(14, 14, 6)
      << convolutional_layer(14, 14, 3, 6, 16) << tanh_layer(12, 12, 16)
      << deconvolutional_layer(12, 12, 3, 16, 6) << tanh_layer(14, 14, 6)
-     << average_unpooling_layer<tan_h>(14, 14, 6, 2)
+     << average_unpooling_layer(14, 14, 6, 2) << tanh_layer(28, 28, 6)
      << deconvolutional_layer(28, 28, 5, 6, 1) << tanh_layer(32, 32, 6);
 
   // load train-data and make corruption

--- a/examples/deconv/visual.cpp
+++ b/examples/deconv/visual.cpp
@@ -37,7 +37,7 @@ void convert_image(const std::string &imagefilename,
 void construct_net(network<sequential> &nn) {
   // construct nets
   nn << convolutional_layer(32, 32, 5, 1, 6) << tanh_layer(28, 28, 6)
-     << average_pooling_layer<activation::identity>(28, 28, 6, 2)
+     << average_pooling_layer(28, 28, 6, 2)
      << convolutional_layer(14, 14, 5, 6, 16) << tanh_layer(10, 10, 16)
      << deconvolutional_layer(10, 10, 5, 16, 6) << tanh_layer(14, 14, 6)
      << average_unpooling_layer<activation::identity>(14, 14, 6, 2)

--- a/examples/deconv/visual.cpp
+++ b/examples/deconv/visual.cpp
@@ -40,7 +40,7 @@ void construct_net(network<sequential> &nn) {
      << average_pooling_layer(28, 28, 6, 2)
      << convolutional_layer(14, 14, 5, 6, 16) << tanh_layer(10, 10, 16)
      << deconvolutional_layer(10, 10, 5, 16, 6) << tanh_layer(14, 14, 6)
-     << average_unpooling_layer<activation::identity>(14, 14, 6, 2)
+     << average_unpooling_layer(14, 14, 6, 2)
      << deconvolutional_layer(28, 28, 5, 6, 1) << tanh_layer(32, 32, 1);
 }
 

--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -64,13 +64,15 @@ void sample1_convnet(const string& data_dir) {
   nn << convolutional_layer(32, 32, 5, 1,
                             6) /* 32x32 in, 5x5 kernel, 1-6 fmaps conv */
      << tanh_layer(28, 28, 6)
-     << average_pooling_layer<tan_h>(28, 28, 6,
-                                     2) /* 28x28 in, 6 fmaps, 2x2 subsampling */
+     << average_pooling_layer(28, 28, 6,
+                              2) /* 28x28 in, 6 fmaps, 2x2 subsampling */
+     << tanh_layer(14, 14, 6)
      << convolutional_layer(14, 14, 5, 6, 16,
                             connection_table(connection, 6, 16))
-     << tanh_layer(10, 10, 16) << average_pooling_layer<tan_h>(10, 10, 16, 2)
-     << convolutional_layer(5, 5, 5, 16, 120) << tanh_layer(1, 1, 120)
-     << fully_connected_layer(120, 10) << tanh_layer(10);
+     << tanh_layer(10, 10, 16) << average_pooling_layer(10, 10, 16, 2)
+     << tanh_layer(5, 5, 16) << convolutional_layer(5, 5, 5, 16, 120)
+     << tanh_layer(1, 1, 120) << fully_connected_layer(120, 10)
+     << tanh_layer(10);
 
   std::cout << "load models..." << std::endl;
 

--- a/examples/mnist/quantized.cpp
+++ b/examples/mnist/quantized.cpp
@@ -33,17 +33,18 @@ void construct_net(network<sequential> &nn) {
   nn << quantized_convolutional_layer<tan_h>(
           32, 32, 5, 1, 6, padding::valid, true, 1, 1,
           backend_type)  // C1, 1@32x32-in, 6@28x28-out
-     << average_pooling_layer<tan_h>(28, 28, 6,
-                                     2)  // S2, 6@28x28-in, 6@14x14-out
+     << average_pooling_layer(28, 28, 6,
+                              2)  // S2, 6@28x28-in, 6@14x14-out
+     << tanh_layer(14, 14, 6)
      << quantized_convolutional_layer<tan_h>(
           14, 14, 5, 6, 16, connection_table(tbl, 6, 16), padding::valid, true,
           1, 1,
           backend_type)  // C3, 6@14x14-in, 16@10x10-in
-     << average_pooling_layer<tan_h>(10, 10, 16,
-                                     2)  // S4, 16@10x10-in, 16@5x5-out
-     << quantized_convolutional_layer<tan_h>(
-          5, 5, 5, 16, 120, padding::valid, true, 1, 1,
-          backend_type)  // C5, 16@5x5-in, 120@1x1-out
+     << average_pooling_layer(10, 10, 16,
+                              2)  // S4, 16@10x10-in, 16@5x5-out
+     << tanh_layer(5, 5, 16) << quantized_convolutional_layer<tan_h>(
+                                  5, 5, 5, 16, 120, padding::valid, true, 1, 1,
+                                  backend_type)  // C5, 16@5x5-in, 120@1x1-out
      << quantized_fully_connected_layer<tan_h>(
           120, 10, true, backend_type);  // F6, 120-in, 10-out
 }

--- a/examples/mnist/quantized.cpp
+++ b/examples/mnist/quantized.cpp
@@ -20,7 +20,6 @@ void construct_net(network<sequential> &nn) {
                              X, X, O, O, O, O, X, O, O, O, O, X, X, X, O, O, O, X, X, O, X, O, O, O,
                              X, O, O, O, X, X, O, O, O, O, X, X, O, X, O, O, X, X, O, O, O, X, X, O,
                              O, O, O, X, O, O, X, O, X, X, X, O, O, O, X, X, O, O, O, O, X, O, O, O};
-// clang-format on
 #undef O
 #undef X
 
@@ -42,11 +41,13 @@ void construct_net(network<sequential> &nn) {
           backend_type)  // C3, 6@14x14-in, 16@10x10-in
      << average_pooling_layer(10, 10, 16,
                               2)  // S4, 16@10x10-in, 16@5x5-out
-     << tanh_layer(5, 5, 16) << quantized_convolutional_layer<tan_h>(
-                                  5, 5, 5, 16, 120, padding::valid, true, 1, 1,
-                                  backend_type)  // C5, 16@5x5-in, 120@1x1-out
+     << tanh_layer(5, 5, 16)
+     << quantized_convolutional_layer<tan_h>(
+          5, 5, 5, 16, 120, padding::valid, true, 1, 1,
+          backend_type)  // C5, 16@5x5-in, 120@1x1-out
      << quantized_fully_connected_layer<tan_h>(
           120, 10, true, backend_type);  // F6, 120-in, 10-out
+  // clang-format on
 }
 
 static void train_lenet(const std::string &data_dir_path) {

--- a/examples/mnist/readme.md
+++ b/examples/mnist/readme.md
@@ -32,12 +32,14 @@ static const bool tbl [] = {
 nn << convolutional_layer(32, 32, 5, 1, 6,         // C1, 1@32x32-in, 6@28x28-out
         padding::valid, true, 1, 1, backend_type)
    << tanh_layer(28, 28, 6)
-   << average_pooling_layer<tan_h>(28, 28, 6, 2)   // S2, 6@28x28-in, 6@14x14-out
+   << average_pooling_layer(28, 28, 6, 2)          // S2, 6@28x28-in, 6@14x14-out
+   << tanh_layer(14, 14, 6)
    << convolutional_layer(14, 14, 5, 6, 16,        // C3, 6@14x14-in, 16@10x10-in
         connection_table(tbl, 6, 16),
         padding::valid, true, 1, 1, backend_type)
    << tanh_layer(10, 10, 16)
-   << average_pooling_layer<tan_h>(10, 10, 16, 2)  // S4, 16@10x10-in, 16@5x5-out
+   << average_pooling_layer(10, 10, 16, 2)         // S4, 16@10x10-in, 16@5x5-out
+   << tanh_layer(5, 5, 16)
    << convolutional_layer(5, 5, 5, 16, 120,        // C5, 16@5x5-in, 120@1x1-out
         padding::valid, true, 1, 1, backend_type)
    << tanh_layer(1, 1, 120)
@@ -144,8 +146,9 @@ static void construct_net(network<sequential>& nn) {
                               6,  // C1, 1@32x32-in, 6@28x28-out
                               padding::valid, true, 1, 1, backend_type)
        << tanh_layer(28, 28, 6)
-       << average_pooling_layer<tan_h>(28, 28, 6,
-                                       2)  // S2, 6@28x28-in, 6@14x14-out
+       << average_pooling_layer(28, 28, 6,
+                                2)  // S2, 6@28x28-in, 6@14x14-out
+       << tanh_layer(14, 14, 6)
        << convolutional_layer(14, 14, 5, 6,
                               16,  // C3, 6@14x14-in, 16@10x10-out
                               connection_table(tbl, 6, 16), padding::valid, true,
@@ -153,6 +156,7 @@ static void construct_net(network<sequential>& nn) {
        << tanh_layer(10, 10, 16)
        << average_pooling_layer(10, 10, 16,
                                 2)  // S4, 16@10x10-in, 16@5x5-out
+       << tanh_layer(5, 5, 16)
        << convolutional_layer(5, 5, 5, 16,
                               120,  // C5, 16@5x5-in, 120@1x1-out
                               padding::valid, true, 1, 1, backend_type)

--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -41,15 +41,17 @@ static void construct_net(network<sequential>& nn) {
                             6,  // C1, 1@32x32-in, 6@28x28-out
                             padding::valid, true, 1, 1, backend_type)
      << tanh_layer(28, 28, 6)
-     << average_pooling_layer<tan_h>(28, 28, 6,
-                                     2)  // S2, 6@28x28-in, 6@14x14-out
+     << average_pooling_layer(28, 28, 6,
+                              2)  // S2, 6@28x28-in, 6@14x14-out
+     << tanh_layer(14, 14, 6)
      << convolutional_layer(14, 14, 5, 6,
                             16,  // C3, 6@14x14-in, 16@10x10-out
                             connection_table(tbl, 6, 16), padding::valid, true,
                             1, 1, backend_type)
      << tanh_layer(10, 10, 16)
-     << average_pooling_layer<tan_h>(10, 10, 16,
-                                     2)  // S4, 16@10x10-in, 16@5x5-out
+     << average_pooling_layer(10, 10, 16,
+                              2)  // S4, 16@10x10-in, 16@5x5-out
+     << tanh_layer(5, 5, 16)
      << convolutional_layer(5, 5, 5, 16,
                             120,  // C5, 16@5x5-in, 120@1x1-out
                             padding::valid, true, 1, 1, backend_type)

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -19,8 +19,7 @@ TEST(ave_pool, gradient_check) {  // sigmoid - cross-entropy
 
   network nn;
   nn << fully_connected_layer(3, 8) << activation_layer(8)
-     << average_pooling_layer<identity>(4, 2, 1, 2)
-     << activation_layer(2);  // 4x2 => 2x1
+     << average_pooling_layer(4, 2, 1, 2) << activation_layer(2);  // 4x2 => 2x1
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -36,7 +35,7 @@ TEST(ave_pool, gradient_check2) {  // x-stride
 
   network nn;
   nn << fully_connected_layer(3, 8) << activation_layer(8)
-     << average_pooling_layer<identity>(4, 2, 1, 2, 1, 2, 1)  // 4x2 => 2x2
+     << average_pooling_layer(4, 2, 1, 2, 1, 2, 1)  // 4x2 => 2x2
      << activation_layer(2, 2, 1);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
@@ -53,7 +52,7 @@ TEST(ave_pool, gradient_check3) {  // y-stride
 
   network nn;
   nn << fully_connected_layer(3, 8) << activation_layer(8)
-     << average_pooling_layer<identity>(4, 2, 1, 1, 2, 1, 2)  // 4x2 => 4x1
+     << average_pooling_layer(4, 2, 1, 1, 2, 1, 2)  // 4x2 => 4x1
      << activation_layer(4);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
@@ -69,7 +68,7 @@ TEST(ave_pool, gradient_check4) {  // padding-same
   using network          = network<sequential>;
 
   network nn;
-  nn << average_pooling_layer<identity>(4, 2, 1, 2, 2, 1, 1, padding::same)
+  nn << average_pooling_layer(4, 2, 1, 2, 2, 1, 1, padding::same)
      << activation_layer(4, 2, 1);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
@@ -80,7 +79,7 @@ TEST(ave_pool, gradient_check4) {  // padding-same
 }
 
 TEST(ave_pool, forward) {
-  average_pooling_layer<identity> l(4, 4, 1, 2);
+  average_pooling_layer l(4, 4, 1, 2);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -107,7 +106,7 @@ TEST(ave_pool, forward) {
 }
 
 TEST(ave_pool, forward_stride) {
-  average_pooling_layer<identity> l(4, 4, 1, 2, 1);
+  average_pooling_layer l(4, 4, 1, 2, 1);
   // clang-format off
     vec_t in = {
         0, 1, 2, 3,
@@ -135,8 +134,8 @@ TEST(ave_pool, forward_stride) {
 }
 
 TEST(ave_pool, read_write) {
-  average_pooling_layer<identity> l1(100, 100, 5, 2);
-  average_pooling_layer<identity> l2(100, 100, 5, 2);
+  average_pooling_layer l1(100, 100, 5, 2);
+  average_pooling_layer l2(100, 100, 5, 2);
 
   l1.setup(true);
   l2.setup(true);

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -19,7 +19,7 @@ TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy
 
   network nn;
   nn << fully_connected_layer(3, 4) << activation_layer(4)
-     << average_unpooling_layer<identity>(2, 2, 1, 2)  // 2x2 => 4x4
+     << average_unpooling_layer(2, 2, 1, 2)  // 2x2 => 4x4
      << activation_layer(4, 4, 1) << average_pooling_layer(4, 4, 1, 2)
      << activation_layer(2, 2, 1);
 
@@ -31,7 +31,7 @@ TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy
 }
 
 TEST(ave_unpool, forward) {
-  average_unpooling_layer<identity> l(2, 2, 1, 2);
+  average_unpooling_layer l(2, 2, 1, 2);
 
   // clang-format off
     vec_t in = {
@@ -59,7 +59,7 @@ TEST(ave_unpool, forward) {
 }
 
 TEST(ave_unpool, forward_stride) {
-  average_unpooling_layer<identity> l(3, 3, 1, 2, 1);
+  average_unpooling_layer l(3, 3, 1, 2, 1);
 
   // clang-format off
     vec_t in = {
@@ -88,8 +88,8 @@ TEST(ave_unpool, forward_stride) {
 }
 
 TEST(ave_unpool, read_write) {
-  average_unpooling_layer<tan_h> l1(100, 100, 5, 2);
-  average_unpooling_layer<tan_h> l2(100, 100, 5, 2);
+  average_unpooling_layer l1(100, 100, 5, 2);
+  average_unpooling_layer l2(100, 100, 5, 2);
 
   l1.setup(true);
   l2.setup(true);

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -20,7 +20,7 @@ TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy
   network nn;
   nn << fully_connected_layer(3, 4) << activation_layer(4)
      << average_unpooling_layer<identity>(2, 2, 1, 2)  // 2x2 => 4x4
-     << activation_layer(4, 4, 1) << average_pooling_layer<identity>(4, 4, 1, 2)
+     << activation_layer(4, 4, 1) << average_pooling_layer(4, 4, 1, 2)
      << activation_layer(2, 2, 1);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -353,20 +353,20 @@ TEST(network, get_loss) {
 TEST(network, at) {
   network<sequential> net;
   convolutional_layer c1(32, 32, 5, 3, 6, padding::same);
-  average_pooling_layer<identity> p1(32, 32, 6, 2);
+  average_pooling_layer p1(32, 32, 6, 2);
 
   net << c1 << p1;
   net.init_weight();
 
   // auto& c = net.at<convolutional_layer>(0);
-  // auto& p = net.at<average_pooling_layer<identity>>(1);
+  // auto& p = net.at<average_pooling_layer>(1);
 }
 
 TEST(network, bracket_operator) {
   network<sequential> net;
 
   net << convolutional_layer(32, 32, 5, 3, 6, padding::same)
-      << average_pooling_layer<identity>(32, 32, 6, 2);
+      << average_pooling_layer(32, 32, 6, 2);
 
   EXPECT_EQ(net[0]->layer_type(), "conv");
   EXPECT_EQ(net[1]->layer_type(), "ave-pool");
@@ -376,7 +376,7 @@ TEST(network, weight_init) {
   network<sequential> net;
 
   net << convolutional_layer(32, 32, 5, 3, 6, padding::same)
-      << average_pooling_layer<identity>(32, 32, 6, 2);
+      << average_pooling_layer(32, 32, 6, 2);
 
   // change all layers at once
   net.weight_init(weight_init::constant(2.0));
@@ -394,7 +394,7 @@ TEST(network, weight_init_per_layer) {
   network<sequential> net;
 
   net << convolutional_layer(32, 32, 5, 3, 6, padding::same)
-      << average_pooling_layer<identity>(32, 32, 6, 2);
+      << average_pooling_layer(32, 32, 6, 2);
 
   // change specific layer
   net[0]->weight_init(weight_init::constant(2.0));
@@ -413,7 +413,7 @@ TEST(network, bias_init) {
   network<sequential> net;
 
   net << convolutional_layer(32, 32, 5, 3, 6, padding::same)
-      << average_pooling_layer<identity>(32, 32, 6, 2);
+      << average_pooling_layer(32, 32, 6, 2);
 
   net.bias_init(weight_init::constant(2.0));
   net.init_weight();
@@ -430,7 +430,7 @@ TEST(network, bias_init_per_layer) {
   network<sequential> net;
 
   net << convolutional_layer(32, 32, 5, 3, 6, padding::same)
-      << average_pooling_layer<identity>(32, 32, 6, 2);
+      << average_pooling_layer(32, 32, 6, 2);
 
   net[0]->bias_init(weight_init::constant(2.0));
   net[1]->bias_init(weight_init::constant(1.0));
@@ -452,9 +452,8 @@ TEST(network, gradient_check) {  // sigmoid - cross-entropy
   network nn;
   nn << fully_connected_layer(10, 14 * 14 * 3) << activation_layer(14 * 14 * 3)
      << convolutional_layer(14, 14, 5, 3, 6) << activation_layer(10, 10, 6)
-     << average_pooling_layer<identity>(10, 10, 6, 2)
-     << activation_layer(5, 5, 6) << fully_connected_layer(5 * 5 * 6, 3)
-     << activation_layer(3);
+     << average_pooling_layer(10, 10, 6, 2) << activation_layer(5, 5, 6)
+     << fully_connected_layer(5 * 5 * 6, 3) << activation_layer(3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -470,9 +469,8 @@ TEST(network, gradient_check2) {  // tan_h - mse
   network nn;
   nn << fully_connected_layer(10, 14 * 14 * 3) << activation_layer(14 * 14 * 3)
      << convolutional_layer(14, 14, 5, 3, 6) << activation_layer(10, 10, 6)
-     << average_pooling_layer<identity>(10, 10, 6, 2)
-     << activation_layer(5, 5, 6) << fully_connected_layer(5 * 5 * 6, 3)
-     << activation_layer(3);
+     << average_pooling_layer(10, 10, 6, 2) << activation_layer(5, 5, 6)
+     << fully_connected_layer(5 * 5 * 6, 3) << activation_layer(3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -487,7 +485,7 @@ TEST(network, gradient_check3) {  // mixture - mse
   network nn;
   nn << fully_connected_layer(10, 14 * 14 * 3) << tanh_layer(14 * 14 * 3)
      << convolutional_layer(14, 14, 5, 3, 6) << sigmoid_layer(10, 10, 6)
-     << average_pooling_layer<identity>(10, 10, 6, 2) << relu_layer(5, 5, 6)
+     << average_pooling_layer(10, 10, 6, 2) << relu_layer(5, 5, 6)
      << fully_connected_layer(5 * 5 * 6, 3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
@@ -504,9 +502,8 @@ TEST(network, gradient_check4) {  // sigmoid - cross-entropy
   network nn;
   nn << fully_connected_layer(10, 14 * 14 * 3) << activation_layer(14 * 14 * 3)
      << convolutional_layer(14, 14, 5, 3, 6) << activation_layer(10, 10, 6)
-     << average_pooling_layer<identity>(10, 10, 6, 2)
-     << activation_layer(5, 5, 6) << fully_connected_layer(5 * 5 * 6, 3)
-     << activation_layer(3);
+     << average_pooling_layer(10, 10, 6, 2) << activation_layer(5, 5, 6)
+     << fully_connected_layer(5 * 5 * 6, 3) << activation_layer(3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -522,9 +519,8 @@ TEST(network, gradient_check5) {  // softmax - cross-entropy
   network nn;
   nn << fully_connected_layer(10, 14 * 14 * 3) << activation_layer(14 * 14 * 3)
      << convolutional_layer(14, 14, 5, 3, 6) << activation_layer(10, 10, 6)
-     << average_pooling_layer<identity>(10, 10, 6, 2)
-     << activation_layer(5, 5, 6) << fully_connected_layer(5 * 5 * 6, 3)
-     << activation_layer(3);
+     << average_pooling_layer(10, 10, 6, 2) << activation_layer(5, 5, 6)
+     << fully_connected_layer(5 * 5 * 6, 3) << activation_layer(3);
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -605,16 +601,16 @@ TEST(network, read_write) {
   network n1, n2;
 
   n1 << convolutional_layer(32, 32, 5, 1, 6) << tanh_layer(28, 28, 6)
-     << average_pooling_layer<identity>(28, 28, 6, 2)
+     << average_pooling_layer(28, 28, 6, 2)
      << convolutional_layer(14, 14, 5, 6, 16) << tanh_layer(10, 10, 16)
-     << average_pooling_layer<identity>(10, 10, 16, 2)
+     << average_pooling_layer(10, 10, 16, 2)
      << convolutional_layer(5, 5, 5, 16, 120) << tanh_layer(1, 1, 120)
      << fully_connected_layer(120, 10) << softmax_layer(10);
 
   n2 << convolutional_layer(32, 32, 5, 1, 6) << tanh_layer(28, 28, 6)
-     << average_pooling_layer<identity>(28, 28, 6, 2)
+     << average_pooling_layer(28, 28, 6, 2)
      << convolutional_layer(14, 14, 5, 6, 16) << tanh_layer(10, 10, 16)
-     << average_pooling_layer<identity>(10, 10, 16, 2)
+     << average_pooling_layer(10, 10, 16, 2)
      << convolutional_layer(5, 5, 5, 16, 120) << tanh_layer(1, 1, 120)
      << fully_connected_layer(120, 10) << softmax_layer(10);
 

--- a/test/test_nodes.h
+++ b/test/test_nodes.h
@@ -27,7 +27,7 @@ TEST(nodes, graph_no_branch) {
 
   auto cnn = std::make_shared<convolutional_layer>(8, 8, 3, 1, 4);
 
-  auto pool = std::make_shared<average_pooling_layer<tan_h>>(6, 6, 4, 2);
+  auto pool = std::make_shared<average_pooling_layer>(6, 6, 4, 2);
 
   auto out = std::make_shared<linear_layer<relu>>(3 * 3 * 4);
 

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -539,7 +539,7 @@ TEST(serialization, sequential_model) {
 
   net2.load(path, content_type::model);
 
-  for (int i = 0; i < 3; i++) {
+  for (int i = 0; i < net1.layer_size(); i++) {
     ASSERT_EQ(net1[i]->in_shape(), net2[i]->in_shape());
     ASSERT_EQ(net1[i]->out_shape(), net2[i]->out_shape());
     ASSERT_EQ(net1[i]->layer_type(), net2[i]->layer_type());

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -87,7 +87,7 @@ TEST(serialization, serialize_avepool) {
     {
         "nodes": [
             {
-                "type": "avepool<relu>",
+                "type": "avepool",
                 "in_size": {
                     "width": 10,
                     "height": 10,
@@ -529,7 +529,7 @@ TEST(serialization, sequential_model) {
   network<sequential> net1, net2;
 
   net1 << fully_connected_layer(10, 16) << tanh_layer(16)
-       << average_pooling_layer<relu>(4, 4, 1, 2)
+       << average_pooling_layer(4, 4, 1, 2) << relu_layer(2, 2, 1)
        << power_layer(shape3d(2, 2, 1), 0.5f);
 
   net1.init_weight();

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -150,7 +150,7 @@ inline std::shared_ptr<layer> create_ave_pool(layer_size_t pool_size_w,
                                               padding pad_type,
                                               const shape_t &bottom_shape,
                                               shape_t *top_shape) {
-  using ave_pool = average_pooling_layer<activation::identity>;
+  using ave_pool = average_pooling_layer;
   auto ap        = std::make_shared<ave_pool>(
     bottom_shape.width_, bottom_shape.height_, bottom_shape.depth_, pool_size_w,
     pool_size_h, stride_w, stride_h, pad_type);

--- a/tiny_dnn/layers/partial_connected_layer.h
+++ b/tiny_dnn/layers/partial_connected_layer.h
@@ -6,28 +6,25 @@
     in the LICENSE file.
 */
 #pragma once
-#include "tiny_dnn/layers/feedforward_layer.h"
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
-template <typename Activation>
-class partial_connected_layer : public feedforward_layer<Activation> {
+class partial_connected_layer : public layer {
  public:
-  CNN_USE_LAYER_MEMBERS;
+  using layer::parallelize_;
 
   typedef std::vector<std::pair<serial_size_t, serial_size_t>> io_connections;
   typedef std::vector<std::pair<serial_size_t, serial_size_t>> wi_connections;
   typedef std::vector<std::pair<serial_size_t, serial_size_t>> wo_connections;
-  typedef feedforward_layer<Activation> Base;
 
   partial_connected_layer(serial_size_t in_dim,
                           serial_size_t out_dim,
                           size_t weight_dim,
                           size_t bias_dim,
                           float_t scale_factor = float_t{1})
-    : Base(std_input_order(bias_dim > 0)),
+    : layer(std_input_order(bias_dim > 0), {vector_type::data}),
       weight2io_(weight_dim),
       out2wi_(out_dim),
       in2wo_(in_dim),
@@ -66,30 +63,28 @@ class partial_connected_layer : public feedforward_layer<Activation> {
     const tensor_t &in = *in_data[0];
     const vec_t &W     = (*in_data[1])[0];
     const vec_t &b     = (*in_data[2])[0];
-    tensor_t &a        = *out_data[1];
+    tensor_t &out      = *out_data[0];
 
     // @todo revise the parallelism strategy
     for (serial_size_t sample       = 0,
                        sample_count = static_cast<serial_size_t>(in.size());
          sample < sample_count; ++sample) {
-      vec_t &a_sample = a[sample];
+      vec_t &out_sample = out[sample];
 
       for_i(parallelize_, out2wi_.size(), [&](int i) {
         const wi_connections &connections = out2wi_[i];
 
-        float_t &a_element = a_sample[i];
+        float_t &out_element = out_sample[i];
 
-        a_element = float_t{0};
+        out_element = float_t{0};
 
         for (auto connection : connections)
-          a_element += W[connection.first] * in[sample][connection.second];
+          out_element += W[connection.first] * in[sample][connection.second];
 
-        a_element *= scale_factor_;
-        a_element += b[out2bias_[i]];
+        out_element *= scale_factor_;
+        out_element += b[out2bias_[i]];
       });
     }
-
-    this->forward_activation(*out_data[0], *out_data[1]);
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -102,8 +97,6 @@ class partial_connected_layer : public feedforward_layer<Activation> {
     vec_t &db                = (*in_grad[2])[0];
     tensor_t &prev_delta     = *in_grad[0];
     tensor_t &curr_delta     = *out_grad[0];
-
-    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
     // @todo revise the parallelism strategy
     for (serial_size_t

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -111,8 +111,7 @@ using deconv = tiny_dnn::deconvolutional_layer;
 template <class T>
 using max_unpool = tiny_dnn::max_unpooling_layer<T>;
 
-template <class T>
-using ave_unpool = tiny_dnn::average_unpooling_layer<T>;
+using ave_unpool = tiny_dnn::average_unpooling_layer;
 
 }  // namespace layers
 

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -87,8 +87,7 @@ using q_conv = tiny_dnn::quantized_convolutional_layer<T>;
 
 using max_pool = tiny_dnn::max_pooling_layer;
 
-template <class T>
-using ave_pool = tiny_dnn::average_pooling_layer<T>;
+using ave_pool = tiny_dnn::average_pooling_layer;
 
 using fc = tiny_dnn::fully_connected_layer;
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -25,12 +25,12 @@ struct LoadAndConstruct<tiny_dnn::elementwise_add_layer> {
   }
 };
 
-template <typename Activation>
-struct LoadAndConstruct<tiny_dnn::average_pooling_layer<Activation>> {
+template <>
+struct LoadAndConstruct<tiny_dnn::average_pooling_layer> {
   template <class Archive>
   static void load_and_construct(
     Archive &ar,
-    cereal::construct<tiny_dnn::average_pooling_layer<Activation>> &construct) {
+    cereal::construct<tiny_dnn::average_pooling_layer> &construct) {
     tiny_dnn::shape3d in;
     tiny_dnn::serial_size_t stride_x, stride_y, pool_size_x, pool_size_y;
     tiny_dnn::padding pad_type;
@@ -329,9 +329,9 @@ struct specialize<Archive,
                   tiny_dnn::elementwise_add_layer,
                   cereal::specialization::non_member_serialize> {};
 
-template <class Archive, typename Activation>
+template <class Archive>
 struct specialize<Archive,
-                  tiny_dnn::average_pooling_layer<Activation>,
+                  tiny_dnn::average_pooling_layer,
                   cereal::specialization::non_member_serialize> {};
 
 template <class Archive>
@@ -437,9 +437,9 @@ struct serialization_buddy {
        cereal::make_nvp("dim", layer.dim_));
   }
 
-  template <class Archive, typename Activation>
-  static inline void serialize(
-    Archive &ar, tiny_dnn::average_pooling_layer<Activation> &layer) {
+  template <class Archive>
+  static inline void serialize(Archive &ar,
+                               tiny_dnn::average_pooling_layer &layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_size", layer.in_),
        cereal::make_nvp("pool_size_x", layer.pool_size_x_),
@@ -608,9 +608,8 @@ void serialize(Archive &ar, tiny_dnn::elementwise_add_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-template <class Archive, typename Activation>
-void serialize(Archive &ar,
-               tiny_dnn::average_pooling_layer<Activation> &layer) {
+template <class Archive>
+void serialize(Archive &ar, tiny_dnn::average_pooling_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -1,10 +1,10 @@
 // Copyright (c) 2017, Taiga Nomi
 #ifndef CNN_NO_SERIALIZATION
 
-CNN_REGISTER_LAYER_WITH_ACTIVATIONS(average_pooling_layer, avepool);
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(linear_layer, linear);
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(lrn_layer, lrn);
 
+CNN_REGISTER_LAYER(average_pooling_layer, avepool);
 CNN_REGISTER_LAYER(batch_normalization_layer, batchnorm);
 CNN_REGISTER_LAYER(concat_layer, concat);
 CNN_REGISTER_LAYER(convolutional_layer, conv);


### PR DESCRIPTION
The `Activation` template parameter has been completely decoupled from `average_pooling_layer` and `average_unpooling_layer`.

First of all the base class `partial_connected_layer` is made to inherit directly from layer, followed y refactor in pooling and unpooling layer classes.