### PR TITLE
Drop templating from quantization layers.

### DIFF
--- a/examples/mnist/quantized.cpp
+++ b/examples/mnist/quantized.cpp
@@ -23,30 +23,32 @@ void construct_net(network<sequential> &nn) {
 #undef O
 #undef X
 
+  using q_conv = quantized_convolutional_layer;
+  using ave_pool = average_pooling_layer;
+  using q_fc = quantized_fully_connected_layer;
+
   core::backend_t backend_type = core::backend_t::internal;
   // construct nets
   //
   // C : convolution
   // S : sub-sampling
   // F : fully connected
-  nn << quantized_convolutional_layer<tan_h>(
-          32, 32, 5, 1, 6, padding::valid, true, 1, 1,
-          backend_type)  // C1, 1@32x32-in, 6@28x28-out
-     << average_pooling_layer(28, 28, 6,
-                              2)  // S2, 6@28x28-in, 6@14x14-out
+  nn << q_conv(32, 32, 5, 1, 6, padding::valid, true, 1, 1,
+          backend_type)                    // C1, 1@32x32-in, 6@28x28-out
+     << tanh_layer(28, 28, 6)
+     << ave_pool(28, 28, 6, 2)             // S2, 6@28x28-in, 6@14x14-out
      << tanh_layer(14, 14, 6)
-     << quantized_convolutional_layer<tan_h>(
-          14, 14, 5, 6, 16, connection_table(tbl, 6, 16), padding::valid, true,
-          1, 1,
-          backend_type)  // C3, 6@14x14-in, 16@10x10-in
-     << average_pooling_layer(10, 10, 16,
-                              2)  // S4, 16@10x10-in, 16@5x5-out
+     << q_conv(14, 14, 5, 6, 16, connection_table(tbl, 6, 16),
+               padding::valid, true, 1, 1,
+               backend_type)               // C3, 6@14x14-in, 16@10x10-in
+     << tanh_layer(10, 10, 16)
+     << ave_pool(10, 10, 16, 2)            // S4, 16@10x10-in, 16@5x5-out
      << tanh_layer(5, 5, 16)
-     << quantized_convolutional_layer<tan_h>(
-          5, 5, 5, 16, 120, padding::valid, true, 1, 1,
-          backend_type)  // C5, 16@5x5-in, 120@1x1-out
-     << quantized_fully_connected_layer<tan_h>(
-          120, 10, true, backend_type);  // F6, 120-in, 10-out
+     << q_conv(5, 5, 5, 16, 120, padding::valid, true, 1, 1,
+               backend_type)               // C5, 16@5x5-in, 120@1x1-out
+     << tanh_layer(120)
+     << q_fc(120, 10, true, backend_type)  // F6, 120-in, 10-out
+     << tanh_layer(10);
   // clang-format on
 }
 

--- a/test/test_quantized_convolutional_layer.h
+++ b/test/test_quantized_convolutional_layer.h
@@ -95,12 +95,12 @@ TEST(quantized_convolutional, fprop) {
 
         EXPECT_NEAR(-0.043426, out[0], 2E-2);
         EXPECT_NEAR(1.6769816, out[1], 2E-2);
-        EXPECT_NEAR(1.4858254, out[2], 2E-2);
+        EXPECT_NEAR(1.4731820, out[2], 2E-2);
         EXPECT_NEAR(1.0822733, out[3], 2E-2);
         EXPECT_NEAR(0.0415336, out[4], 2E-2);
         EXPECT_NEAR(-1.997466, out[5], 2E-2);
         EXPECT_NEAR(0.4238461, out[6], 2E-2);
-        EXPECT_NEAR(1.1884713, out[7], 2E-2);
+        EXPECT_NEAR(1.1756143, out[7], 2E-2);
         EXPECT_NEAR(0.8273983, out[8], 2E-2);
         EXPECT_NEAR(-0.192101, out[9], 2E-2);
         EXPECT_NEAR(1.2309504, out[10], 2E-2);
@@ -153,51 +153,23 @@ TEST(quantized_convolutional, fprop_npp) {
     for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
   }
 
-  weight[0] = 0.3;
-  weight[1] = 0.1;
-  weight[2] = 0.2;
-  weight[3] = 0.0;
-  weight[4] = -0.1;
-  weight[5] = -0.1;
-  weight[6] = 0.05;
-  weight[7] = -0.2;
-  weight[8] = 0.05;
+  // clang-format off
+  weight[0] = 0.3;  weight[1] = 0.1;   weight[2] = 0.2;
+  weight[3] = 0.0;  weight[4] = -0.1;  weight[5] = -0.1;
+  weight[6] = 0.05; weight[7] = -0.2;  weight[8] = 0.05;
 
-  weight[9]  = 0.0;
-  weight[10] = -0.1;
-  weight[11] = 0.1;
-  weight[12] = 0.1;
-  weight[13] = -0.2;
-  weight[14] = 0.3;
-  weight[15] = 0.2;
-  weight[16] = -0.3;
-  weight[17] = 0.2;
+  weight[9]  = 0.0; weight[10] = -0.1; weight[11] = 0.1;
+  weight[12] = 0.1; weight[13] = -0.2; weight[14] = 0.3;
+  weight[15] = 0.2; weight[16] = -0.3; weight[17] = 0.2;
 
-  in[0]  = 3;
-  in[1]  = 2;
-  in[2]  = 1;
-  in[3]  = 5;
-  in[4]  = 2;
-  in[5]  = 3;
-  in[6]  = 0;
-  in[7]  = 2;
-  in[8]  = 0;
-  in[9]  = 1;
-  in[10] = 0;
-  in[11] = 6;
-  in[12] = 1;
-  in[13] = 1;
-  in[14] = 10;
-  in[15] = 3;
-  in[16] = -1;
-  in[17] = 2;
-  in[18] = 9;
-  in[19] = 0;
-  in[20] = 1;
-  in[21] = 2;
-  in[22] = 1;
-  in[23] = 5;
+  in[0]  = 3;  in[1]  = 2;  in[2]  = 1;  in[3]  = 5;
+  in[4]  = 2;  in[5]  = 3;  in[6]  = 0;  in[7]  = 2;
+  in[8]  = 0;  in[9]  = 1;  in[10] = 0;  in[11] = 6;
+  in[12] = 1;  in[13] = 1;  in[14] = 10; in[15] = 3;
+  in[16] = -1; in[17] = 2;  in[18] = 9;  in[19] = 0;
+  in[20] = 1;  in[21] = 2;  in[22] = 1;  in[23] = 5;
   in[24] = 5;
+  // clang-format on
 
   {
     l.forward_propagation(in_data, out_data);

--- a/test/test_quantized_convolutional_layer.h
+++ b/test/test_quantized_convolutional_layer.h
@@ -13,12 +13,12 @@
 namespace tiny_dnn {
 
 TEST(quantized_convolutional, setup_internal) {
-  quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2, padding::valid, true,
-                                           1, 1, backend_t::internal);
+  quantized_convolutional_layer l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                  backend_t::internal);
 
   EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
   EXPECT_EQ(l.in_channels(), serial_size_t(3));  // num of input tensors
-  EXPECT_EQ(l.out_channels(), serial_size_t(2));    // num of output tensors
+  EXPECT_EQ(l.out_channels(), serial_size_t(1));    // num of output tensors
   EXPECT_EQ(l.in_data_size(), serial_size_t(25));   // size of input tensors
   EXPECT_EQ(l.out_data_size(), serial_size_t(18));  // size of output tensors
   EXPECT_EQ(l.in_data_shape().size(),
@@ -29,10 +29,10 @@ TEST(quantized_convolutional, setup_internal) {
   EXPECT_EQ(l.weights_grads().size(),
             serial_size_t(2));                       // the wieghts vector size
   EXPECT_EQ(l.inputs().size(), serial_size_t(3));    // num of input edges
-  EXPECT_EQ(l.outputs().size(), serial_size_t(2));   // num of outpus edges
+  EXPECT_EQ(l.outputs().size(), serial_size_t(1));   // num of outpus edges
   EXPECT_EQ(l.in_types().size(), serial_size_t(3));  // num of input data types
   EXPECT_EQ(l.out_types().size(),
-            serial_size_t(2));                   // num of output data types
+            serial_size_t(1));                   // num of output data types
   EXPECT_EQ(l.fan_in_size(), serial_size_t(9));  // num of incoming connections
   EXPECT_EQ(l.fan_out_size(),
             serial_size_t(18));  // num of outgoing connections
@@ -40,14 +40,12 @@ TEST(quantized_convolutional, setup_internal) {
 }
 
 TEST(quantized_convolutional, fprop) {
-  typedef network<sequential> CNN;
-  CNN nn;
+  network<sequential> nn;
 
-  quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2);
+  quantized_convolutional_layer l(5, 5, 3, 1, 2);
 
   // layer::forward_propagation expects tensors, even if we feed only one
-  // input
-  // at a time
+  // input at a time
   auto create_simple_tensor = [](size_t vector_size) {
     return tensor_t(1, vec_t(vector_size));
   };
@@ -55,7 +53,6 @@ TEST(quantized_convolutional, fprop) {
   // create simple tensors that wrap the payload vectors of the correct size
   tensor_t in_tensor     = create_simple_tensor(25),
            out_tensor    = create_simple_tensor(18),
-           a_tensor      = create_simple_tensor(18),
            weight_tensor = create_simple_tensor(18),
            bias_tensor   = create_simple_tensor(2);
 
@@ -71,12 +68,11 @@ TEST(quantized_convolutional, fprop) {
   in_data.push_back(&weight_tensor);
   in_data.push_back(&bias_tensor);
   out_data.push_back(&out_tensor);
-  out_data.push_back(&a_tensor);
   l.setup(false);
   {
     l.forward_propagation(in_data, out_data);
 
-    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+    for (auto o : out) EXPECT_NEAR(0.0, o, 1E-3);
   }
 
   // clang-format off
@@ -97,97 +93,141 @@ TEST(quantized_convolutional, fprop) {
     {
         l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.4875026, out[0], 2E-2);
-        EXPECT_NEAR(0.8388910, out[1], 2E-2);
-        EXPECT_NEAR(0.8099984, out[2], 2E-2);
-        EXPECT_NEAR(0.7407749, out[3], 2E-2);
-        EXPECT_NEAR(0.5000000, out[4], 2E-2);
-        EXPECT_NEAR(0.1192029, out[5], 2E-2);
-        EXPECT_NEAR(0.5986877, out[6], 2E-2);
-        EXPECT_NEAR(0.7595109, out[7], 2E-2);
-        EXPECT_NEAR(0.6899745, out[8], 2E-2);
+        EXPECT_NEAR(-0.043426, out[0], 2E-2);
+        EXPECT_NEAR(1.6769816, out[1], 2E-2);
+        EXPECT_NEAR(1.4858254, out[2], 2E-2);
+        EXPECT_NEAR(1.0822733, out[3], 2E-2);
+        EXPECT_NEAR(0.0415336, out[4], 2E-2);
+        EXPECT_NEAR(-1.997466, out[5], 2E-2);
+        EXPECT_NEAR(0.4238461, out[6], 2E-2);
+        EXPECT_NEAR(1.1884713, out[7], 2E-2);
+        EXPECT_NEAR(0.8273983, out[8], 2E-2);
+        EXPECT_NEAR(-0.192101, out[9], 2E-2);
+        EXPECT_NEAR(1.2309504, out[10], 2E-2);
+        EXPECT_NEAR(2.2292108, out[11], 2E-2);
+        EXPECT_NEAR(0.5300441, out[12], 2E-2);
+        EXPECT_NEAR(1.7407004, out[13], 2E-2);
+        EXPECT_NEAR(1.6345025, out[14], 2E-2);
+        EXPECT_NEAR(0.6362420, out[15], 2E-2);
+        EXPECT_NEAR(3.4186277, out[16], 2E-2);
+        EXPECT_NEAR(-0.489455, out[17], 2E-2);
     }
   // clang-format on
 }
 
-/*#ifdef CNN_USE_NNPACK
+#ifdef CNN_USE_NNPACK
 TEST(quantized_convolutional, fprop_npp) {
-    typedef network<sequential> CNN;
-    CNN nn;
+  using network = network<sequential>;
+  network nn;
 
-    quantized_convolutional_layer<sigmoid> l(5, 5, 3, 1, 2,
-        padding::valid, true, 1, 1, backend_t::nnpack);
+  quantized_convolutional_layer l(5, 5, 3, 1, 2, padding::valid, true, 1, 1,
+                                  backend_t::nnpack);
 
-    // layer::forward_propagation expects tensors, even if we feed only one
-input at a time
-    auto create_simple_tensor = [](size_t vector_size) {
-        return tensor_t(1, vec_t(vector_size));
-    };
+  // layer::forward_propagation expects tensors, even if we feed only one
+  input at a time auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    // create simple tensors that wrap the payload vectors of the correct size
-    tensor_t in_tensor = create_simple_tensor(25)
-        , out_tensor = create_simple_tensor(18)
-        , a_tensor = create_simple_tensor(18)
-        , weight_tensor = create_simple_tensor(18)
-        , bias_tensor = create_simple_tensor(2);
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor     = create_simple_tensor(25),
+           out_tensor    = create_simple_tensor(18),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor   = create_simple_tensor(2);
 
-    // short-hand references to the payload vectors
-    vec_t &in = in_tensor[0]
-        , &out = out_tensor[0]
-        , &weight = weight_tensor[0];
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    ASSERT_EQ(l.in_shape()[1].size(), serial_size_t(18)); // weight
+  ASSERT_EQ(l.in_shape()[1].size(), serial_size_t(18));  // weight
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-    std::vector<tensor_t*> in_data, out_data;
-    in_data.push_back(&in_tensor);
-    in_data.push_back(&weight_tensor);
-    in_data.push_back(&bias_tensor);
-    out_data.push_back(&out_tensor);
-    out_data.push_back(&a_tensor);
-    l.setup(false);
-    {
-        l.forward_propagation(in_data, out_data);
+  std::vector<tensor_t *> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        for (auto o: out)
-            EXPECT_NEAR(0.5, o, 1E-3);
-    }
+    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+  }
 
-    weight[0] = 0.3;  weight[1] = 0.1; weight[2] = 0.2;
-    weight[3] = 0.0;  weight[4] =-0.1; weight[5] =-0.1;
-    weight[6] = 0.05; weight[7] =-0.2; weight[8] = 0.05;
+  weight[0] = 0.3;
+  weight[1] = 0.1;
+  weight[2] = 0.2;
+  weight[3] = 0.0;
+  weight[4] = -0.1;
+  weight[5] = -0.1;
+  weight[6] = 0.05;
+  weight[7] = -0.2;
+  weight[8] = 0.05;
 
-    weight[9]  = 0.0; weight[10] =-0.1; weight[11] = 0.1;
-    weight[12] = 0.1; weight[13] =-0.2; weight[14] = 0.3;
-    weight[15] = 0.2; weight[16] =-0.3; weight[17] = 0.2;
+  weight[9]  = 0.0;
+  weight[10] = -0.1;
+  weight[11] = 0.1;
+  weight[12] = 0.1;
+  weight[13] = -0.2;
+  weight[14] = 0.3;
+  weight[15] = 0.2;
+  weight[16] = -0.3;
+  weight[17] = 0.2;
 
-    in[0] = 3;  in[1] = 2;  in[2] = 1;  in[3] = 5; in[4] = 2;
-    in[5] = 3;  in[6] = 0;  in[7] = 2;  in[8] = 0; in[9] = 1;
-    in[10] = 0; in[11] = 6; in[12] = 1; in[13] = 1; in[14] = 10;
-    in[15] = 3; in[16] =-1; in[17] = 2; in[18] = 9; in[19] = 0;
-    in[20] = 1; in[21] = 2; in[22] = 1; in[23] = 5; in[24] = 5;
+  in[0]  = 3;
+  in[1]  = 2;
+  in[2]  = 1;
+  in[3]  = 5;
+  in[4]  = 2;
+  in[5]  = 3;
+  in[6]  = 0;
+  in[7]  = 2;
+  in[8]  = 0;
+  in[9]  = 1;
+  in[10] = 0;
+  in[11] = 6;
+  in[12] = 1;
+  in[13] = 1;
+  in[14] = 10;
+  in[15] = 3;
+  in[16] = -1;
+  in[17] = 2;
+  in[18] = 9;
+  in[19] = 0;
+  in[20] = 1;
+  in[21] = 2;
+  in[22] = 1;
+  in[23] = 5;
+  in[24] = 5;
 
-    {
-        l.forward_propagation(in_data, out_data);
+  {
+    l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.4875026, out[0], 2E-2);
-        EXPECT_NEAR(0.8388910, out[1], 2E-2);
-        EXPECT_NEAR(0.8099984, out[2], 2E-2);
-        EXPECT_NEAR(0.7407749, out[3], 2E-2);
-        EXPECT_NEAR(0.5000000, out[4], 2E-2);
-        EXPECT_NEAR(0.1192029, out[5], 2E-2);
-        EXPECT_NEAR(0.5986877, out[6], 2E-2);
-        EXPECT_NEAR(0.7595109, out[7], 2E-2);
-        EXPECT_NEAR(0.6899745, out[8], 2E-2);
-    }
+    EXPECT_NEAR(-0.043426, out[0], 2E-2);
+    EXPECT_NEAR(1.6769816, out[1], 2E-2);
+    EXPECT_NEAR(1.4858254, out[2], 2E-2);
+    EXPECT_NEAR(1.0822733, out[3], 2E-2);
+    EXPECT_NEAR(0.0415336, out[4], 2E-2);
+    EXPECT_NEAR(-1.997466, out[5], 2E-2);
+    EXPECT_NEAR(0.4238461, out[6], 2E-2);
+    EXPECT_NEAR(1.1884713, out[7], 2E-2);
+    EXPECT_NEAR(0.8273983, out[8], 2E-2);
+    EXPECT_NEAR(-0.192101, out[9], 2E-2);
+    EXPECT_NEAR(1.2309504, out[10], 2E-2);
+    EXPECT_NEAR(2.2292108, out[11], 2E-2);
+    EXPECT_NEAR(0.5300441, out[12], 2E-2);
+    EXPECT_NEAR(1.7407004, out[13], 2E-2);
+    EXPECT_NEAR(1.6345025, out[14], 2E-2);
+    EXPECT_NEAR(0.6362420, out[15], 2E-2);
+    EXPECT_NEAR(3.4186277, out[16], 2E-2);
+    EXPECT_NEAR(-0.489455, out[17], 2E-2);
+  }
 }
-#endif*/
+#endif
 
 /*
 TEST(quantized_convolutional, gradient_check) { // tanh - mse
     network<sequential> nn;
-    nn << quantized_convolutional_layer<tan_h>(5, 5, 3, 1, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -200,7 +240,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check2) { // sigmoid - mse
     network<sequential> nn;
-    nn << quantized_convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
+1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -213,8 +254,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check3) { // rectified - mse
     network<sequential> nn;
-
-    nn << quantized_convolutional_layer<rectified_linear>(5, 5, 3, 1, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << relu_layer(3, 3, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -227,8 +267,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check4) { // identity - mse
     network<sequential> nn;
-
-    nn << quantized_convolutional_layer<identity>(5, 5, 3, 1, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -241,8 +280,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check5) { // sigmoid - cross-entropy
     network<sequential> nn;
-
-    nn << quantized_convolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
+1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -255,8 +294,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, read_write)
 {
-    quantized_convolutional_layer<tan_h> l1(5, 5, 3, 1, 1);
-    quantized_convolutional_layer<tan_h> l2(5, 5, 3, 1, 1);
+    quantized_convolutional_layer l1(5, 5, 3, 1, 1);
+    quantized_convolutional_layer l2(5, 5, 3, 1, 1);
 
     l1.init_weight();
     l2.init_weight();
@@ -274,9 +313,9 @@ TEST(quantized_convolutional, read_write2) {
     };
 #undef O
 #undef X
-    quantized_convolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+    quantized_convolutional_layer layer1(14, 14, 5, 3, 6,
 connection_table(connection, 3, 6));
-    quantized_convolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+    quantized_convolutional_layer layer2(14, 14, 5, 3, 6,
 connection_table(connection, 3, 6));
     layer1.init_weight();
     layer2.init_weight();

--- a/test/test_quantized_deconvolutional_layer.h
+++ b/test/test_quantized_deconvolutional_layer.h
@@ -144,30 +144,17 @@ TEST(quantized_deconvolutional, fprop2) {
     for (auto o : out) EXPECT_NEAR(0.0, o, 1E-3);
   }
 
-  weight[0] = 0.3;
-  weight[1] = 0.1;
-  weight[2] = 0.2;
-  weight[3] = 0.0;
-  weight[4] = -0.1;
-  weight[5] = -0.1;
-  weight[6] = 0.05;
-  weight[7] = -0.2;
-  weight[8] = 0.05;
+  // clang-format off
+  weight[0] = 0.3f;  weight[1] = 0.1f; weight[2] = 0.2f;
+  weight[3] = 0.0f;  weight[4] =-0.1f; weight[5] =-0.1f;
+  weight[6] = 0.05f; weight[7] =-0.2f; weight[8] = 0.05f;
 
-  weight[9]  = 0.0;
-  weight[10] = -0.1;
-  weight[11] = 0.1;
-  weight[12] = 0.1;
-  weight[13] = -0.2;
-  weight[14] = 0.3;
-  weight[15] = 0.2;
-  weight[16] = -0.3;
-  weight[17] = 0.2;
+  weight[9]  = 0.0f; weight[10] =-0.1f; weight[11] = 0.1f;
+  weight[12] = 0.1f; weight[13] =-0.2f; weight[14] = 0.3f;
+  weight[15] = 0.2f; weight[16] =-0.3f; weight[17] = 0.2f;
 
-  in[0] = 3;
-  in[1] = 2;
-  in[2] = 3;
-  in[3] = 0;
+  in[0] = 3;  in[1] = 2;
+  in[2] = 3;  in[3] = 0;
 
   {
     l.forward_propagation(in_data, out_data);
@@ -180,7 +167,16 @@ TEST(quantized_deconvolutional, fprop2) {
     EXPECT_NEAR(0.8049019, out[5], 1E-2);
     EXPECT_NEAR(-0.797058, out[6], 1E-2);
     EXPECT_NEAR(1.1029412, out[7], 1E-2);
+    EXPECT_NEAR(0.1566666, out[8], 1E-2);
+    EXPECT_NEAR(-0.797058, out[9], 1E-2);
+    EXPECT_NEAR(-0.551176, out[10], 1E-2);
+    EXPECT_NEAR(0.1045097, out[11], 1E-2);
+    EXPECT_NEAR(0.1566666, out[12], 1E-2);
+    EXPECT_NEAR(-0.603333, out[13], 1E-2);
+    EXPECT_NEAR(0.1566666, out[14], 1E-2);
+    EXPECT_NEAR(0.0001960, out[15], 1E-2);
   }
+  // clang-format on
 }
 
 /*

--- a/test/test_quantized_deconvolutional_layer.h
+++ b/test/test_quantized_deconvolutional_layer.h
@@ -13,12 +13,12 @@
 namespace tiny_dnn {
 
 TEST(quantized_deconvolutional, setup_internal) {
-  quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2, padding::valid,
-                                             true, 1, 1, backend_t::internal);
+  quantized_deconvolutional_layer l(2, 2, 3, 1, 2, padding::valid, true, 1, 1,
+                                    backend_t::internal);
 
   EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
   EXPECT_EQ(l.in_channels(), serial_size_t(3));  // num of input tensors
-  EXPECT_EQ(l.out_channels(), serial_size_t(2));    // num of output tensors
+  EXPECT_EQ(l.out_channels(), serial_size_t(1));    // num of output tensors
   EXPECT_EQ(l.in_data_size(), serial_size_t(4));    // size of input tensors
   EXPECT_EQ(l.out_data_size(), serial_size_t(32));  // size of output tensors
   EXPECT_EQ(l.in_data_shape().size(),
@@ -29,10 +29,10 @@ TEST(quantized_deconvolutional, setup_internal) {
   EXPECT_EQ(l.weights_grads().size(),
             serial_size_t(2));                       // the wieghts vector size
   EXPECT_EQ(l.inputs().size(), serial_size_t(3));    // num of input edges
-  EXPECT_EQ(l.outputs().size(), serial_size_t(2));   // num of outpus edges
+  EXPECT_EQ(l.outputs().size(), serial_size_t(1));   // num of outpus edges
   EXPECT_EQ(l.in_types().size(), serial_size_t(3));  // num of input data types
   EXPECT_EQ(l.out_types().size(),
-            serial_size_t(2));                   // num of output data types
+            serial_size_t(1));                   // num of output data types
   EXPECT_EQ(l.fan_in_size(), serial_size_t(9));  // num of incoming connections
   EXPECT_EQ(l.fan_out_size(),
             serial_size_t(18));  // num of outgoing connections
@@ -40,10 +40,7 @@ TEST(quantized_deconvolutional, setup_internal) {
 }
 
 TEST(quantized_deconvolutional, fprop) {
-  typedef network<sequential> CNN;
-  CNN nn;
-
-  quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2);
+  quantized_deconvolutional_layer l(2, 2, 3, 1, 2);
 
   // layer::forward_propagation expects tensors, even if we feed only one
   // input
@@ -55,7 +52,6 @@ TEST(quantized_deconvolutional, fprop) {
   // create simple tensors that wrap the payload vectors of the correct size
   tensor_t in_tensor     = create_simple_tensor(4),
            out_tensor    = create_simple_tensor(32),
-           a_tensor      = create_simple_tensor(32),
            weight_tensor = create_simple_tensor(18),
            bias_tensor   = create_simple_tensor(2);
 
@@ -71,12 +67,11 @@ TEST(quantized_deconvolutional, fprop) {
   in_data.push_back(&weight_tensor);
   in_data.push_back(&bias_tensor);
   out_data.push_back(&out_tensor);
-  out_data.push_back(&a_tensor);
   l.setup(false);
   {
     l.forward_propagation(in_data, out_data);
 
-    for (auto o : out) EXPECT_NEAR(0.5, o, 1E-3);
+    for (auto o : out) EXPECT_NEAR(0.0, o, 1E-3);
   }
 
   // clang-format off
@@ -94,78 +89,104 @@ TEST(quantized_deconvolutional, fprop) {
     {
         l.forward_propagation(in_data, out_data);
 
-        EXPECT_NEAR(0.7109495, out[0], 1E-2);
-        EXPECT_NEAR(0.7109495, out[1], 1E-2);
-        EXPECT_NEAR(0.6899745, out[2], 1E-2);
-        EXPECT_NEAR(0.5986877, out[3], 1E-2);
-        EXPECT_NEAR(0.7109495, out[4], 1E-2);
-        EXPECT_NEAR(0.5000000, out[5], 1E-2);
-        EXPECT_NEAR(0.5249792, out[6], 1E-2);
-        EXPECT_NEAR(0.4501660, out[7], 1E-2);
-        EXPECT_NEAR(0.5374298, out[8], 1E-2);
-        EXPECT_NEAR(0.3100255, out[9], 1E-2);
-        EXPECT_NEAR(0.3658644, out[10], 1E-2);
-        EXPECT_NEAR(0.5249791, out[11], 1E-2);
-        EXPECT_NEAR(0.5374298, out[12], 1E-2);
-        EXPECT_NEAR(0.3543437, out[13], 1E-2);
-        EXPECT_NEAR(0.5374298, out[14], 1E-2);
-        EXPECT_NEAR(0.5000000, out[15], 1E-2);
+        EXPECT_NEAR(0.9017647, out[0], 1E-2);
+        EXPECT_NEAR(0.9017647, out[1], 1E-2);
+        EXPECT_NEAR(0.8049019, out[2], 1E-2);
+        EXPECT_NEAR(0.4025490, out[3], 1E-2);
+        EXPECT_NEAR(0.9017647, out[4], 1E-2);
+        EXPECT_NEAR(0.0001960, out[5], 1E-2);
+        EXPECT_NEAR(0.1045097, out[6], 1E-2);
+        EXPECT_NEAR(-0.200980, out[7], 1E-2);
+        EXPECT_NEAR(0.1566666, out[8], 1E-2);
+        EXPECT_NEAR(-0.797058, out[9], 1E-2);
+        EXPECT_NEAR(-0.551176, out[10], 1E-2);
+        EXPECT_NEAR(0.1045097, out[11], 1E-2);
+        EXPECT_NEAR(0.1566666, out[12], 1E-2);
+        EXPECT_NEAR(-0.603333, out[13], 1E-2);
+        EXPECT_NEAR(0.1566666, out[14], 1E-2);
+        EXPECT_NEAR(0.0001960, out[15], 1E-2);
     }
   // clang-format on
 }
 
-/*
-
 TEST(quantized_deconvolutional, fprop2) {
-    typedef network<sequential> CNN;
-    CNN nn;
+  quantized_deconvolutional_layer l(2, 2, 3, 1, 2, padding::same);
 
-    quantized_deconvolutional_layer<sigmoid> l(2, 2, 3, 1, 2, padding::same);
+  // layer::forward_propagation expects tensors, even if we feed only one
+  // input at a time
+  auto create_simple_tensor = [](size_t vector_size) {
+    return tensor_t(1, vec_t(vector_size));
+  };
 
-    vec_t in(4), out(32), a(32), weight(18), bias(2);
+  // create simple tensors that wrap the payload vectors of the correct size
+  tensor_t in_tensor     = create_simple_tensor(4),
+           out_tensor    = create_simple_tensor(32),
+           weight_tensor = create_simple_tensor(18),
+           bias_tensor   = create_simple_tensor(2);
 
-    ASSERT_EQ(l.in_shape()[1].size(), 18); // weight
+  // short-hand references to the payload vectors
+  vec_t &in = in_tensor[0], &out = out_tensor[0], &weight = weight_tensor[0];
 
-    uniform_rand(in.begin(), in.end(), -1.0, 1.0);
+  ASSERT_EQ(l.in_shape()[1].size(), serial_size_t(18));  // weight
 
-    std::vector<vec_t*> in_data, out_data;
-    in_data.push_back(&in);
-    in_data.push_back(&weight);
-    in_data.push_back(&bias);
-    out_data.push_back(&out);
-    out_data.push_back(&a);
-    l.setup(false, 1);
-    {
-        l.forward_propagation(0, in_data, out_data);
+  uniform_rand(in.begin(), in.end(), -1.0, 1.0);
 
-        for (auto o: out)
-            EXPECT_NEAR(0.5, o, 1E-3);
-    }
+  std::vector<tensor_t *> in_data, out_data;
+  in_data.push_back(&in_tensor);
+  in_data.push_back(&weight_tensor);
+  in_data.push_back(&bias_tensor);
+  out_data.push_back(&out_tensor);
 
-    weight[0] = 0.3;  weight[1] = 0.1; weight[2] = 0.2;
-    weight[3] = 0.0;  weight[4] =-0.1; weight[5] =-0.1;
-    weight[6] = 0.05; weight[7] =-0.2; weight[8] = 0.05;
+  l.setup(false);
+  {
+    l.forward_propagation(in_data, out_data);
 
-    weight[9]  = 0.0; weight[10] =-0.1; weight[11] = 0.1;
-    weight[12] = 0.1; weight[13] =-0.2; weight[14] = 0.3;
-    weight[15] = 0.2; weight[16] =-0.3; weight[17] = 0.2;
+    for (auto o : out) EXPECT_NEAR(0.0, o, 1E-3);
+  }
 
-    in[0] = 3;  in[1] = 2;
-    in[2] = 3;  in[3] = 0;
+  weight[0] = 0.3;
+  weight[1] = 0.1;
+  weight[2] = 0.2;
+  weight[3] = 0.0;
+  weight[4] = -0.1;
+  weight[5] = -0.1;
+  weight[6] = 0.05;
+  weight[7] = -0.2;
+  weight[8] = 0.05;
 
-    {
-        l.forward_propagation(0, in_data, out_data);
+  weight[9]  = 0.0;
+  weight[10] = -0.1;
+  weight[11] = 0.1;
+  weight[12] = 0.1;
+  weight[13] = -0.2;
+  weight[14] = 0.3;
+  weight[15] = 0.2;
+  weight[16] = -0.3;
+  weight[17] = 0.2;
 
-        EXPECT_NEAR(0.5000000, out[0], 1E-2);
-        EXPECT_NEAR(0.5249792, out[1], 1E-2);
-        EXPECT_NEAR(0.3100255, out[2], 1E-2);
-        EXPECT_NEAR(0.3658644, out[3], 1E-2);
-    }
+  in[0] = 3;
+  in[1] = 2;
+  in[2] = 3;
+  in[3] = 0;
+
+  {
+    l.forward_propagation(in_data, out_data);
+
+    EXPECT_NEAR(0.0001960, out[0], 1E-2);
+    EXPECT_NEAR(0.1045097, out[1], 1E-2);
+    EXPECT_NEAR(-0.797058, out[2], 1E-2);
+    EXPECT_NEAR(-0.551176, out[3], 1E-2);
+    EXPECT_NEAR(-0.707647, out[4], 1E-2);
+    EXPECT_NEAR(0.8049019, out[5], 1E-2);
+    EXPECT_NEAR(-0.797058, out[6], 1E-2);
+    EXPECT_NEAR(1.1029412, out[7], 1E-2);
+  }
 }
 
+/*
 TEST(quantized_deconvolutional, gradient_check) { // tanh - mse
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer<tan_h>(5, 5, 3, 1, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -178,7 +199,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check2) { // sigmoid - mse
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
+1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -191,8 +213,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check3) { // rectified - mse
     network<sequential> nn;
-
-    nn << quantized_deconvolutional_layer<rectified_linear>(5, 5, 3, 1, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -205,8 +226,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check4) { // identity - mse
     network<sequential> nn;
-
-    nn << quantized_deconvolutional_layer<identity>(5, 5, 3, 1, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -219,8 +239,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check5) { // sigmoid - cross-entropy
     network<sequential> nn;
-
-    nn << quantized_deconvolutional_layer<sigmoid>(5, 5, 3, 1, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
+1);
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -233,8 +253,8 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, read_write)
 {
-    quantized_deconvolutional_layer<tan_h> l1(5, 5, 3, 1, 1);
-    quantized_deconvolutional_layer<tan_h> l2(5, 5, 3, 1, 1);
+    quantized_deconvolutional_layer l1(5, 5, 3, 1, 1);
+    quantized_deconvolutional_layer l2(5, 5, 3, 1, 1);
 
     l1.init_weight();
     l2.init_weight();
@@ -252,9 +272,9 @@ TEST(quantized_deconvolutional, read_write2) {
     };
 #undef O
 #undef X
-    quantized_deconvolutional_layer<tan_h> layer1(14, 14, 5, 3, 6,
+    quantized_deconvolutional_layer layer1(14, 14, 5, 3, 6,
 connection_table(connection, 3, 6));
-    quantized_deconvolutional_layer<tan_h> layer2(14, 14, 5, 3, 6,
+    quantized_deconvolutional_layer layer2(14, 14, 5, 3, 6,
 connection_table(connection, 3, 6));
     layer1.init_weight();
     layer2.init_weight();

--- a/test/test_quantized_fully_connected_layer.h
+++ b/test/test_quantized_fully_connected_layer.h
@@ -12,93 +12,107 @@
 
 namespace tiny_dnn {
 
-/*
 TEST(quantized_fully_connected, train) {
-    network<sequential> nn;
-    adagrad optimizer;
+  network<sequential> nn;
+  adagrad optimizer;
 
-    nn << quantized_fully_connected_layer<sigmoid>(3, 2);
+  nn << quantized_fully_connected_layer(3, 2) << sigmoid_layer(2);
 
-    vec_t a(3), t(2), a2(3), t2(2);
+  vec_t a(3), t(2), a2(3), t2(2);
 
-    a[0] = 3.0; a[1] = 0.0; a[2] = -1.0;
-    t[0] = 0.3; t[1] = 0.7;
+  // clang-format off
+  a[0] = 3.0;  a[1] = 0.0;  a[2] = -1.0;
+  t[0] = 0.3;  t[1] = 0.7;
 
-    a2[0] = 0.2; a2[1] = 0.5; a2[2] = 4.0;
-    t2[0] = 0.5; t2[1] = 0.1;
+  a2[0] = 0.2; a2[1] = 0.5; a2[2] = 4.0;
+  t2[0] = 0.5; t2[1] = 0.1;
+  // clang-format on
 
-    std::vector<vec_t> data, train;
+  std::vector<vec_t> data, train;
 
-    for (int i = 0; i < 100; i++) {
-        data.push_back(a);
-        data.push_back(a2);
-        train.push_back(t);
-        train.push_back(t2);
-    }
-    optimizer.alpha = 0.1;
-    nn.train<mse>(optimizer, data, train, 1, 10);
+  for (int i = 0; i < 100; i++) {
+    data.push_back(a);
+    data.push_back(a2);
+    train.push_back(t);
+    train.push_back(t2);
+  }
+  optimizer.alpha = 0.1;
+  nn.train<mse>(optimizer, data, train, 1, 10);
 
-    vec_t predicted = nn.predict(a);
+  vec_t predicted = nn.predict(a);
 
-    EXPECT_NEAR(predicted[0], t[0], 2E-2);
-    EXPECT_NEAR(predicted[1], t[1], 2E-2);
+  EXPECT_NEAR(predicted[0], t[0], 2E-2);
+  EXPECT_NEAR(predicted[1], t[1], 2E-2);
 
-    predicted = nn.predict(a2);
+  predicted = nn.predict(a2);
 
-    EXPECT_NEAR(predicted[0], t2[0], 5E-2);
-    EXPECT_NEAR(predicted[1], t2[1], 5E-2);
+  EXPECT_NEAR(predicted[0], t2[0], 5E-2);
+  EXPECT_NEAR(predicted[1], t2[1], 5E-2);
 }
 
 TEST(quantized_fully_connected, train2) {
-    network<sequential> nn;
-    gradient_descent optimizer;
+  network<sequential> nn;
+  gradient_descent optimizer;
 
-    nn << quantized_fully_connected_layer<tan_h>(4, 6)
-       << quantized_fully_connected_layer<tan_h>(6, 3);
+  nn << quantized_fully_connected_layer<tan_h>(4, 6) << tanh_layer(6)
+     << quantized_fully_connected_layer<tan_h>(6, 3) << tanh_layer(3);
 
-    vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
+  vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
 
-    a[0] = 3.0; a[1] = 1.0; a[2] = -1.0; a[3] = 4.0;
-    t[0] = 0.3; t[1] = 0.7; t[2] = 0.3;
+  // clang-format on
+  a[0] = 3.0;
+  a[1] = 1.0;
+  a[2] = -1.0;
+  a[3] = 4.0;
+  t[0] = 0.3;
+  t[1] = 0.7;
+  t[2] = 0.3;
 
-    a2[0] = 1.0; a2[1] = 0.0; a2[2] = 4.0; a2[3] = 2.0;
-    t2[0] = 0.6; t2[1] = 0.0; t2[2] = 0.1;
+  a2[0] = 1.0;
+  a2[1] = 0.0;
+  a2[2] = 4.0;
+  a2[3] = 2.0;
+  t2[0] = 0.6;
+  t2[1] = 0.0;
+  t2[2] = 0.1;
+  // clang-format on
 
-    std::vector<vec_t> data, train;
+  std::vector<vec_t> data, train;
 
-    for (int i = 0; i < 100; i++) {
-        data.push_back(a);
-        data.push_back(a2);
-        train.push_back(t);
-        train.push_back(t2);
-    }
-    optimizer.alpha = 0.1;
-    nn.train<mse>(optimizer, data, train, 1, 10);
+  for (int i = 0; i < 100; i++) {
+    data.push_back(a);
+    data.push_back(a2);
+    train.push_back(t);
+    train.push_back(t2);
+  }
+  optimizer.alpha = 0.1;
+  nn.train<mse>(optimizer, data, train, 1, 10);
 
-    vec_t predicted = nn.predict(a);
+  vec_t predicted = nn.predict(a);
 
-    EXPECT_NEAR(predicted[0], t[0], 5E-2);
-    EXPECT_NEAR(predicted[1], t[1], 5E-2);
+  EXPECT_NEAR(predicted[0], t[0], 5E-2);
+  EXPECT_NEAR(predicted[1], t[1], 5E-2);
 
-    predicted = nn.predict(a2);
+  predicted = nn.predict(a2);
 
-    EXPECT_NEAR(predicted[0], t2[0], 5E-2);
-    EXPECT_NEAR(predicted[1], t2[1], 5E-2);
+  EXPECT_NEAR(predicted[0], t2[0], 5E-2);
+  EXPECT_NEAR(predicted[1], t2[1], 5E-2);
 }
 
 TEST(quantized_fully_connected, gradient_check) {
-    network<sequential> nn;
-    nn << quantized_fully_connected_layer<tan_h>(50, 10);
+  network<sequential> nn;
+  nn << quantized_fully_connected_layer(50, 10) << tanh_layer(10);
 
-    vec_t a(50, 0.0);
-    label_t t = 9;
+  vec_t a(50, 0.0);
+  label_t t = 9;
 
-    uniform_rand(a.begin(), a.end(), -1, 1);
-    nn.init_weight();
-    EXPECT_TRUE(nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(),
-GRAD_CHECK_ALL));
+  uniform_rand(a.begin(), a.end(), -1, 1);
+  nn.init_weight();
+  EXPECT_TRUE(
+    nn.gradient_check<mse>(&a, &t, 1, epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
+/*
 TEST(quantized_fully_connected, read_write)
 {
     quantized_fully_connected_layer<tan_h> l1(100, 100);
@@ -111,7 +125,7 @@ TEST(quantized_fully_connected, read_write)
 }*/
 
 TEST(quantized_fully_connected, forward) {
-  quantized_fully_connected_layer<identity> l(4, 2);
+  quantized_fully_connected_layer l(4, 2);
   EXPECT_EQ(l.in_channels(), serial_size_t(3));  // in, W and b
 
   l.weight_init(weight_init::constant(1.0));
@@ -126,28 +140,26 @@ TEST(quantized_fully_connected, forward) {
   }
 }
 
-/*#ifdef CNN_USE_NNPACK
-TEST(quantized_fully_connected, forward_nnp)
-{
-    quantized_fully_connected_layer<identity> l(4, 2, true,
-core::backend_t::nnpack);
-    EXPECT_EQ(l.in_channels(), serial_size_t(3)); // in, W and b
+#ifdef CNN_USE_NNPACK
+TEST(quantized_fully_connected, forward_nnp) {
+  quantized_fully_connected_layer l(4, 2, true, core::backend_t::nnpack);
+  EXPECT_EQ(l.in_channels(), serial_size_t(3));  // in, W and b
 
-    l.weight_init(weight_init::constant(1.0));
-    l.bias_init(weight_init::constant(0.5));
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(0.5));
 
-    vec_t in = {0,1,2,3};
-    vec_t out = l.forward({ {in} })[0][0];
-    vec_t out_expected = {6.5, 6.5}; // 0+1+2+3+0.5
+  vec_t in           = {0, 1, 2, 3};
+  vec_t out          = l.forward({{in}})[0][0];
+  vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
-    for (size_t i = 0; i < out_expected.size(); i++) {
-        EXPECT_NEAR(out_expected[i], out[i], 1E-2);
-    }
+  for (size_t i = 0; i < out_expected.size(); i++) {
+    EXPECT_NEAR(out_expected[i], out[i], 1E-2);
+  }
 }
-#endif*/
+#endif
 
 TEST(quantized_fully_connected, forward_nobias) {
-  quantized_fully_connected_layer<identity> l(4, 2, false);
+  quantized_fully_connected_layer l(4, 2, false);
   EXPECT_EQ(l.in_channels(), serial_size_t(2));  // in and W
 
   l.weight_init(weight_init::constant(1.0));

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -89,14 +89,14 @@ class tiny_backend : public backend {
     copy_and_pad_input(*in_data[0]);
     const vec_t &W    = (*in_data[1])[0];
     const vec_t &bias = (*in_data[2])[0];
-    tensor_t &a       = *out_data[1];
+    tensor_t &out     = *out_data[0];
     const std::vector<const vec_t *> &in =
       (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
 
-    fill_tensor(a, float_t{0});
+    fill_tensor(out, float_t{0});
 
     for (serial_size_t i = 0; i < in.size(); i++) {
-      kernels::tiny_quantized_conv2d_kernel(*params_c_, *in[i], W, bias, a[i],
+      kernels::tiny_quantized_conv2d_kernel(*params_c_, *in[i], W, bias, out[i],
                                             layer_->parallelize());
     }
   }
@@ -110,16 +110,16 @@ class tiny_backend : public backend {
     const tensor_t &in_r = *in_data[3];
     const vec_t &W_r     = (*in_data[4])[0];
     const vec_t &b_r     = (*in_data[5])[0];
-    tensor_t &a          = *out_data[1];
-    tensor_t &a_r        = *out_data[2];
+    tensor_t &out        = *out_data[0];
+    tensor_t &out_r      = *out_data[1];
 
     const std::vector<const vec_t *> &in =
       (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
 
-    fill_tensor(a, float_t{0});
+    fill_tensor(out, float_t{0});
     for (serial_size_t i = 0; i < in.size(); i++) {
       kernels::tiny_quantized_conv2d_kernel(*params_c_, *in[i], W, bias,
-                                            in_r[i], W_r, b_r, a[i], a_r[i],
+                                            in_r[i], W_r, b_r, out[i], out_r[i],
                                             layer_->parallelize());
     }
   }
@@ -134,7 +134,7 @@ class tiny_backend : public backend {
     const vec_t &W                       = (*in_data[1])[0];
     tensor_t &dW                         = *in_grad[1];
     tensor_t &db                         = *in_grad[2];
-    tensor_t &curr_delta                 = *out_grad[1];
+    tensor_t &curr_delta                 = *out_grad[0];
     tensor_t *prev_delta = (params_c_->pad_type == padding::same)
                              ? &cws.prev_delta_padded_
                              : in_grad[0];
@@ -184,19 +184,19 @@ class tiny_backend : public backend {
     const tensor_t &in                        = *in_data[0];  // input
     const vec_t &W                            = (*in_data[1])[0];
     const vec_t &bias                         = (*in_data[2])[0];
-    tensor_t &a                               = *out_data[1];
+    tensor_t &out                             = *out_data[0];
 
     fill_tensor(
-      a, float_t{0},
+      out, float_t{0},
       params_d_->out.size());  // deconv2d-kernel requires padded size buffer
 
     for (serial_size_t i = 0; i < in.size(); i++) {
-      kernels::tiny_quantized_deconv2d_kernel(*params_d_, in[i], W, bias, a[i],
-                                              layer_->parallelize());
+      kernels::tiny_quantized_deconv2d_kernel(*params_d_, in[i], W, bias,
+                                              out[i], layer_->parallelize());
     }
 
-    copy_and_unpad_output(a);
-    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+    copy_and_unpad_output(out);
+    out = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
   }
 
   // efficient quantization without abundant quantization/dequantization
@@ -209,21 +209,21 @@ class tiny_backend : public backend {
     const tensor_t &in_r                      = *in_data[3];
     const vec_t &W_r                          = (*in_data[4])[0];
     const vec_t &b_r                          = (*in_data[5])[0];
-    tensor_t &a                               = *out_data[1];
-    tensor_t &a_r                             = *out_data[2];
+    tensor_t &out                             = *out_data[0];
+    tensor_t &out_r                           = *out_data[1];
 
     fill_tensor(
-      a, float_t{0},
+      out, float_t{0},
       params_d_->out.size());  // deconv2d-kernel requires padded size buffer
 
     for (serial_size_t i = 0; i < in.size(); i++) {
       kernels::tiny_quantized_deconv2d_kernel(*params_d_, in[i], W, bias,
-                                              in_r[i], W_r, b_r, a[i], a_r[i],
-                                              layer_->parallelize());
+                                              in_r[i], W_r, b_r, out[i],
+                                              out_r[i], layer_->parallelize());
     }
 
-    copy_and_unpad_output(a);
-    a = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
+    copy_and_unpad_output(out);
+    out = *(*deconv_layer_worker_storage_).curr_out_unpadded_;
   }
 
   void deconv2d(const std::vector<tensor_t *> &in_data,
@@ -292,7 +292,7 @@ class tiny_backend : public backend {
 #ifdef CNN_USE_GEMMLOWP
     const tensor_t &in = *in_data[0];
     const vec_t &W     = (*in_data[1])[0];
-    tensor_t &a        = *out_data[1];
+    tensor_t &out      = *out_data[0];
 
     for (serial_size_t i = 0; i < in.size(); i++) {
       kernels::tiny_quantized_fully_connected_kernel(
@@ -317,12 +317,12 @@ class tiny_backend : public backend {
     const tensor_t &in_r = *in_data[3];
     const vec_t &W_r     = (*in_data[4])[0];
     const vec_t &b_r     = (*in_data[5])[0];
-    tensor_t &a          = *out_data[1];
-    tensor_t &a_r        = *out_data[2];
+    tensor_t &out        = *out_data[0];
+    tensor_t &out_r      = *out_data[1];
 
     for (serial_size_t i = 0; i < in.size(); i++) {
       kernels::tiny_quantized_fully_connected_kernel(
-        *params_f_, in[i], W, b, in_r[i], W_r, b_r, a[i], a_r[i],
+        *params_f_, in[i], W, b, in_r[i], W_r, b_r, out[i], out_r[i],
         layer_->parallelize());
     }
 #else
@@ -344,7 +344,7 @@ class tiny_backend : public backend {
     tensor_t &dW             = *in_grad[1];
     tensor_t &db             = *in_grad[2];
     tensor_t &prev_delta     = *in_grad[0];
-    tensor_t &curr_delta     = *out_grad[1];
+    tensor_t &curr_delta     = *out_grad[0];
 
     backward_activation(*out_grad[0], *out_data[0], curr_delta);
 

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -354,8 +354,8 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
                                            const vec_t &in_r,
                                            const vec_t &W_r,
                                            const vec_t &b_r,
-                                           vec_t &a,
-                                           vec_t &a_r,
+                                           vec_t &out,
+                                           vec_t &out_r,
                                            const bool layer_parallelize) {
   // filter range
   float_t min_filter(W_r[0]);
@@ -391,7 +391,7 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
     bias_quantized.push_back(static_cast<uint8_t>(bias[i]));
   }
 
-  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  std::vector<int32_t> out_quantized(out.size(), static_cast<int32_t>(0));
 
   // calculating offset
   const int32_t offset_input = int64_to_int32(
@@ -413,8 +413,8 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
       idx               = params.in.get_index(0, 0, inc);
       const uint8_t *pi = &in_quantized[idx];
 
-      idx                   = params.out.get_index(0, 0, o);
-      int32_t *pa_quantized = &a_quantized[idx];
+      idx                     = params.out.get_index(0, 0, o);
+      int32_t *pout_quantized = &pout_quantized[idx];
 
       for (serial_size_t y = 0; y < params.in.height_; y++) {
         for (serial_size_t x = 0; x < params.in.width_; x++) {
@@ -423,8 +423,8 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
           // should be optimized for small kernel(3x3,5x5)
           for (serial_size_t wy = 0; wy < params.weight.height_; wy++) {
             for (serial_size_t wx = 0; wx < params.weight.width_; wx++) {
-              pa_quantized[(y * params.h_stride + wy) * params.out.width_ +
-                           (x * params.w_stride + wx)] +=
+              pout_quantized[(y * params.h_stride + wy) * params.out.width_ +
+                             (x * params.w_stride + wx)] +=
                 static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] -
                                      offset_filter) *
                 static_cast<int32_t>(*ppi - offset_input);
@@ -434,10 +434,10 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
       }
     }
     if (params.has_bias) {
-      int32_t *pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
-      int32_t *paa_quantized =
-        pa_quantized + params.out.width_ * params.out.height_;
-      std::for_each(pa_quantized, paa_quantized, [&](int32_t &f) {
+      int32_t *pout_quantized = &pout_quantized[params.out.get_index(0, 0, o)];
+      int32_t *poutout_quantized =
+        pout_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pout_quantized, poutout_quantized, [&](int32_t &f) {
         f += static_cast<int32_t>((bias[o] - zero_in_total_space));
       });
     }
@@ -445,19 +445,19 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
 
   float_t min_output_requantized;
   float_t max_output_requantized;
-  std::vector<uint8_t> a_requantized(a_quantized.size(),
-                                     static_cast<uint8_t>(0));
+  std::vector<uint8_t> out_requantized(out_quantized.size(),
+                                       static_cast<uint8_t>(0));
 
   // Requantize from 32bits to 8 bits for next layer
   quantize_down_and_shrink_range<int32_t, uint8_t>(
-    a_quantized, min_output_value, max_output_value, &min_output_requantized,
-    &max_output_requantized, &a_requantized);
+    out_quantized, min_output_value, max_output_value, &min_output_requantized,
+    &max_output_requantized, &out_requantized);
   // store directly in float datatype
-  for (size_t i = 0; i < a_requantized.size(); i++) {
-    a[i] = static_cast<float>(a_requantized[i]);
+  for (size_t i = 0; i < out_requantized.size(); i++) {
+    out[i] = static_cast<float>(out_requantized[i]);
   }
-  a_r[0] = min_output_requantized;
-  a_r[1] = max_output_requantized;
+  out_r[0] = min_output_requantized;
+  out_r[1] = max_output_requantized;
 }
 
 }  // namespace kernels

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -18,7 +18,7 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
                                            const vec_t &in,
                                            const vec_t &W,
                                            const vec_t &bias,
-                                           vec_t &a,
+                                           vec_t &out,
                                            const bool layer_parallelize) {
   // image quantization
   float_t min_input(in[0]);
@@ -74,7 +74,7 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
     min_input, max_input, min_filter, max_filter, &min_output_value,
     &max_output_value);
 
-  std::vector<int32_t> a_quantized(a.size(), static_cast<int32_t>(0));
+  std::vector<int32_t> out_quantized(out.size(), static_cast<int32_t>(0));
 
   // calculating offset
   const int32_t offset_input = int64_to_int32(
@@ -96,8 +96,8 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
       idx               = params.in.get_index(0, 0, inc);
       const uint8_t *pi = &in_quantized[idx];
 
-      idx                   = params.out.get_index(0, 0, o);
-      int32_t *pa_quantized = &a_quantized[idx];
+      idx                     = params.out.get_index(0, 0, o);
+      int32_t *pout_quantized = &out_quantized[idx];
 
       for (serial_size_t y = 0; y < params.in.height_; y++) {
         for (serial_size_t x = 0; x < params.in.width_; x++) {
@@ -106,8 +106,8 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
           // should be optimized for small kernel(3x3,5x5)
           for (serial_size_t wy = 0; wy < params.weight.height_; wy++) {
             for (serial_size_t wx = 0; wx < params.weight.width_; wx++) {
-              pa_quantized[(y * params.h_stride + wy) * params.out.width_ +
-                           (x * params.w_stride + wx)] +=
+              pout_quantized[(y * params.h_stride + wy) * params.out.width_ +
+                             (x * params.w_stride + wx)] +=
                 static_cast<int32_t>(ppw[wy * params.weight.width_ + wx] -
                                      offset_filter) *
                 static_cast<int32_t>(*ppi - offset_input);
@@ -117,10 +117,10 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
       }
     }
     if (params.has_bias) {
-      int32_t *pa_quantized = &a_quantized[params.out.get_index(0, 0, o)];
-      int32_t *paa_quantized =
-        pa_quantized + params.out.width_ * params.out.height_;
-      std::for_each(pa_quantized, paa_quantized, [&](int32_t &f) {
+      int32_t *pout_quantized = &out_quantized[params.out.get_index(0, 0, o)];
+      int32_t *ppout_quantized =
+        pout_quantized + params.out.width_ * params.out.height_;
+      std::for_each(pout_quantized, ppout_quantized, [&](int32_t &f) {
         f += (bias_quantized[o] - zero_in_total_space);
       });
     }
@@ -128,18 +128,18 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
 
   float_t min_output_requantized;
   float_t max_output_requantized;
-  std::vector<uint8_t> a_requantized(a_quantized.size(),
-                                     static_cast<uint8_t>(0));
+  std::vector<uint8_t> out_requantized(out_quantized.size(),
+                                       static_cast<uint8_t>(0));
 
   // Requantize from 32bits to 8 bits for next layer
   quantize_down_and_shrink_range<int32_t, uint8_t>(
-    a_quantized, min_output_value, max_output_value, &min_output_requantized,
-    &max_output_requantized, &a_requantized);
+    out_quantized, min_output_value, max_output_value, &min_output_requantized,
+    &max_output_requantized, &out_requantized);
 
   // dequantize to flaot, this could be removed within concatenated quantized
   // network
-  a = quantized_tensor_to_float<uint8_t>(a_requantized, min_output_requantized,
-                                         max_output_requantized);
+  out = quantized_tensor_to_float<uint8_t>(
+    out_requantized, min_output_requantized, max_output_requantized);
 }
 
 inline void tiny_quantized_deconv2d_back_kernel(const deconv_params &params,

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -426,15 +426,6 @@ class quantized_convolutional_layer : public layer {
           return copy_and_unpad_delta(delta, dst);
         },
         &cws_);
-#ifdef CNN_USE_AVX
-    } else if (backend_type == backend_t::avx) {
-      backend = std::make_shared<core::avx_backend>(
-        &params_, [this](const tensor_t &in) { return copy_and_pad_input(in); },
-        [this](const tensor_t &delta, tensor_t &dst) {
-          return copy_and_unpad_delta(delta, dst);
-        },
-        &cws_);
-#endif
     } else {
       throw nn_error("Not supported backend type.");
     }

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -32,11 +32,9 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template <typename Activation = activation::identity>
-class quantized_convolutional_layer : public feedforward_layer<Activation> {
+class quantized_convolutional_layer : public layer {
  public:
-  typedef feedforward_layer<Activation> Base;
-  CNN_USE_LAYER_MEMBERS;
+  using layer::parallelize_;
 
   /**
   * constructing convolutional layer
@@ -73,7 +71,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     conv_set_params(shape3d(in_width, in_height, in_channels), window_size,
                     window_size, out_channels, pad_type, has_bias, w_stride,
                     h_stride);
@@ -117,7 +115,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
                     window_height, out_channels, pad_type, has_bias, w_stride,
                     h_stride);
@@ -161,55 +159,9 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     conv_set_params(shape3d(in_width, in_height, in_channels), window_size,
                     window_size, out_channels, pad_type, has_bias, w_stride,
-                    h_stride, connection_table);
-    init_backend(backend_type);
-  }
-
-  /**
-  * constructing convolutional layer
-  *
-  * @param in_width         [in] input image width
-  * @param in_height        [in] input image height
-  * @param window_width     [in] window_width(kernel) size of convolution
-  * @param window_height    [in] window_height(kernel) size of convolution
-  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-  * @param out_channels     [in] output image channels
-  * @param connection_table [in] definition of connections between in-channels
-  *and out-channels
-  * @param pad_type         [in] rounding strategy
-  *                               valid: use valid pixels of input only.
-  *output-size = (in-width - window_size + 1) *
-  *(in-height - window_size + 1) * out_channels
-  *                               same: add zero-padding to keep same
-  *width/height. output-size = in-width * in-height *
-  *out_channels
-  * @param has_bias         [in] whether to add a bias vector to the filter
-  *outputs
-  * @param w_stride         [in] specify the horizontal interval at which to
-  *apply the filters to the input
-  * @param h_stride         [in] specify the vertical interval at which to
-  *apply
-  *the filters to the input
-  **/
-  quantized_convolutional_layer(
-    serial_size_t in_width,
-    serial_size_t in_height,
-    serial_size_t window_width,
-    serial_size_t window_height,
-    serial_size_t in_channels,
-    serial_size_t out_channels,
-    const connection_table &connection_table,
-    padding pad_type       = padding::valid,
-    bool has_bias          = true,
-    serial_size_t w_stride = 1,
-    serial_size_t h_stride = 1,
-    backend_t backend_type = core::backend_t::internal)
-    : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
-    conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
-                    window_height, out_channels, pad_type, has_bias, w_stride,
                     h_stride, connection_table);
     init_backend(backend_type);
   }
@@ -217,7 +169,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
   // move constructor
   quantized_convolutional_layer(
     quantized_convolutional_layer &&other)  // NOLINT
-    : Base(std::move(other)),
+    : layer(std::move(other)),
       params_(std::move(other.params_)),
       cws_(std::move(other.cws_)) {
     init_backend(core::backend_t::internal);
@@ -242,12 +194,10 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
                            std::vector<tensor_t *> &out_data) override {
     // launch convolutional kernel
     if (in_data.size() == 3) {
-      Base::backend_->conv2d_q(in_data, out_data);
+      layer::backend_->conv2d_q(in_data, out_data);
 
-      // activations
-      this->forward_activation(*out_data[0], *out_data[1]);
     } else if (in_data.size() == 6) {
-      Base::backend_->conv2d_eq(in_data, out_data);
+      layer::backend_->conv2d_eq(in_data, out_data);
     }
   }
 
@@ -267,7 +217,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    Base::backend_->conv2d_q(in_data, out_data, out_grad, in_grad);
+    layer::backend_->conv2d_q(in_data, out_data, out_grad, in_grad);
   }
 
   std::vector<index3d<serial_size_t>> in_shape() const override {
@@ -280,7 +230,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
   }
 
   std::vector<index3d<serial_size_t>> out_shape() const override {
-    return {params_.out, params_.out};
+    return {params_.out};
   }
 
   std::string layer_type() const override { return "q_conv"; }
@@ -293,7 +243,7 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     const auto width  = params_.out.depth_ * pitch + border_width;
     const auto height = params_.in.depth_ * pitch + border_width;
     const image<>::intensity_t bg_color = 255;
-    const vec_t &W                      = *this->get_weights()[0];
+    const vec_t &W                      = *this->weights()[0];
 
     img.resize(width, height);
     img.fill(bg_color);
@@ -475,10 +425,6 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
         [this](const tensor_t &delta, tensor_t &dst) {
           return copy_and_unpad_delta(delta, dst);
         },
-        [this](const tensor_t &p_delta, const tensor_t &out,
-               tensor_t &c_delta) {
-          return Base::backward_activation(p_delta, out, c_delta);
-        },
         &cws_);
 #ifdef CNN_USE_AVX
     } else if (backend_type == backend_t::avx) {
@@ -487,10 +433,6 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
         [this](const tensor_t &delta, tensor_t &dst) {
           return copy_and_unpad_delta(delta, dst);
         },
-        [this](const tensor_t &p_delta, const tensor_t &out,
-               tensor_t &c_delta) {
-          return Base::backward_activation(p_delta, out, c_delta);
-        },
         &cws_);
 #endif
     } else {
@@ -498,8 +440,8 @@ class quantized_convolutional_layer : public feedforward_layer<Activation> {
     }
 
     if (backend) {
-      Base::set_backend(backend);
-      Base::backend_->set_layer(this);
+      layer::set_backend(backend);
+      layer::backend_->set_layer(this);
     } else {
       throw nn_error("Could not allocate the backend.");
     }

--- a/tiny_dnn/layers/quantized_deconvolutional_layer.h
+++ b/tiny_dnn/layers/quantized_deconvolutional_layer.h
@@ -32,11 +32,9 @@ namespace tiny_dnn {
  *
  * take input as two-dimensional *image* and applying filtering operation.
  **/
-template <typename Activation = activation::identity>
-class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
+class quantized_deconvolutional_layer : public layer {
  public:
-  typedef feedforward_layer<Activation> Base;
-  CNN_USE_LAYER_MEMBERS;
+  using layer::parallelize_;
 
   /**
   * constructing deconvolutional layer
@@ -73,7 +71,7 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
                       window_size, out_channels, pad_type, has_bias, w_stride,
                       h_stride);
@@ -117,7 +115,7 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
                       window_height, out_channels, pad_type, has_bias, w_stride,
                       h_stride);
@@ -161,67 +159,21 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
     serial_size_t w_stride = 1,
     serial_size_t h_stride = 1,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     deconv_set_params(shape3d(in_width, in_height, in_channels), window_size,
                       window_size, out_channels, pad_type, has_bias, w_stride,
                       h_stride, connection_table);
     init_backend(backend_type);
   }
 
-  /**
-  * constructing deconvolutional layer
-  *
-  * @param in_width         [in] input image width
-  * @param in_height        [in] input image height
-  * @param window_width     [in] window_width(kernel) size of convolution
-  * @param window_height    [in] window_height(kernel) size of convolution
-  * @param in_channels      [in] input image channels (grayscale=1, rgb=3)
-  * @param out_channels     [in] output image channels
-  * @param connection_table [in] definition of connections between in-channels
-  *and out-channels
-  * @param pad_type         [in] rounding strategy
-  *                               valid: use valid pixels of input only.
-  *output-size = (in-width - window_size + 1) *
-  *(in-height - window_size + 1) * out_channels
-  *                               same: add zero-padding to keep same
-  *width/height. output-size = in-width * in-height *
-  *out_channels
-  * @param has_bias         [in] whether to add a bias vector to the filter
-  *outputs
-  * @param w_stride         [in] specify the horizontal interval at which to
-  *apply the filters to the input
-  * @param h_stride         [in] specify the vertical interval at which to
-  *apply
-  *the filters to the input
-  **/
-  quantized_deconvolutional_layer(
-    serial_size_t in_width,
-    serial_size_t in_height,
-    serial_size_t window_width,
-    serial_size_t window_height,
-    serial_size_t in_channels,
-    serial_size_t out_channels,
-    const connection_table &connection_table,
-    padding pad_type       = padding::valid,
-    bool has_bias          = true,
-    serial_size_t w_stride = 1,
-    serial_size_t h_stride = 1,
-    backend_t backend_type = core::backend_t::internal)
-    : Base(has_bias ? 3 : 2, 1, std_input_order(has_bias)) {
-    deconv_set_params(shape3d(in_width, in_height, in_channels), window_width,
-                      window_height, out_channels, pad_type, has_bias, w_stride,
-                      h_stride, connection_table);
-    init_backend(backend_type);
-  }
-
   // move constructor
   quantized_deconvolutional_layer(quantized_deconvolutional_layer &&other)
-    : Base(std::move(other)),
+    : layer(std::move(other)),
       params_(std::move(other.params_)),
       backend_type_(std::move(other.backend_type_)),
       deconv_layer_worker_storage_(
         std::move(other.deconv_layer_worker_storage_)) {
-    init_backend(std::move(Base::get_backend_type()));
+    init_backend(std::move(layer::engine()));
   }
 
   ///< number of incoming connections for each output unit
@@ -239,12 +191,10 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
                            std::vector<tensor_t *> &out_data) override {
     // launch deconvolutional kernel
     if (in_data.size() == 3) {
-      Base::backend_->deconv2d_q(in_data, out_data);
+      layer::backend_->deconv2d_q(in_data, out_data);
 
-      // activations
-      this->forward_activation(*out_data[0], *out_data[1]);
     } else if (in_data.size() == 6) {
-      Base::backend_->deconv2d_eq(in_data, out_data);
+      layer::backend_->deconv2d_eq(in_data, out_data);
     }
   }
 
@@ -264,7 +214,7 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    Base::backend_->deconv2d_q(in_data, out_data, out_grad, in_grad);
+    layer::backend_->deconv2d_q(in_data, out_data, out_grad, in_grad);
   }
 
   std::vector<index3d<serial_size_t>> in_shape() const override {
@@ -277,7 +227,7 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
   }
 
   std::vector<index3d<serial_size_t>> out_shape() const override {
-    return {params_.out_unpadded, params_.out_unpadded};
+    return {params_.out_unpadded};
   }
 
   std::string layer_type() const override { return "q_deconv"; }
@@ -290,7 +240,7 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
     const auto width  = params_.out.depth_ * pitch + border_width;
     const auto height = params_.in.depth_ * pitch + border_width;
     const image<>::intensity_t bg_color = 255;
-    const vec_t &W                      = *this->get_weights()[0];
+    const vec_t &W                      = *this->weights()[0];
 
     img.resize(width, height);
     img.fill(bg_color);
@@ -333,10 +283,6 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
         [this](const tensor_t &delta, tensor_t &dst) {
           return copy_and_pad_delta(delta, dst);
         },
-        [this](const tensor_t &p_delta, const tensor_t &out,
-               tensor_t &c_delta) {
-          return Base::backward_activation(p_delta, out, c_delta);
-        },
         &deconv_layer_worker_storage_);
 #ifdef CNN_USE_AVX
     } else if (backend_type == backend_t::avx) {
@@ -346,10 +292,6 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
         [this](const tensor_t &delta, tensor_t &dst) {
           return copy_and_pad_delta(delta, dst);
         },
-        [this](const tensor_t &p_delta, const tensor_t &out,
-               tensor_t &c_delta) {
-          return Base::backward_activation(p_delta, out, c_delta);
-        },
         &deconv_layer_worker_storage_);
 #endif
     } else {
@@ -357,8 +299,8 @@ class quantized_deconvolutional_layer : public feedforward_layer<Activation> {
     }
 
     if (backend) {
-      Base::set_backend(backend);
-      Base::backend_->set_layer(this);
+      layer::set_backend(backend);
+      layer::backend_->set_layer(this);
     } else {
       throw nn_error("Could not allocate the backend.");
     }

--- a/tiny_dnn/layers/quantized_deconvolutional_layer.h
+++ b/tiny_dnn/layers/quantized_deconvolutional_layer.h
@@ -284,16 +284,6 @@ class quantized_deconvolutional_layer : public layer {
           return copy_and_pad_delta(delta, dst);
         },
         &deconv_layer_worker_storage_);
-#ifdef CNN_USE_AVX
-    } else if (backend_type == backend_t::avx) {
-      backend = std::make_shared<core::avx_backend>(
-        &params_,
-        [this](const tensor_t &in) { return copy_and_unpad_output(in); },
-        [this](const tensor_t &delta, tensor_t &dst) {
-          return copy_and_pad_delta(delta, dst);
-        },
-        &deconv_layer_worker_storage_);
-#endif
     } else {
       throw nn_error("Not supported backend type.");
     }

--- a/tiny_dnn/layers/quantized_fully_connected_layer.h
+++ b/tiny_dnn/layers/quantized_fully_connected_layer.h
@@ -15,11 +15,9 @@ namespace tiny_dnn {
 /**
  * compute fully-connected(matmul) operation
  **/
-template <typename Activation>
-class quantized_fully_connected_layer : public feedforward_layer<Activation> {
+class quantized_fully_connected_layer : public layer {
  public:
-  typedef feedforward_layer<Activation> Base;
-  CNN_USE_LAYER_MEMBERS;
+  using layer::parallelize_;
 
   /**
    * @param in_dim [in] number of elements of the input
@@ -31,14 +29,14 @@ class quantized_fully_connected_layer : public feedforward_layer<Activation> {
     serial_size_t out_dim,
     bool has_bias          = true,
     backend_t backend_type = core::backend_t::internal)
-    : Base(std_input_order(has_bias)) {
+    : layer(std_input_order(has_bias), {vector_type::data}) {
     set_params(in_dim, out_dim, has_bias);
     init_backend(backend_type);
   }
 
   // move constructor
   quantized_fully_connected_layer(quantized_fully_connected_layer &&other)
-    : Base(std::move(other)), params_(std::move(other.params_)) {
+    : layer(std::move(other)), params_(std::move(other.params_)) {
     init_backend(core::backend_t::internal);
   }
 
@@ -58,19 +56,16 @@ class quantized_fully_connected_layer : public feedforward_layer<Activation> {
   }
 
   std::vector<index3d<serial_size_t>> out_shape() const override {
-    return {index3d<serial_size_t>(params_.out_size_, 1, 1),
-            index3d<serial_size_t>(params_.out_size_, 1, 1)};
+    return {index3d<serial_size_t>(params_.out_size_, 1, 1)};
   }
 
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {
     if (in_data.size() == 2 || in_data.size() == 3) {
-      Base::backend_->fully_q(in_data, out_data);
+      layer::backend_->fully_q(in_data, out_data);
 
-      // activations
-      this->forward_activation(*out_data[0], *out_data[1]);
     } else if (in_data.size() == 4 || in_data.size() == 6) {
-      Base::backend_->fully_eq(in_data, out_data);
+      layer::backend_->fully_eq(in_data, out_data);
     }
   }
 
@@ -78,7 +73,7 @@ class quantized_fully_connected_layer : public feedforward_layer<Activation> {
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    Base::backend_->fully_q(in_data, out_data, out_grad, in_grad);
+    layer::backend_->fully_q(in_data, out_data, out_grad, in_grad);
   }
 
   std::string layer_type() const override { return "q_fully-connected"; }
@@ -99,19 +94,15 @@ class quantized_fully_connected_layer : public feedforward_layer<Activation> {
 
     // allocate new backend
     if (backend_type == backend_t::internal) {
-      backend = std::make_shared<core::tiny_backend>(
-        &params_, [this](const tensor_t &p_delta, const tensor_t &out,
-                         tensor_t &c_delta) {
-          return Base::backward_activation(p_delta, out, c_delta);
-        });
+      backend = std::make_shared<core::tiny_backend>(&params_);
     } else {
       throw nn_error("Not supported backend type.");
     }
 
     if (backend) {
-      Base::set_backend(backend);
-      Base::set_backend_type(backend_type);
-      Base::backend_->set_layer(this);
+      layer::set_backend(backend);
+      layer::set_backend_type(backend_type);
+      layer::backend_->set_layer(this);
     } else {
       throw nn_error("Could not allocate the backend.");
     }

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -82,8 +82,7 @@ namespace layers {
 
 using conv = tiny_dnn::convolutional_layer;
 
-template <class T>
-using q_conv = tiny_dnn::quantized_convolutional_layer<T>;
+using q_conv = tiny_dnn::quantized_convolutional_layer;
 
 using max_pool = tiny_dnn::max_pooling_layer;
 
@@ -92,6 +91,8 @@ using ave_pool = tiny_dnn::average_pooling_layer;
 using fc = tiny_dnn::fully_connected_layer;
 
 using dense = tiny_dnn::fully_connected_layer;
+
+using q_fc = tiny_dnn::quantized_fully_connected_layer;
 
 using add = tiny_dnn::elementwise_add_layer;
 


### PR DESCRIPTION
The `Activation` template parameter has been completely decoupled from the following layers:

1. `quantized_convolution_layer`
2. `quantized_deconvolution_layer`
3. `quantized_fully_connected_layer`

Changes have been made in layer implementation, tests, examples and serialization helpers.

### Future Roadmap:

This PR marks a checkpoint in decoupling activations job. All the layers act as standalone layers with no implicit application of activation function. Next, I will safely remove **activation_function.h** and put the newly defined _activation layers_ in `tiny_dnn::activation` namespace.