### PR TITLE
Remove repeated initialization of "using input = ..."

### DIFF
--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -99,8 +99,6 @@ using input = tiny_dnn::input_layer;
 template <class T>
 using lrn = tiny_dnn::lrn_layer<T>;
 
-using input = tiny_dnn::input_layer;
-
 using concat = tiny_dnn::concat_layer;
 
 template <class T>


### PR DESCRIPTION
This PR removes an extra declaration of the `using` statement to define `tiny_dnn::input_layer`two times in the main header file. I was perusing for the purpose of creating a wrapper and stumbled upon this. I'm apologize that this a such a small change and kind of a "creepy" pull request :neckbeard:.