### PR TITLE
Provide automatic shape inference in activation layers.

### DIFF
--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -13,13 +13,13 @@
 namespace tiny_dnn {
 
 TEST(ave_pool, gradient_check) {  // sigmoid - cross-entropy
-  using loss_func        = cross_entropy;
-  using activation_layer = sigmoid_layer;
-  using network          = network<sequential>;
+  using loss_func  = cross_entropy;
+  using activation = sigmoid;
+  using network    = network<sequential>;
 
   network nn;
-  nn << fully_connected_layer(3, 8) << activation_layer(8)
-     << average_pooling_layer(4, 2, 1, 2) << activation_layer(2);  // 4x2 => 2x1
+  nn << fully_connected_layer(3, 8) << activation()
+     << average_pooling_layer(4, 2, 1, 2) << activation();  // 4x2 => 2x1
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -34,9 +34,9 @@ TEST(ave_pool, gradient_check2) {  // x-stride
   using network          = network<sequential>;
 
   network nn;
-  nn << fully_connected_layer(3, 8) << activation_layer(8)
+  nn << fully_connected_layer(3, 8) << activation_layer()
      << average_pooling_layer(4, 2, 1, 2, 1, 2, 1)  // 4x2 => 2x2
-     << activation_layer(2, 2, 1);
+     << activation_layer();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -46,14 +46,14 @@ TEST(ave_pool, gradient_check2) {  // x-stride
 }
 
 TEST(ave_pool, gradient_check3) {  // y-stride
-  using loss_func        = cross_entropy;
-  using activation_layer = sigmoid_layer;
-  using network          = network<sequential>;
+  using loss_func  = cross_entropy;
+  using activation = sigmoid;
+  using network    = network<sequential>;
 
   network nn;
-  nn << fully_connected_layer(3, 8) << activation_layer(8)
+  nn << fully_connected_layer(3, 8) << activation()
      << average_pooling_layer(4, 2, 1, 1, 2, 1, 2)  // 4x2 => 4x1
-     << activation_layer(4);
+     << activation_layer();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -63,13 +63,13 @@ TEST(ave_pool, gradient_check3) {  // y-stride
 }
 
 TEST(ave_pool, gradient_check4) {  // padding-same
-  using loss_func        = cross_entropy;
-  using activation_layer = sigmoid_layer;
-  using network          = network<sequential>;
+  using loss_func  = cross_entropy;
+  using activation = sigmoid;
+  using network    = network<sequential>;
 
   network nn;
   nn << average_pooling_layer(4, 2, 1, 2, 2, 1, 1, padding::same)
-     << activation_layer(4, 2, 1);
+     << activation_layer();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(ave_pool, gradient_check) {  // sigmoid - cross-entropy
@@ -29,14 +31,14 @@ TEST(ave_pool, gradient_check) {  // sigmoid - cross-entropy
 }
 
 TEST(ave_pool, gradient_check2) {  // x-stride
-  using loss_func        = cross_entropy;
-  using activation_layer = sigmoid_layer;
-  using network          = network<sequential>;
+  using loss_func  = cross_entropy;
+  using activation = sigmoid;
+  using network    = network<sequential>;
 
   network nn;
-  nn << fully_connected_layer(3, 8) << activation_layer()
+  nn << fully_connected_layer(3, 8) << activation()
      << average_pooling_layer(4, 2, 1, 2, 1, 2, 1)  // 4x2 => 2x2
-     << activation_layer();
+     << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -53,7 +55,7 @@ TEST(ave_pool, gradient_check3) {  // y-stride
   network nn;
   nn << fully_connected_layer(3, 8) << activation()
      << average_pooling_layer(4, 2, 1, 1, 2, 1, 2)  // 4x2 => 4x1
-     << activation_layer();
+     << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -69,7 +71,7 @@ TEST(ave_pool, gradient_check4) {  // padding-same
 
   network nn;
   nn << average_pooling_layer(4, 2, 1, 2, 2, 1, 1, padding::same)
-     << activation_layer();
+     << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy

--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -13,15 +13,14 @@
 namespace tiny_dnn {
 
 TEST(ave_unpool, gradient_check) {  // sigmoid - cross-entropy
-  using loss_func        = cross_entropy;
-  using activation_layer = sigmoid_layer;
-  using network          = network<sequential>;
+  using loss_func  = cross_entropy;
+  using activation = sigmoid;
+  using network    = network<sequential>;
 
   network nn;
-  nn << fully_connected_layer(3, 4) << activation_layer(4)
+  nn << fully_connected_layer(3, 4) << activation()
      << average_unpooling_layer(2, 2, 1, 2)  // 2x2 => 4x4
-     << activation_layer(4, 4, 1) << average_pooling_layer(4, 4, 1, 2)
-     << activation_layer(2, 2, 1);
+     << activation() << average_pooling_layer(4, 4, 1, 2) << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(convolutional, setup_internal) {
@@ -555,7 +557,7 @@ TEST(convolutional, fprop_nnp) {
 
 TEST(convolutional, gradient_check) {  // tanh - mse
   network<sequential> nn;
-  nn << convolutional_layer(5, 5, 3, 1, 1) << tanh_layer();
+  nn << convolutional_layer(5, 5, 3, 1, 1) << tanh();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -565,7 +567,7 @@ TEST(convolutional, gradient_check) {  // tanh - mse
 
 TEST(convolutional, gradient_check2) {  // sigmoid - mse
   network<sequential> nn;
-  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -576,7 +578,7 @@ TEST(convolutional, gradient_check2) {  // sigmoid - mse
 TEST(convolutional, gradient_check3) {  // rectified - mse
   network<sequential> nn;
 
-  nn << convolutional_layer(5, 5, 3, 1, 1) << relu_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << relu();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -598,7 +600,7 @@ TEST(convolutional, gradient_check4) {  // identity - mse
 TEST(convolutional, gradient_check5) {  // sigmoid - cross-entropy
   network<sequential> nn;
 
-  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -609,7 +611,7 @@ TEST(convolutional, gradient_check5) {  // sigmoid - cross-entropy
 TEST(convolutional, gradient_check6) {  // sigmoid - absolute
   network<sequential> nn;
 
-  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -620,7 +622,7 @@ TEST(convolutional, gradient_check6) {  // sigmoid - absolute
 TEST(convolutional, gradient_check7) {  // sigmoid - absolute eps
   network<sequential> nn;
 
-  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -633,7 +635,7 @@ TEST(convolutional, gradient_check8_pad_same) {  // sigmoid - mse - padding same
 
   nn << convolutional_layer(5, 5, 3, 1, 1, padding::same, true, 1, 1,
                             core::backend_t::internal)
-     << sigmoid_layer(5, 5, 1);
+     << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -646,7 +648,7 @@ TEST(convolutional, gradient_check9_w_stride) {  // sigmoid - mse - w_stride > 1
 
   nn << convolutional_layer(3, 3, 1, 1, 1, padding::valid, true, 2, 1,
                             core::backend_t::internal)
-     << sigmoid_layer(2, 3, 1);
+     << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
   nn.init_weight();
@@ -660,7 +662,7 @@ TEST(convolutional,
 
   nn << convolutional_layer(3, 3, 1, 1, 1, padding::valid, true, 1, 2,
                             core::backend_t::internal)
-     << sigmoid_layer(3, 2, 1);
+     << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size(), 1);
   nn.init_weight();
@@ -677,7 +679,7 @@ TEST(convolutional,
 
   nn << convolutional_layer(7, 7, 3, 3, 1, connections, padding::valid, true, 1,
                             1, core::backend_t::internal)
-     << sigmoid_layer(5, 5, 1);
+     << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -692,7 +694,7 @@ TEST(convolutional,
   nn << fully_connected_layer(10, 5 * 5)
      << convolutional_layer(5, 5, 3, 1, 1, padding::same, true, 1, 1,
                             core::backend_t::internal)
-     << sigmoid_layer(5, 5, 1);
+     << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -555,7 +555,7 @@ TEST(convolutional, fprop_nnp) {
 
 TEST(convolutional, gradient_check) {  // tanh - mse
   network<sequential> nn;
-  nn << convolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
+  nn << convolutional_layer(5, 5, 3, 1, 1) << tanh_layer();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_deconvolutional_layer.h
+++ b/test/test_deconvolutional_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(deconvolutional, setup_tiny) {
@@ -195,7 +197,7 @@ TEST(deconvolutional, fprop2) {
 /*
 TEST(deconvolutional, gradient_check) {  // tanh - mse
   network<sequential> nn;
-  nn << deconvolutional_layer(2, 2, 3, 1, 1) << tanh_layer(4, 4, 1);
+  nn << deconvolutional_layer(2, 2, 3, 1, 1) << tanh();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -205,7 +207,7 @@ TEST(deconvolutional, gradient_check) {  // tanh - mse
 
 TEST(deconvolutional, gradient_check2) {  // sigmoid - mse
   network<sequential> nn;
-  nn << deconvolutional_layer(2, 2, 3, 1, 1) << sigmoid_layer(4, 4, 1);
+  nn << deconvolutional_layer(2, 2, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -216,7 +218,7 @@ TEST(deconvolutional, gradient_check2) {  // sigmoid - mse
 TEST(deconvolutional, gradient_check3) {  // rectified - mse
   network<sequential> nn;
 
-  nn << deconvolutional_layer(2, 2, 3, 1, 1) << relu_layer(4, 4, 1);
+  nn << deconvolutional_layer(2, 2, 3, 1, 1) << relu();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();
@@ -238,7 +240,7 @@ TEST(deconvolutional, gradient_check4) {  // identity - mse
 TEST(deconvolutional, gradient_check5) {  // sigmoid - cross-entropy
   network<sequential> nn;
 
-  nn << deconvolutional_layer(2, 2, 3, 1, 1) << sigmoid_layer(4, 4, 1);
+  nn << deconvolutional_layer(2, 2, 3, 1, 1) << sigmoid();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_dropout_layer.h
+++ b/test/test_dropout_layer.h
@@ -12,6 +12,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(dropout, randomized) {
@@ -73,8 +75,8 @@ TEST(dropout, full_net) {
     train.push_back(t2);
   }
 
-  nn << fully_connected_layer(4, 10) << relu_layer(10) << dropout(10, 0.5)
-     << fully_connected_layer(10, 2) << sigmoid_layer(2);
+  nn << fully_connected_layer(4, 10) << relu() << dropout(10, 0.5)
+     << fully_connected_layer(10, 2) << sigmoid();
 
   nn.train<mse>(optimizer, data, train, 1, 10);
   // batch = 11,20,50
@@ -103,8 +105,8 @@ TEST(dropout, full_net_batch) {
     train.push_back(t2);
   }
 
-  nn << fully_connected_layer(4, 10) << relu_layer(10) << dropout(10, 0.5)
-     << fully_connected_layer(10, 2) << sigmoid_layer(2);
+  nn << fully_connected_layer(4, 10) << relu() << dropout(10, 0.5)
+     << fully_connected_layer(10, 2) << sigmoid();
 
   nn.train<mse>(optimizer, data, train, 20, 10);
 }

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -10,13 +10,15 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(fully_connected, train) {
   network<sequential> nn;
   adagrad optimizer;
 
-  nn << fully_connected_layer(3, 2) << sigmoid_layer(2);
+  nn << fully_connected_layer(3, 2) << sigmoid();
 
   vec_t a(3), t(2), a2(3), t2(2);
 
@@ -58,7 +60,7 @@ TEST(fully_connected, train_different_batches) {
     network<sequential> nn;
     adagrad optimizer;
 
-    nn << fully_connected_layer(3, 2) << sigmoid_layer(2);
+    nn << fully_connected_layer(3, 2) << sigmoid();
 
     vec_t a(3), t(2), a2(3), t2(2);
 
@@ -97,8 +99,8 @@ TEST(fully_connected, train2) {
   network<sequential> nn;
   gradient_descent optimizer;
 
-  nn << fully_connected_layer(4, 6) << tanh_layer(6)
-     << fully_connected_layer(6, 3) << tanh_layer(3);
+  nn << fully_connected_layer(4, 6) << tanh() << fully_connected_layer(6, 3)
+     << tanh();
 
   vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
 
@@ -134,7 +136,7 @@ TEST(fully_connected, train2) {
 
 TEST(fully_connected, gradient_check) {
   network<sequential> nn;
-  nn << fully_connected_layer(50, 10) << tanh_layer(10);
+  nn << fully_connected_layer(50, 10) << tanh();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_large_thread_count.h
+++ b/test/test_large_thread_count.h
@@ -3,11 +3,13 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(test_large_thread_count, test_large_thread_count) {
   network<sequential> net;
-  net << fully_connected_layer(1, 2) << tanh_layer(2);
+  net << fully_connected_layer(1, 2) << tanh();
   adagrad optimizer;
 
   std::vector<vec_t> data;

--- a/test/test_nodes.h
+++ b/test/test_nodes.h
@@ -11,14 +11,15 @@
 #include "tiny_dnn/tiny_dnn.h"
 
 using namespace tiny_dnn::layers;
+using namespace tiny_dnn::activation;
 
 namespace tiny_dnn {
 
 TEST(nodes, sequential) {
   network<sequential> nn;
 
-  nn << fully_connected_layer(10, 100) << tanh_layer(100)
-     << fully_connected_layer(100, 10) << softmax_layer(10);
+  nn << fully_connected_layer(10, 100) << tanh()
+     << fully_connected_layer(100, 10) << softmax();
 }
 
 TEST(nodes, graph_no_branch) {
@@ -44,7 +45,7 @@ TEST(nodes, graph_branch) {
   auto in2   = std::make_shared<input_layer>(shape3d(3, 1, 1));
   auto added = std::make_shared<add>(2, 3);
   auto lin   = std::make_shared<linear_layer>(3);
-  auto out   = std::make_shared<relu_layer>(3);
+  auto out   = std::make_shared<relu>(3);
 
   // connect
   (in1, in2) << added;

--- a/test/test_power_layer.h
+++ b/test/test_power_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(power, forward) {
@@ -35,9 +37,9 @@ TEST(power, forward) {
 TEST(power, gradient_check) {
   network<sequential> nn;
 
-  nn << fully_connected_layer(10, 20) << tanh_layer(20)
+  nn << fully_connected_layer(10, 20) << tanh()
      << power_layer(shape3d(20, 1, 1), 3.0, 1.5)
-     << fully_connected_layer(20, 10) << tanh_layer(10);
+     << fully_connected_layer(20, 10) << tanh();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
   nn.init_weight();

--- a/test/test_quantized_convolutional_layer.h
+++ b/test/test_quantized_convolutional_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(quantized_convolutional, setup_internal) {
@@ -199,7 +201,7 @@ TEST(quantized_convolutional, fprop_npp) {
 /*
 TEST(quantized_convolutional, gradient_check) { // tanh - mse
     network<sequential> nn;
-    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << tanh();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -212,8 +214,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check2) { // sigmoid - mse
     network<sequential> nn;
-    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
-1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -226,7 +227,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check3) { // rectified - mse
     network<sequential> nn;
-    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << relu_layer(3, 3, 1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << relu();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -252,8 +253,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_convolutional, gradient_check5) { // sigmoid - cross-entropy
     network<sequential> nn;
-    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
-1);
+    nn << quantized_convolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
     vec_t a(25, 0.0);
     label_t t = 3;

--- a/test/test_quantized_deconvolutional_layer.h
+++ b/test/test_quantized_deconvolutional_layer.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(quantized_deconvolutional, setup_internal) {
@@ -182,7 +184,7 @@ TEST(quantized_deconvolutional, fprop2) {
 /*
 TEST(quantized_deconvolutional, gradient_check) { // tanh - mse
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -195,8 +197,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check2) { // sigmoid - mse
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
-1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -209,7 +210,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check3) { // rectified - mse
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh_layer(3, 3, 1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << tanh();
 
     vec_t a(25, 0.0);
     label_t t = 3;
@@ -235,8 +236,7 @@ GRAD_CHECK_ALL));
 
 TEST(quantized_deconvolutional, gradient_check5) { // sigmoid - cross-entropy
     network<sequential> nn;
-    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid_layer(3, 3,
-1);
+    nn << quantized_deconvolutional_layer(5, 5, 3, 1, 1) << sigmoid();
 
     vec_t a(25, 0.0);
     label_t t = 3;

--- a/test/test_quantized_fully_connected_layer.h
+++ b/test/test_quantized_fully_connected_layer.h
@@ -10,13 +10,15 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(quantized_fully_connected, train) {
   network<sequential> nn;
   adagrad optimizer;
 
-  nn << quantized_fully_connected_layer(3, 2) << sigmoid_layer(2);
+  nn << quantized_fully_connected_layer(3, 2) << sigmoid();
 
   vec_t a(3), t(2), a2(3), t2(2);
 
@@ -54,27 +56,17 @@ TEST(quantized_fully_connected, train2) {
   network<sequential> nn;
   gradient_descent optimizer;
 
-  nn << quantized_fully_connected_layer<tan_h>(4, 6) << tanh_layer(6)
-     << quantized_fully_connected_layer<tan_h>(6, 3) << tanh_layer(3);
+  nn << quantized_fully_connected_layer(4, 6) << tanh()
+     << quantized_fully_connected_layer(6, 3) << tanh();
 
   vec_t a(4, 0.0), t(3, 0.0), a2(4, 0.0), t2(3, 0.0);
 
-  // clang-format on
-  a[0] = 3.0;
-  a[1] = 1.0;
-  a[2] = -1.0;
-  a[3] = 4.0;
-  t[0] = 0.3;
-  t[1] = 0.7;
-  t[2] = 0.3;
+  // clang-format off
+  a[0] = 3.0;  a[1] = 1.0;  a[2] = -1.0;  a[3] = 4.0;
+  t[0] = 0.3;  t[1] = 0.7;  t[2] = 0.3;
 
-  a2[0] = 1.0;
-  a2[1] = 0.0;
-  a2[2] = 4.0;
-  a2[3] = 2.0;
-  t2[0] = 0.6;
-  t2[1] = 0.0;
-  t2[2] = 0.1;
+  a2[0] = 1.0; a2[1] = 0.0; a2[2] = 4.0;  a2[3] = 2.0;
+  t2[0] = 0.6; t2[1] = 0.0; t2[2] = 0.1;
   // clang-format on
 
   std::vector<vec_t> data, train;
@@ -101,7 +93,7 @@ TEST(quantized_fully_connected, train2) {
 
 TEST(quantized_fully_connected, gradient_check) {
   network<sequential> nn;
-  nn << quantized_fully_connected_layer(50, 10) << tanh_layer(10);
+  nn << quantized_fully_connected_layer(50, 10) << tanh();
 
   vec_t a(50, 0.0);
   label_t t = 9;
@@ -115,8 +107,8 @@ TEST(quantized_fully_connected, gradient_check) {
 /*
 TEST(quantized_fully_connected, read_write)
 {
-    quantized_fully_connected_layer<tan_h> l1(100, 100);
-    quantized_fully_connected_layer<tan_h> l2(100, 100);
+    quantized_fully_connected_layer l1(100, 100);
+    quantized_fully_connected_layer l2(100, 100);
 
     l1.setup(true);
     l2.setup(true);

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -10,6 +10,8 @@
 #include "testhelper.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(serialization, serialize_conv) {
@@ -495,10 +497,10 @@ TEST(serialization, serialize_tanh_p1m2) {
 TEST(serialization, sequential_to_json) {
   network<sequential> net1, net2;
 
-  net1 << fully_connected_layer(10, 100) << tanh_layer(100)
+  net1 << fully_connected_layer(10, 100) << tanh()
        << dropout_layer(100, 0.3f, net_phase::test)
-       << fully_connected_layer(100, 9) << softmax_layer(9)
-       << convolutional_layer(3, 3, 3, 1, 1) << tanh_layer(1);
+       << fully_connected_layer(100, 9) << softmax()
+       << convolutional_layer(3, 3, 3, 1, 1) << tanh();
 
   auto json = net1.to_json();
 
@@ -528,8 +530,8 @@ TEST(serialization, sequential_to_json) {
 TEST(serialization, sequential_model) {
   network<sequential> net1, net2;
 
-  net1 << fully_connected_layer(10, 16) << tanh_layer(16)
-       << average_pooling_layer(4, 4, 1, 2) << relu_layer(2, 2, 1)
+  net1 << fully_connected_layer(10, 16) << tanh()
+       << average_pooling_layer(4, 4, 1, 2) << relu()
        << power_layer(shape3d(2, 2, 1), 0.5f);
 
   net1.init_weight();
@@ -550,10 +552,9 @@ TEST(serialization, sequential_weights) {
   network<sequential> net1, net2;
   vec_t data = {1, 2, 3, 4, 5, 6};
 
-  net1 << fully_connected_layer(6, 6) << sigmoid_layer(6)
-       << fully_connected_layer(6, 4) << tanh_layer(4)
-       << fully_connected_layer(4, 2) << relu_layer(2)
-       << fully_connected_layer(2, 2) << softmax_layer(2);
+  net1 << fully_connected_layer(6, 6) << sigmoid()
+       << fully_connected_layer(6, 4) << tanh() << fully_connected_layer(4, 2)
+       << relu() << fully_connected_layer(2, 2) << softmax();
 
   net1.init_weight();
   net1.set_netphase(net_phase::test);
@@ -578,8 +579,8 @@ TEST(serialization, sequential_weights2) {
   vec_t data = {1, 2, 3, 4, 5, 0};
 
   net1 << batch_normalization_layer(3, 2, 0.01f, 0.99f, net_phase::train)
-       << linear_layer(3 * 2, 2.0f, 0.5f) << elu_layer(6)
-       << power_layer(shape3d(3, 2, 1), 2.0, 1.5) << leaky_relu_layer(6);
+       << linear_layer(3 * 2, 2.0f, 0.5f) << elu()
+       << power_layer(shape3d(3, 2, 1), 2.0, 1.5) << leaky_relu();
 
   net1.init_weight();
   net1.at<batch_normalization_layer>(0).update_immidiately(true);

--- a/test/test_target_cost.h
+++ b/test/test_target_cost.h
@@ -4,6 +4,8 @@
 #include "tiny_dnn/tiny_dnn.h"
 #include "tiny_dnn/util/target_cost.h"
 
+using namespace tiny_dnn::activation;
+
 namespace tiny_dnn {
 
 TEST(target_cost, calculate_label_counts) {
@@ -156,8 +158,8 @@ TEST(target_cost, train_unbalanced_data_1dim) {
 
   auto create_net = []() {
     network<sequential> net;
-    net << fully_connected_layer(1, 10) << tanh_layer(10)
-        << fully_connected_layer(10, 2) << tanh_layer(2);
+    net << fully_connected_layer(1, 10) << tanh()
+        << fully_connected_layer(10, 2) << tanh();
     return net;
   };
 
@@ -244,8 +246,8 @@ TEST(target_cost, train_unbalanced_data) {
 
   auto create_net = []() {
     network<sequential> net;
-    net << fully_connected_layer(2, 10) << tanh_layer(10)
-        << fully_connected_layer(10, 2) << tanh_layer(2);
+    net << fully_connected_layer(2, 10) << tanh()
+        << fully_connected_layer(10, 2) << tanh();
     return net;
   };
 

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -15,14 +15,26 @@ namespace tiny_dnn {
 class activation_layer : public layer {
  public:
   /**
-   * @param in_shape [in] shape of input tensor
+   * Construct an activation layer which will take shape when connected to some
+   * layer. Connection happens like ( layer1 << act_layer1 ) and shape of this
+   * layer is inferred at that time.
    */
-  activation_layer(const shape3d &in_shape)
-    : layer({vector_type::data}, {vector_type::data}), in_shape_(in_shape) {}
+  activation_layer() : activation_layer(shape3d(0, 0, 0)) {}
 
   /**
+   * Construct a flat activation layer with specified number of neurons.
    * This constructor is suitable for adding an activation layer after
-   * 3D layers such as convolution / pooling layers.
+   * flat layers such as fully connected layers.
+   *
+   * @param in_dim      [in] number of elements of the input
+   */
+  activation_layer(serial_size_t in_dim)
+    : activation_layer(shape3d(in_dim, 1, 1)) {}
+
+  /**
+   * Construct an activation layer with specified width, height and channels.
+   * This constructor is suitable for adding an activation layer after spatial
+   * layers such as convolution / pooling layers.
    *
    * @param in_width    [in] number of input elements along width
    * @param in_height   [in] number of input elements along height
@@ -31,18 +43,15 @@ class activation_layer : public layer {
   activation_layer(serial_size_t in_width,
                    serial_size_t in_height,
                    serial_size_t in_channels)
-    : layer({vector_type::data}, {vector_type::data}),
-      in_shape_(in_width, in_height, in_channels) {}
+    : activation_layer(shape3d(in_width, in_height, in_channels)) {}
 
   /**
-   * This constructor is suitable for adding an activation layer after
-   * 1D layers such as fully connected layers.
+   * Construct an activation layer with specified input shape.
    *
-   * @param in_dim      [in] number of elements of the input
+   * @param in_shape [in] shape of input tensor
    */
-  activation_layer(serial_size_t in_dim)
-    : layer({vector_type::data}, {vector_type::data}),
-      in_shape_(in_dim, 1, 1) {}
+  activation_layer(const shape3d &in_shape)
+    : layer({vector_type::data}, {vector_type::data}), in_shape_(in_shape) {}
 
   activation_layer(const layer &prev_layer)
     : layer({vector_type::data}, {vector_type::data}),
@@ -51,6 +60,10 @@ class activation_layer : public layer {
   std::vector<shape3d> in_shape() const override { return {in_shape_}; }
 
   std::vector<shape3d> out_shape() const override { return {in_shape_}; }
+
+  void set_in_shape(const shape3d &in_shape) override {
+    this->in_shape_ = in_shape;
+  }
 
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -262,6 +262,15 @@ class layer : public node {
   virtual std::vector<shape3d> in_shape() const = 0;
 
   /**
+   * set input shape of a layer (only used internally while shape inferring)
+   */
+  virtual void set_in_shape(const shape3d &in_shape) {
+    throw nn_error(
+      "Can't set shape. Shape inferring not applicable for this "
+      "layer (yet).");
+  };
+
+  /**
    * array of output shapes (width x height x depth)
    **/
   virtual std::vector<shape3d> out_shape() const = 0;
@@ -803,6 +812,13 @@ inline void connect(layerptr_t head,
   auto in_shape  = tail->in_shape()[tail_index];
 
   head->setup(false);
+
+  // todo (karandesai) enable shape inferring for all layers
+  // currently only possible for activation layers.
+  if (in_shape.size() == 0) {
+    tail->set_in_shape(out_shape);
+    in_shape = out_shape;
+  }
 
   if (out_shape.size() != in_shape.size()) {
     connection_mismatch(*head, *tail);


### PR DESCRIPTION
This PR makes changes in the activation layers API, and allows the user to declare an activation layer without specifying its dimensions.

#### Prior to this PR:
```c++
nn << fully(784, 30) << relu(30) << fully(30, 10) << softmax(10);
```
The constructors required layer dimension to be specified.

#### Changes Introduced:
```c++
nn << fully(784, 30) << relu() << fully(30, 10) << softmax();
```
Note that the older way of declaration is still valid. For this to work properly, the `out_shape` of previous layer attached to any activation layer must be defined properly. (`fully` layers in our example here).

#### Implementation Details:

* A new virtual method `set_in_shape` is introduced in `layer` class, which currently throws an `nn-error` by default, as shape inference is currently not supported for any other layers except activation layers. Activation layers override this method.

* On declaring an activation layer without passing input shape, it sets the input shape to `shape3d(0, 0, 0)` hence its `size` is zero.

* In the `<<` operator ( of the format `layer1 << layer2`, where `layer2` is activation layer ), the size of `layer2` is checked, which if zero, then `in_shape` of `layer2` is set to be same as `out_shape` of `layer1`. This is how shape inference takes place in activation layers.

#### Future Plans:

This shape inference can be extended to all the layers gradually, and then finally the user will have to specify the input shape at only the first layer of the network, while all the intermediate shapes of tensors at different layers will be automatically deduced while stacking layers using `<<` operator.