### PR TITLE
Enable Coverity-Scan API token in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,11 +5,12 @@ language: cpp
 
 os:
   - linux
-  - osx
+  # use just one of the environments in coverity_scan branch in order not to consume too much API
+  # - osx
 
 compiler:
   - gcc
-  - clang
+  # - clang
 
 cache:
   pip: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,9 @@ env:
     - BUILD_TESTS=ON
     - BUILD_EXAMPLES=ON
     - COVERALLS=ON
-    - secure: "TOKEN"
+   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+   #   via the "travis encrypt" command using the project repo's public key
+    - secure: "klsXQXZDTInfHtiqbDyUcM5VMpZWO1cWnwxc/253Y6foCIcgCV+vLzRQz0CzBl18e4+KQdQBXi1/FcpZMjdlvQF80bqisU/g6IKF7C5h29A62MbosSATSHKLelmRrNfEwvGthK2fc13akM8Z+FdKespbB7Q3ME+PaBl84y2Uq2UjAr48AzMFlCyEXa969oZwrV7B5qJvxL9PdTX2sXgFHGryFeffl7w2yb85cBJ/zDiGdMvPUTN+y9GtzmYbQFpMWaBd0jIQHlkY6SigSvzqt2fyj8ptU13MT+Big0XkMC1KrvClEKqVgZiCZ+CSxH1TUXj0WB54f8dabfCFR+YdysQp6jLJNjEOuovU+1dpm/JXJgZQ/05ZmeLQE+S6gc23ous3nTrlChTwE5YS9rX1Jc9NN5+LHv1DaMDzuM4Cagnexr6zXIAJsYsSL5co/rKpjtBqHrVczMLHHdrf1preipXOemusvOPFCYjkC92giz3Ry2BAIUVNz6LRfu6RnLMR7ca98n2F26k4v4jeBjkKWqSgBBvNNDAazzRQj7TIUcGNTc+4Biiqu7OrEvt1cMoGH0PeDbUrHkqUkc2kdjqTAEnomY3HcrjteNGNe6YBnihlDhIsGTHV6ZfNE6D0gKMVQOTDxpmLyqdWko6cOPaKrjmIe8k+JNWp0uVmVsXuN98="
 
   matrix:
     - USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
@@ -85,6 +87,7 @@ before_install:
     fi
   - gcc --version
   - g++ --version
+  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 install:
   - bash -x .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,9 +66,7 @@ env:
     - BUILD_TESTS=ON
     - BUILD_EXAMPLES=ON
     - COVERALLS=ON
-   # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
-   #   via the "travis encrypt" command using the project repo's public key
-    - secure: "klsXQXZDTInfHtiqbDyUcM5VMpZWO1cWnwxc/253Y6foCIcgCV+vLzRQz0CzBl18e4+KQdQBXi1/FcpZMjdlvQF80bqisU/g6IKF7C5h29A62MbosSATSHKLelmRrNfEwvGthK2fc13akM8Z+FdKespbB7Q3ME+PaBl84y2Uq2UjAr48AzMFlCyEXa969oZwrV7B5qJvxL9PdTX2sXgFHGryFeffl7w2yb85cBJ/zDiGdMvPUTN+y9GtzmYbQFpMWaBd0jIQHlkY6SigSvzqt2fyj8ptU13MT+Big0XkMC1KrvClEKqVgZiCZ+CSxH1TUXj0WB54f8dabfCFR+YdysQp6jLJNjEOuovU+1dpm/JXJgZQ/05ZmeLQE+S6gc23ous3nTrlChTwE5YS9rX1Jc9NN5+LHv1DaMDzuM4Cagnexr6zXIAJsYsSL5co/rKpjtBqHrVczMLHHdrf1preipXOemusvOPFCYjkC92giz3Ry2BAIUVNz6LRfu6RnLMR7ca98n2F26k4v4jeBjkKWqSgBBvNNDAazzRQj7TIUcGNTc+4Biiqu7OrEvt1cMoGH0PeDbUrHkqUkc2kdjqTAEnomY3HcrjteNGNe6YBnihlDhIsGTHV6ZfNE6D0gKMVQOTDxpmLyqdWko6cOPaKrjmIe8k+JNWp0uVmVsXuN98="
+    - secure: "TOKEN"
 
   matrix:
     - USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
@@ -87,7 +85,6 @@ before_install:
     fi
   - gcc --version
   - g++ --version
-  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 install:
   - bash -x .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -39,20 +39,19 @@ addons:
   coverity_scan:
 
     project:
-      name: tiny-dnn/tiny-dnn
-      version: 1.0
-      description: Header only, dependency-free deep learning framework in C++11
+      name: "tiny-dnn/tiny-dnn"
+      description: "Header only, dependency-free deep learning framework in C++11"
 
     notification_email: example@example.com
 
-    build_command_prepend: cmake -DUSE_TBB=ON
+    build_command_prepend: "cmake -DUSE_TBB=ON
             -DUSE_SSE=ON
             -DUSE_AVX=ON
             -DUSE_DOUBLE=OFF
             -DBUILD_TESTS=ON
-            -DBUILD_EXAMPLES=ON .
+            -DBUILD_EXAMPLES=ON ."
 
-    build_command: make -j8
+    build_command: "make -j8"
 
     branch_pattern: master
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -66,7 +66,9 @@ env:
     - BUILD_TESTS=ON
     - BUILD_EXAMPLES=ON
     - COVERALLS=ON
-    - secure: "TOKEN"
+    # The next declaration is the encrypted COVERITY_SCAN_TOKEN, created
+    #   via the "travis encrypt" command using the project repo's public key
+    - secure: "glPl20nNNuLZdUokmCnXaoS0JrbvfYH/39w4fhPdb0qFha7fiqsUpgqX6zFndVfLXOEJiYD41SjdZPz3exXHuLhvO/hBVz8IAlM8Or+5lDc/76Cj6bZJ6UFVjlOzft++7Y8t3aksWiL4ultNg/xWvx9rfWLDPT2vMOUwIM3CX51ZsN0ag8gd+4N3hkLlk2wPn5JnEvDP5Ti5XV4apOMayxKyFf80cR4Z1tM/nhbnClsDq3bIEKXlUmoM4xnHR+aBwg0XrVwMAuTV2xqxQ7YPYH9FBAcRZE6OkSGP+ad9YQ1o2IiRSRCWimxFGrmZ/zuXktrsEyESDixlHM9OpXy5GShrV6iWmHlAzoQRUE6OMMv6822tA2TsSXWcWOqL5bPySwyQ5CUDztU/5GOgz4Fa0ilP6Ew55Fq8pW1BFoaccMhdqo2NyuFz9ln7e/8Q096PXS5dFCOM32RYHlH8wYMMEbpwAiKoYMiIa0U7OaU2F4UxcF2ED7Z36LPgxj78RN7mM3FrHYo25wWfI5dy0K2/KqJVzbcnvGih5OXTjuFV4uW48YGE42+/6e9JiM05DPYVlGeK8whpkoFFieb4uexvXe0Kx+AW4uhVakkJmvCJkKkwELPTtFYwVTI3/dPu/3i2N2DRdfI7q+vh4ynzvWiiULE8j3y7I7qaRMuso/FFDGg="
 
   matrix:
     - USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
@@ -85,6 +87,7 @@ before_install:
     fi
   - gcc --version
   - g++ --version
+  - echo -n | openssl s_client -connect scan.coverity.com:443 | sed -ne '/-BEGIN CERTIFICATE-/,/-END CERTIFICATE-/p' | sudo tee -a /etc/ssl/certs/ca-
 
 install:
   - bash -x .travis/install.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -59,6 +59,7 @@ addons:
 branches:
   only:
     - master
+    - coverity_scan
     - feat/tensor_integration
 env:
   global:

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ addons:
 
     build_command: "make -j8"
 
-    branch_pattern: master
+    branch_pattern: coverity_scan
 
 branches:
   only:


### PR DESCRIPTION
This is continued from #531. This PR replaces dummy API token with encrypted token for coverity scan-build.