### PR TITLE
Update Dockerfile and fix build problem

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,6 +31,7 @@ RUN cd /software && \
 # Download and configure NNPACK
 RUN apt-get install ninja-build && \
     pip install ninja-syntax && \
+    pip install confu && \
     cd /software && \
     git clone --recursive https://github.com/Maratyszcza/NNPACK.git && \
     cd /software/NNPACK && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:17.04
 
 MAINTAINER Edgar Riba <edgar.riba@gmail.com>
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,21 +20,22 @@ RUN apt-get install -y    \
     libpthread-stubs0-dev \
     libtbb-dev
 
+# Upgrade pip
+RUN pip install --upgrade pip
+
 # Download and configure PeachPy
-RUN cd /software && \
-    git clone https://github.com/Maratyszcza/PeachPy.git && \
-    cd /software/PeachPy && \
-    pip install -r requirements.txt && \
-    python setup.py generate && \
-    pip install .
+RUN pip install --upgrade git+https://github.com/Maratyszcza/PeachPy
+
+# Download and configure confu
+RUN pip install --upgrade git+https://github.com/Maratyszcza/confu
 
 # Download and configure NNPACK
 RUN apt-get install ninja-build && \
     pip install ninja-syntax && \
-    pip install confu && \
     cd /software && \
     git clone --recursive https://github.com/Maratyszcza/NNPACK.git && \
     cd /software/NNPACK && \
+    confu setup && \
     python ./configure.py && \
     ninja
 


### PR DESCRIPTION
The old Dockerfile have some problem while building NNPACK, such as missing confu, mismatched ninja version.

Before fix

```bash
...
Cloning into 'NNPACK'...
Traceback (most recent call last):
File "./configure.py", line 4, in <module>
import confu
ImportError: No module named confu
Removing intermediate container a7d5d50c6b88
The command '/bin/sh -c apt-get install ninja-build && pip install ninja-syntax && cd /software && git clone --recursive https://github.com/Maratyszcza/NNPACK.git && cd /software/NNPACK && python ./configure.py && ninja' returned a non-zero code: 1
```

After fix

```bash
...
[152/156] LINK bin/convolution-inference+relu-smoketest
[153/156] CXX test/softmax-output/smoke.cc
[154/156] LINK bin/softmax-output-smoketest
[155/156] CXX test/max-pooling-output/smoke.cc
[156/156] LINK bin/max-pooling-output-smoketest
---> 60abb17a95c2
Removing intermediate container 0b970dd3258e
# build success
```