### PR TITLE
Parallelize activation_layer forward_propagation and backward_propagation methods

### DIFF
--- a/examples/mnist/train.cpp
+++ b/examples/mnist/train.cpp
@@ -37,25 +37,23 @@ static void construct_net(network<sequential> &nn,
   nn << convolutional_layer(32, 32, 5, 1,
                             6,  // C1, 1@32x32-in, 6@28x28-out
                             padding::valid, true, 1, 1, backend_type)
-     << tanh_layer(28, 28, 6)
-     << average_pooling_layer(28, 28, 6,
-                              2)  // S2, 6@28x28-in, 6@14x14-out
-     << tanh_layer(14, 14, 6)
+     << tanh_layer() << average_pooling_layer(28, 28, 6,
+                                              2)  // S2, 6@28x28-in, 6@14x14-out
+     << tanh_layer()
      << convolutional_layer(14, 14, 5, 6,
                             16,  // C3, 6@14x14-in, 16@10x10-out
                             connection_table(tbl, 6, 16), padding::valid, true,
                             1, 1, backend_type)
-     << tanh_layer(10, 10, 16)
-     << average_pooling_layer(10, 10, 16,
-                              2)  // S4, 16@10x10-in, 16@5x5-out
-     << tanh_layer(5, 5, 16)
+     << tanh_layer() << average_pooling_layer(10, 10, 16,
+                                              2)  // S4, 16@10x10-in, 16@5x5-out
+     << tanh_layer()
      << convolutional_layer(5, 5, 5, 16,
                             120,  // C5, 16@5x5-in, 120@1x1-out
                             padding::valid, true, 1, 1, backend_type)
-     << tanh_layer(1, 1, 120)
+     << tanh_layer()
      << fully_connected_layer(120, 10, true,  // F6, 120-in, 10-out
                               backend_type)
-     << tanh_layer(10);
+     << tanh_layer();
 }
 
 static void train_lenet(const std::string &data_dir_path,

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -69,10 +69,7 @@ class activation_layer : public layer {
                            std::vector<tensor_t *> &out_data) override {
     const tensor_t &x = *in_data[0];
     tensor_t &y       = *out_data[0];
-
-    for (serial_size_t i = 0; i < x.size(); i++) {
-      forward_activation(x[i], y[i]);
-    }
+    for_i(x.size(), [&](int i) { forward_activation(x[i], y[i]); });
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -83,10 +80,8 @@ class activation_layer : public layer {
     const tensor_t &dy = *out_grad[0];
     const tensor_t &x  = *in_data[0];
     const tensor_t &y  = *out_data[0];
-
-    for (serial_size_t i = 0; i < x.size(); i++) {
-      backward_activation(x[i], y[i], dx[i], dy[i]);
-    }
+    for_i(x.size(),
+          [&](int i) { backward_activation(x[i], y[i], dx[i], dy[i]); });
   }
 
   virtual std::string layer_type() const = 0;


### PR DESCRIPTION
Hi, this PR parallelizes `activation_layer`'s `forward_propagation` and `backward_propagation` methods.

After merging #651, `example_mnist_train` significantly slows down.

In old `feedforward_layer` class, `for_i` function is used inside `forward_activation` and `backward_activation` methods, so this PR recovers it.
https://github.com/tiny-dnn/tiny-dnn/pull/651/files#diff-b5252a229ea3c08ea12d86fe29fa5cd2L28
