### PR TITLE
Drop activation template from linear and lrn layers.

### DIFF
--- a/examples/main.cpp
+++ b/examples/main.cpp
@@ -383,7 +383,7 @@ void sample6_graph() {
   auto in1   = std::make_shared<input_layer>(shape3d(3, 1, 1));
   auto in2   = std::make_shared<input_layer>(shape3d(3, 1, 1));
   auto added = std::make_shared<add>(2, 3);
-  auto out   = std::make_shared<linear_layer<relu>>(3);
+  auto out   = std::make_shared<linear_layer>(3);
 
   // connect
   (in1, in2) << added;

--- a/test/test_caffe_converter.h
+++ b/test/test_caffe_converter.h
@@ -282,7 +282,7 @@ TEST(caffe_converter, lenet) {
   // relu
   EXPECT_EQ((*model)[5]->in_shape()[0], shape3d(500, 1, 1));
   EXPECT_EQ((*model)[5]->out_shape()[0], shape3d(500, 1, 1));
-  EXPECT_EQ((*model)[5]->layer_type(), "linear");
+  EXPECT_EQ((*model)[5]->layer_type(), "relu-activation");
 
   // fc
   EXPECT_EQ((*model)[6]->in_shape()[0], shape3d(500, 1, 1));
@@ -292,7 +292,7 @@ TEST(caffe_converter, lenet) {
   // softmax
   EXPECT_EQ((*model)[7]->in_shape()[0], shape3d(10, 1, 1));
   EXPECT_EQ((*model)[7]->out_shape()[0], shape3d(10, 1, 1));
-  EXPECT_EQ((*model)[7]->layer_type(), "linear");
+  EXPECT_EQ((*model)[7]->layer_type(), "softmax-activation");
 }
 
 TEST(caffe_converter, lenet_v1) {
@@ -452,7 +452,7 @@ TEST(caffe_converter, lenet_v1) {
   // relu
   EXPECT_EQ((*model)[5]->in_shape()[0], shape3d(500, 1, 1));
   EXPECT_EQ((*model)[5]->out_shape()[0], shape3d(500, 1, 1));
-  EXPECT_EQ((*model)[5]->layer_type(), "linear");
+  EXPECT_EQ((*model)[5]->layer_type(), "relu-activation");
 
   // fc
   EXPECT_EQ((*model)[6]->in_shape()[0], shape3d(500, 1, 1));
@@ -462,7 +462,7 @@ TEST(caffe_converter, lenet_v1) {
   // softmax
   EXPECT_EQ((*model)[7]->in_shape()[0], shape3d(10, 1, 1));
   EXPECT_EQ((*model)[7]->out_shape()[0], shape3d(10, 1, 1));
-  EXPECT_EQ((*model)[7]->layer_type(), "linear");
+  EXPECT_EQ((*model)[7]->layer_type(), "softmax-activation");
 }
 
 TEST(caffe_converter, dropout) {

--- a/test/test_lrn_layer.h
+++ b/test/test_lrn_layer.h
@@ -13,8 +13,8 @@
 namespace tiny_dnn {
 
 TEST(lrn, cross) {
-  lrn_layer<identity> lrn(1, 1, 3, 4, /*alpha=*/1.5, /*beta=*/2.0,
-                          norm_region::across_channels);
+  lrn_layer lrn(1, 1, 3, 4, /*alpha=*/1.5, /*beta=*/2.0,
+                norm_region::across_channels);
 
   tiny_dnn::float_t in[4]       = {-1.0, 3.0, 2.0, 5.0};
   tiny_dnn::float_t expected[4] = {
@@ -33,10 +33,8 @@ TEST(lrn, cross) {
 }
 
 TEST(lrn, read_write) {
-  lrn_layer<identity> l1(10, 10, 3, 4, 1.5f, 2.0f,
-                         norm_region::across_channels);
-  lrn_layer<identity> l2(10, 10, 3, 4, 1.5f, 2.0f,
-                         norm_region::across_channels);
+  lrn_layer l1(10, 10, 3, 4, 1.5f, 2.0f, norm_region::across_channels);
+  lrn_layer l2(10, 10, 3, 4, 1.5f, 2.0f, norm_region::across_channels);
 
   l1.init_weight();
   l2.init_weight();

--- a/test/test_network.h
+++ b/test/test_network.h
@@ -72,7 +72,7 @@ TEST(network, construct_multi_by_local_variables) {
   sigmoid_layer sgm2(32, 32, 12);
   max_pool pool1(32, 32, 12, 2);
   relu_layer relu1(16, 16, 12);
-  lrn_layer<identity> lrn(16, 16, 4, 12);
+  lrn_layer lrn(16, 16, 4, 12);
   dropout dp(16 * 16 * 12, 0.5);
   fc full(16 * 16 * 12, 1);
   softmax_layer softmax(1);
@@ -86,7 +86,7 @@ TEST(network, construct_multi_by_temporary_variables) {
   net << conv(32, 32, 5, 1, 6, padding::same) << tanh_layer(32, 32, 6)
       << conv(32, 32, 7, 6, 12, padding::same) << sigmoid_layer(32, 32, 12)
       << max_pool(32, 32, 12, 2) << relu_layer(16, 16, 12)
-      << lrn_layer<identity>(16, 16, 4, 12) << dropout(16 * 16 * 12, 0.5)
+      << lrn_layer(16, 16, 4, 12) << dropout(16 * 16 * 12, 0.5)
       << fc(16 * 16 * 12, 1) << softmax_layer(1);
 }
 

--- a/test/test_nodes.h
+++ b/test/test_nodes.h
@@ -29,7 +29,7 @@ TEST(nodes, graph_no_branch) {
 
   auto pool = std::make_shared<average_pooling_layer>(6, 6, 4, 2);
 
-  auto out = std::make_shared<linear_layer<relu>>(3 * 3 * 4);
+  auto out = std::make_shared<linear_layer>(3 * 3 * 4);
 
   // connect
   in << cnn << pool << out;
@@ -43,11 +43,12 @@ TEST(nodes, graph_branch) {
   auto in1   = std::make_shared<input_layer>(shape3d(3, 1, 1));
   auto in2   = std::make_shared<input_layer>(shape3d(3, 1, 1));
   auto added = std::make_shared<add>(2, 3);
-  auto out   = std::make_shared<linear_layer<relu>>(3);
+  auto lin   = std::make_shared<linear_layer>(3);
+  auto out   = std::make_shared<relu_layer>(3);
 
   // connect
   (in1, in2) << added;
-  added << out;
+  added << lin << out;
 
   network<graph> net;
   construct_graph(net, {in1, in2}, {out});
@@ -65,14 +66,14 @@ TEST(nodes, graph_branch2) {
   input_layer in1(shape3d(3, 1, 1));
   input_layer in2(shape3d(3, 1, 1));
   add added(2, 3);
-  linear_layer<relu> out(3);
-
+  linear_layer out(3);
+  relu_layer out_relu(3);
   // connect
   (in1, in2) << added;
-  added << out;
+  added << out << out_relu;
 
   network<graph> net;
-  construct_graph(net, {&in1, &in2}, {&out});
+  construct_graph(net, {&in1, &in2}, {&out_relu});
 
   auto res = net.predict({{2, 4, 3}, {-1, 2, -5}})[0];
 

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -238,7 +238,7 @@ TEST(serialization, serialize_lrn) {
     {
         "nodes": [
             {
-                "type": "lrn<elu>",
+                "type": "lrn",
                 "in_shape": {
                     "width": 5,
                     "height": 4,

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -578,7 +578,7 @@ TEST(serialization, sequential_weights2) {
   vec_t data = {1, 2, 3, 4, 5, 0};
 
   net1 << batch_normalization_layer(3, 2, 0.01f, 0.99f, net_phase::train)
-       << linear_layer<identity>(3 * 2, 2.0f, 0.5f) << elu_layer(6)
+       << linear_layer(3 * 2, 2.0f, 0.5f) << elu_layer(6)
        << power_layer(shape3d(3, 2, 1), 2.0, 1.5) << leaky_relu_layer(6);
 
   net1.init_weight();

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -174,8 +174,7 @@ inline std::shared_ptr<layer> create_ave_pool(layer_size_t pool_size_w,
 inline std::shared_ptr<layer> create_softmax(const caffe::LayerParameter &layer,
                                              const shape_t &bottom_shape,
                                              shape_t *) {
-  auto sm =
-    std::make_shared<linear_layer<activation::softmax>>(bottom_shape.size());
+  auto sm = std::make_shared<softmax_layer>(bottom_shape.size());
   sm->init_weight();
   return sm;
 }
@@ -183,16 +182,14 @@ inline std::shared_ptr<layer> create_softmax(const caffe::LayerParameter &layer,
 inline std::shared_ptr<layer> create_sigmoid(const caffe::LayerParameter &layer,
                                              const shape_t &bottom_shape,
                                              shape_t *) {
-  auto ce =
-    std::make_shared<linear_layer<activation::sigmoid>>(bottom_shape.size());
+  auto ce = std::make_shared<sigmoid_layer>(bottom_shape.size());
   return ce;
 }
 
 inline std::shared_ptr<layer> create_tanh(const caffe::LayerParameter &layer,
                                           const shape_t &bottom_shape,
                                           shape_t *) {
-  auto tanh =
-    std::make_shared<linear_layer<activation::tan_h>>(bottom_shape.size());
+  auto tanh = std::make_shared<tanh_layer>(bottom_shape.size());
   return tanh;
 }
 
@@ -285,16 +282,14 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
 inline std::shared_ptr<layer> create_relu(const caffe::LayerParameter &layer,
                                           const shape_t &bottom_shape,
                                           shape_t *) {
-  auto relu =
-    std::make_shared<linear_layer<activation::relu>>(bottom_shape.size());
+  auto relu = std::make_shared<relu_layer>(bottom_shape.size());
   return relu;
 }
 
 inline std::shared_ptr<layer> create_elu(const caffe::LayerParameter &layer,
                                          const shape_t &bottom_shape,
                                          shape_t *) {
-  auto elu =
-    std::make_shared<linear_layer<activation::elu>>(bottom_shape.size());
+  auto elu = std::make_shared<elu_layer>(bottom_shape.size());
   return elu;
 }
 

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -514,8 +514,6 @@ inline void load_weights_pool(const caffe::LayerParameter &src, layer *dst) {
 inline std::shared_ptr<layer> create_lrn(const caffe::LayerParameter &layer,
                                          const shape_t &bottom_shape,
                                          shape_t *top_shape) {
-  using lrn_layer = lrn_layer<activation::identity>;
-
   if (!layer.has_lrn_param()) {
     throw nn_error("lrn param missing");
   }

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -16,12 +16,9 @@ namespace tiny_dnn {
 /**
  * element-wise operation: ```f(x) = h(scale*x+bias)```
  */
-template <typename Activation>
-class linear_layer : public feedforward_layer<Activation> {
+class linear_layer : public layer {
  public:
-  CNN_USE_LAYER_MEMBERS;
-
-  typedef feedforward_layer<Activation> Base;
+  using layer::parallelize_;
 
   /**
    * @param dim   [in] number of elements
@@ -31,14 +28,17 @@ class linear_layer : public feedforward_layer<Activation> {
   explicit linear_layer(serial_size_t dim,
                         float_t scale = float_t{1},
                         float_t bias  = float_t{0})
-    : Base({vector_type::data}), dim_(dim), scale_(scale), bias_(bias) {}
+    : layer({vector_type::data}, {vector_type::data}),
+      dim_(dim),
+      scale_(scale),
+      bias_(bias) {}
 
   std::vector<shape3d> in_shape() const override {
     return {shape3d(dim_, 1, 1)};
   }
 
   std::vector<shape3d> out_shape() const override {
-    return {shape3d(dim_, 1, 1), shape3d(dim_, 1, 1)};
+    return {shape3d(dim_, 1, 1)};
   }
 
   std::string layer_type() const override { return "linear"; }
@@ -47,7 +47,6 @@ class linear_layer : public feedforward_layer<Activation> {
                            std::vector<tensor_t *> &out_data) override {
     const tensor_t &in = *in_data[0];
     tensor_t &out      = *out_data[0];
-    tensor_t &a        = *out_data[1];
 
     // do nothing
     CNN_UNREFERENCED_PARAMETER(out);
@@ -57,9 +56,8 @@ class linear_layer : public feedforward_layer<Activation> {
       for (serial_size_t sample       = 0,
                          sample_count = static_cast<serial_size_t>(in.size());
            sample < sample_count; ++sample)
-        a[sample][i] = scale_ * in[sample][i] + bias_;
+        out[sample][i] = scale_ * in[sample][i] + bias_;
     });
-    this->forward_activation(*out_data[0], *out_data[1]);
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -67,11 +65,9 @@ class linear_layer : public feedforward_layer<Activation> {
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
     tensor_t &prev_delta = *in_grad[0];
-    tensor_t &curr_delta = *out_grad[1];
+    tensor_t &curr_delta = *out_grad[0];
 
     CNN_UNREFERENCED_PARAMETER(in_data);
-
-    this->backward_activation(*out_grad[0], *out_data[0], curr_delta);
 
     // @todo revise parallelism strategy
     for (serial_size_t sample = 0;

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -18,19 +18,16 @@ enum class norm_region { across_channels, within_channels };
 /**
  * local response normalization
  */
-template <typename Activation>
-class lrn_layer : public feedforward_layer<Activation> {
+class lrn_layer : public layer {
  public:
-  CNN_USE_LAYER_MEMBERS;
-
-  typedef feedforward_layer<Activation> Base;
+  using layer::parallelize_;
 
   lrn_layer(const shape3d &in_shape,
             serial_size_t local_size,
             float_t alpha      = 1.0,
             float_t beta       = 5.0,
             norm_region region = norm_region::across_channels)
-    : Base({vector_type::data}),
+    : layer({vector_type::data}, {vector_type::data}),
       in_shape_(in_shape),
       size_(local_size),
       alpha_(alpha),
@@ -79,9 +76,7 @@ class lrn_layer : public feedforward_layer<Activation> {
 
   std::vector<shape3d> in_shape() const override { return {in_shape_}; }
 
-  std::vector<shape3d> out_shape() const override {
-    return {in_shape_, in_shape_};
-  }
+  std::vector<shape3d> out_shape() const override { return {in_shape_}; }
 
   std::string layer_type() const override { return "lrn"; }
 
@@ -92,15 +87,12 @@ class lrn_layer : public feedforward_layer<Activation> {
          sample < sample_count; ++sample) {
       vec_t &in  = (*in_data[0])[sample];
       vec_t &out = (*out_data[0])[sample];
-      vec_t &a   = (*out_data[1])[sample];
 
       if (region_ == norm_region::across_channels) {
-        forward_across(in, a);
+        forward_across(in, out);
       } else {
-        forward_within(in, a);
+        forward_within(in, out);
       }
-
-      for_i(parallelize_, out.size(), [&](int i) { out[i] = h_.f(a, i); });
     }
   }
 

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -99,6 +99,8 @@ using dropout = tiny_dnn::dropout_layer;
 
 using input = tiny_dnn::input_layer;
 
+using linear = linear_layer;
+
 using lrn = tiny_dnn::lrn_layer;
 
 using input = tiny_dnn::input_layer;

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -99,8 +99,7 @@ using dropout = tiny_dnn::dropout_layer;
 
 using input = tiny_dnn::input_layer;
 
-template <class T>
-using lrn = tiny_dnn::lrn_layer<T>;
+using lrn = tiny_dnn::lrn_layer;
 
 using input = tiny_dnn::input_layer;
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -139,12 +139,11 @@ struct LoadAndConstruct<tiny_dnn::fully_connected_layer> {
   }
 };
 
-template <typename Activation>
-struct LoadAndConstruct<tiny_dnn::linear_layer<Activation>> {
+template <>
+struct LoadAndConstruct<tiny_dnn::linear_layer> {
   template <class Archive>
   static void load_and_construct(
-    Archive &ar,
-    cereal::construct<tiny_dnn::linear_layer<Activation>> &construct) {
+    Archive &ar, cereal::construct<tiny_dnn::linear_layer> &construct) {
     tiny_dnn::serial_size_t dim;
     tiny_dnn::float_t scale, bias;
 
@@ -358,9 +357,9 @@ struct specialize<Archive,
                   tiny_dnn::fully_connected_layer,
                   cereal::specialization::non_member_serialize> {};
 
-template <class Archive, typename Activation>
+template <class Archive>
 struct specialize<Archive,
-                  tiny_dnn::linear_layer<Activation>,
+                  tiny_dnn::linear_layer,
                   cereal::specialization::non_member_serialize> {};
 
 template <class Archive>
@@ -501,9 +500,8 @@ struct serialization_buddy {
        cereal::make_nvp("has_bias", params_.has_bias_));
   }
 
-  template <class Archive, typename Activation>
-  static inline void serialize(Archive &ar,
-                               tiny_dnn::linear_layer<Activation> &layer) {
+  template <class Archive>
+  static inline void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_size", layer.dim_),
        cereal::make_nvp("scale", layer.scale_),
@@ -636,8 +634,8 @@ void serialize(Archive &ar, tiny_dnn::fully_connected_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-template <class Archive, typename Activation>
-void serialize(Archive &ar, tiny_dnn::linear_layer<Activation> &layer) {
+template <class Archive>
+void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -155,12 +155,11 @@ struct LoadAndConstruct<tiny_dnn::linear_layer<Activation>> {
   }
 };
 
-template <typename Activation>
-struct LoadAndConstruct<tiny_dnn::lrn_layer<Activation>> {
+template <>
+struct LoadAndConstruct<tiny_dnn::lrn_layer> {
   template <class Archive>
   static void load_and_construct(
-    Archive &ar,
-    cereal::construct<tiny_dnn::lrn_layer<Activation>> &construct) {
+    Archive &ar, cereal::construct<tiny_dnn::lrn_layer> &construct) {
     tiny_dnn::shape3d in_shape;
     tiny_dnn::serial_size_t size;
     tiny_dnn::float_t alpha, beta;
@@ -364,9 +363,9 @@ struct specialize<Archive,
                   tiny_dnn::linear_layer<Activation>,
                   cereal::specialization::non_member_serialize> {};
 
-template <class Archive, typename Activation>
+template <class Archive>
 struct specialize<Archive,
-                  tiny_dnn::lrn_layer<Activation>,
+                  tiny_dnn::lrn_layer,
                   cereal::specialization::non_member_serialize> {};
 
 template <class Archive>
@@ -511,9 +510,8 @@ struct serialization_buddy {
        cereal::make_nvp("bias", layer.bias_));
   }
 
-  template <class Archive, typename Activation>
-  static inline void serialize(Archive &ar,
-                               tiny_dnn::lrn_layer<Activation> &layer) {
+  template <class Archive>
+  static inline void serialize(Archive &ar, tiny_dnn::lrn_layer &layer) {
     layer.serialize_prolog(ar);
     ar(cereal::make_nvp("in_shape", layer.in_shape_),
        cereal::make_nvp("size", layer.size_),
@@ -643,8 +641,8 @@ void serialize(Archive &ar, tiny_dnn::linear_layer<Activation> &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-template <class Archive, typename Activation>
-void serialize(Archive &ar, tiny_dnn::lrn_layer<Activation> &layer) {
+template <class Archive>
+void serialize(Archive &ar, tiny_dnn::lrn_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -1,14 +1,13 @@
 // Copyright (c) 2017, Taiga Nomi
 #ifndef CNN_NO_SERIALIZATION
 
-CNN_REGISTER_LAYER_WITH_ACTIVATIONS(linear_layer, linear);
-
 CNN_REGISTER_LAYER(average_pooling_layer, avepool);
 CNN_REGISTER_LAYER(batch_normalization_layer, batchnorm);
 CNN_REGISTER_LAYER(concat_layer, concat);
 CNN_REGISTER_LAYER(convolutional_layer, conv);
 CNN_REGISTER_LAYER(dropout_layer, dropout);
 CNN_REGISTER_LAYER(fully_connected_layer, fully_connected);
+CNN_REGISTER_LAYER(linear_layer, linear);
 CNN_REGISTER_LAYER(lrn_layer, lrn);
 CNN_REGISTER_LAYER(max_pooling_layer, maxpool);
 CNN_REGISTER_LAYER(power_layer, power);

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -2,7 +2,6 @@
 #ifndef CNN_NO_SERIALIZATION
 
 CNN_REGISTER_LAYER_WITH_ACTIVATIONS(linear_layer, linear);
-CNN_REGISTER_LAYER_WITH_ACTIVATIONS(lrn_layer, lrn);
 
 CNN_REGISTER_LAYER(average_pooling_layer, avepool);
 CNN_REGISTER_LAYER(batch_normalization_layer, batchnorm);
@@ -10,6 +9,7 @@ CNN_REGISTER_LAYER(concat_layer, concat);
 CNN_REGISTER_LAYER(convolutional_layer, conv);
 CNN_REGISTER_LAYER(dropout_layer, dropout);
 CNN_REGISTER_LAYER(fully_connected_layer, fully_connected);
+CNN_REGISTER_LAYER(lrn_layer, lrn);
 CNN_REGISTER_LAYER(max_pooling_layer, maxpool);
 CNN_REGISTER_LAYER(power_layer, power);
 CNN_REGISTER_LAYER(slice_layer, slice);


### PR DESCRIPTION
The `Activation` template parameter has been completely decoupled from `linear_layer` and `lrn_layer`.

Refactoring procedure is very much similar to #600 and #601.