### PR TITLE
Replace node_tuple with layer_tuple to fix graph networks.

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -28,6 +28,7 @@ using namespace tiny_dnn::activation;
 #include "test_lrn_layer.h"
 #include "test_max_pooling_layer.h"
 #include "test_models.h"
+#include "test_node.h"
 #include "test_nodes.h"
 #include "test_power_layer.h"
 #include "test_quantization.h"

--- a/test/test_node.h
+++ b/test/test_node.h
@@ -1,0 +1,95 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+#include "gtest/gtest.h"
+#include "testhelper.h"
+#include "tiny_dnn/tiny_dnn.h"
+
+namespace tiny_dnn {
+
+TEST(layer_tuple, comma_operator_layer_layer1) {
+  max_pooling_layer maxpool(4, 4, 1, 2, 1);
+  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  sigmoid_layer sgm(4, 4, 1);
+
+  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
+  EXPECT_EQ(tuple_1.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_1.layers_.at(1)->layer_type(), "ave-pool");
+
+  layer_tuple<layerptr_t> tuple_2 = (maxpool, sgm);
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "sigmoid-activation");
+}
+
+TEST(layer_tuple, comma_operator_layer_layer2) {
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
+
+  layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);
+  EXPECT_EQ(tuple_1.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_1.layers_.at(1)->layer_type(), "ave-pool");
+
+  layer_tuple<std::shared_ptr<layer>> tuple_2 = (maxpool, sgm);
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "sigmoid-activation");
+}
+
+TEST(layer_tuple, comma_operator_tuple_layer1) {
+  max_pooling_layer maxpool(4, 4, 1, 2, 1);
+  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  sigmoid_layer sgm(4, 4, 1);
+
+  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
+  layer_tuple<layerptr_t> tuple_2 = (tuple_1, sgm);
+
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "ave-pool");
+  EXPECT_EQ(tuple_2.layers_.at(2)->layer_type(), "sigmoid-activation");
+}
+
+TEST(layer_tuple, comma_operator_tuple_layer2) {
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
+
+  layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);
+  layer_tuple<std::shared_ptr<layer>> tuple_2 = (tuple_1, sgm);
+
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "ave-pool");
+  EXPECT_EQ(tuple_2.layers_.at(2)->layer_type(), "sigmoid-activation");
+}
+
+TEST(layer_tuple, comma_operator_layer_tuple1) {
+  max_pooling_layer maxpool(4, 4, 1, 2, 1);
+  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  sigmoid_layer sgm(4, 4, 1);
+
+  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
+  layer_tuple<layerptr_t> tuple_2 = (sgm, tuple_1);
+
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "sigmoid-activation");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(2)->layer_type(), "ave-pool");
+}
+
+TEST(layer_tuple, comma_operator_layer_tuple2) {
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
+
+  layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);
+  layer_tuple<std::shared_ptr<layer>> tuple_2 = (sgm, tuple_1);
+
+  EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "sigmoid-activation");
+  EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "max-pool");
+  EXPECT_EQ(tuple_2.layers_.at(2)->layer_type(), "ave-pool");
+}
+
+}  // namespace tiny-dnn

--- a/test/test_node.h
+++ b/test/test_node.h
@@ -17,11 +17,11 @@ TEST(layer_tuple, comma_operator_layer_layer1) {
   average_pooling_layer avepool(4, 4, 1, 2, 1);
   sigmoid_layer sgm(4, 4, 1);
 
-  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
+  layer_tuple<layer *> tuple_1 = (maxpool, avepool);
   EXPECT_EQ(tuple_1.layers_.at(0)->layer_type(), "max-pool");
   EXPECT_EQ(tuple_1.layers_.at(1)->layer_type(), "ave-pool");
 
-  layer_tuple<layerptr_t> tuple_2 = (maxpool, sgm);
+  layer_tuple<layer *> tuple_2 = (maxpool, sgm);
   EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
   EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "sigmoid-activation");
 }
@@ -45,8 +45,8 @@ TEST(layer_tuple, comma_operator_tuple_layer1) {
   average_pooling_layer avepool(4, 4, 1, 2, 1);
   sigmoid_layer sgm(4, 4, 1);
 
-  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
-  layer_tuple<layerptr_t> tuple_2 = (tuple_1, sgm);
+  layer_tuple<layer *> tuple_1 = (maxpool, avepool);
+  layer_tuple<layer *> tuple_2 = (tuple_1, sgm);
 
   EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "max-pool");
   EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "ave-pool");
@@ -71,8 +71,8 @@ TEST(layer_tuple, comma_operator_layer_tuple1) {
   average_pooling_layer avepool(4, 4, 1, 2, 1);
   sigmoid_layer sgm(4, 4, 1);
 
-  layer_tuple<layerptr_t> tuple_1 = (maxpool, avepool);
-  layer_tuple<layerptr_t> tuple_2 = (sgm, tuple_1);
+  layer_tuple<layer *> tuple_1 = (maxpool, avepool);
+  layer_tuple<layer *> tuple_2 = (sgm, tuple_1);
 
   EXPECT_EQ(tuple_2.layers_.at(0)->layer_type(), "sigmoid-activation");
   EXPECT_EQ(tuple_2.layers_.at(1)->layer_type(), "max-pool");

--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -156,13 +156,13 @@ class backend {
 
   context *get_context() const { return ctx_; }
 
-  void set_layer(layerptr_t layer) { layer_ = layer; }
+  void set_layer(layer *layer) { layer_ = layer; }
 
   virtual backend_t type() const = 0;
 
  protected:
   context *ctx_;
-  layerptr_t layer_;
+  layer *layer_;
 };
 
 }  // namespace core

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -204,7 +204,7 @@ class layer : public node {
   std::vector<edgeptr_t> outputs() const {
     std::vector<edgeptr_t> nodes(out_channels_);
     for (serial_size_t i = 0; i < out_channels_; i++) {
-      nodes[i] = const_cast<layerptr_t>(this)->ith_out_node(i);
+      nodes[i] = const_cast<layer *>(this)->ith_out_node(i);
     }
     return nodes;
   }
@@ -232,7 +232,7 @@ class layer : public node {
     for (serial_size_t i = 0; i < out_channels_; i++) {
       if (out_type_[i] == vector_type::data) {
         out.push_back(
-          *(const_cast<layerptr_t>(this))->ith_out_node(i)->get_data());
+          *(const_cast<layer *>(this))->ith_out_node(i)->get_data());
       }
     }
     return out;
@@ -800,12 +800,12 @@ class layer : public node {
    */
   const vec_t *get_weight_data(serial_size_t i) const {
     assert(is_trainable_weight(in_type_[i]));
-    return &(*(const_cast<layerptr_t>(this)->ith_in_node(i)->get_data()))[0];
+    return &(*(const_cast<layer *>(this)->ith_in_node(i)->get_data()))[0];
   }
 };
 
-inline void connect(layerptr_t head,
-                    layerptr_t tail,
+inline void connect(layer *head,
+                    layer *tail,
                     serial_size_t head_index = 0,
                     serial_size_t tail_index = 0) {
   auto out_shape = head->out_shape()[head_index];

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -146,8 +146,8 @@ void construct_graph(network<graph> &graph,
 template <typename NetType>
 class network {
  public:
-  typedef typename std::vector<layerptr_t>::iterator iterator;
-  typedef typename std::vector<layerptr_t>::const_iterator const_iterator;
+  typedef typename std::vector<layer *>::iterator iterator;
+  typedef typename std::vector<layer *>::const_iterator const_iterator;
 
   explicit network(const std::string &name = "")
     : name_(name), stop_training_(false) {}

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -188,6 +188,14 @@ layer_tuple<std::shared_ptr<layer>> operator,(std::shared_ptr<T> l1,
 template <
   typename T,
   typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
+layer_tuple<layerptr_t> operator,(layer_tuple<layerptr_t> lhs, T &rhs) {
+  lhs.layers_.push_back(&rhs);
+  return lhs;
+}
+
+template <
+  typename T,
+  typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
 layer_tuple<std::shared_ptr<layer>> operator,(
   layer_tuple<std::shared_ptr<layer>> lhs, std::shared_ptr<T> &rhs) {
   lhs.layers_.push_back(rhs);
@@ -197,9 +205,18 @@ layer_tuple<std::shared_ptr<layer>> operator,(
 template <
   typename T,
   typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
-layer_tuple<layerptr_t> operator,(layer_tuple<layerptr_t> lhs, T &rhs) {
-  lhs.layers_.push_back(&rhs);
-  return lhs;
+layer_tuple<layerptr_t> operator,(T &lhs, layer_tuple<layerptr_t> rhs) {
+  rhs.layers_.insert(rhs.layers_.begin(), &lhs);
+  return rhs;
+}
+
+template <
+  typename T,
+  typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
+layer_tuple<std::shared_ptr<layer>> operator,(
+  std::shared_ptr<T> &lhs, layer_tuple<std::shared_ptr<layer>> rhs) {
+  rhs.layers_.insert(rhs.layers_.begin(), lhs);
+  return rhs;
 }
 
 template <typename T, typename U>

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -139,22 +139,24 @@ class edge {
 };
 
 inline std::vector<node *> node::prev_nodes() const {
-  std::set<node *> sets;
+  std::vector<node *> vecs;
   for (auto &e : prev_) {
-    if (e && e->prev()) sets.insert(e->prev());
+    if (e && e->prev()) {
+      vecs.insert(vecs.end(), e->prev());
+    }
   }
-  return std::vector<node *>(sets.begin(), sets.end());
+  return vecs;
 }
 
 inline std::vector<node *> node::next_nodes() const {
-  std::set<node *> sets;
+  std::vector<node *> vecs;
   for (auto &e : next_) {
     if (e) {
       auto n = e->next();
-      sets.insert(n.begin(), n.end());
+      vecs.insert(vecs.end(), n.begin(), n.end());
     }
   }
-  return std::vector<node *>(sets.begin(), sets.end());
+  return vecs;
 }
 
 template <typename T>

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -218,7 +218,7 @@ inline T &operator<<(const layer_tuple<std::shared_ptr<layer>> &lhs, T &rhs) {
 }
 
 template <typename T>
-inline layer_tuple<std::shared_ptr<layer>> &operator<<(
+inline const layer_tuple<std::shared_ptr<layer>> &operator<<(
   T &lhs, const layer_tuple<std::shared_ptr<layer>> &rhs) {
   for (size_t i = 0; i < static_cast<size_t>(rhs.layers_.size()); i++) {
     connect(&*lhs, &*rhs.layers_[i], i, 0);
@@ -235,8 +235,8 @@ inline T &operator<<(const layer_tuple<layerptr_t> &lhs, T &rhs) {
 }
 
 template <typename T>
-inline layer_tuple<layerptr_t> &operator<<(T &lhs,
-                                           const layer_tuple<layerptr_t> &rhs) {
+inline const layer_tuple<layerptr_t> &operator<<(
+  T &lhs, const layer_tuple<layerptr_t> &rhs) {
   for (size_t i = 0; i < static_cast<size_t>(rhs.layers_.size()); i++) {
     connect(&lhs, rhs.layers_[i], i, 0);
   }

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -31,10 +31,7 @@ class node;
 class layer;
 class edge;
 
-typedef node *nodeptr_t;
 typedef std::shared_ptr<edge> edgeptr_t;
-
-typedef layer *layerptr_t;
 
 /**
  * base class of all kind of tinny-cnn data
@@ -68,8 +65,8 @@ class node : public std::enable_shared_from_this<node> {
  protected:
   node() = delete;
 
-  friend void connect(layerptr_t head,
-                      layerptr_t tail,
+  friend void connect(layer *head,
+                      layer *tail,
                       serial_size_t head_index,
                       serial_size_t tail_index);
 
@@ -173,8 +170,8 @@ template <
   typename U,
   typename std::enable_if<std::is_base_of<layer, T>::value &&
                           std::is_base_of<layer, U>::value>::type * = nullptr>
-layer_tuple<layerptr_t> operator,(T &l1, U &l2) {
-  return layer_tuple<layerptr_t>(&l1, &l2);
+layer_tuple<layer *> operator,(T &l1, U &l2) {
+  return layer_tuple<layer *>(&l1, &l2);
 }
 
 template <
@@ -190,7 +187,7 @@ layer_tuple<std::shared_ptr<layer>> operator,(std::shared_ptr<T> l1,
 template <
   typename T,
   typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
-layer_tuple<layerptr_t> operator,(layer_tuple<layerptr_t> lhs, T &rhs) {
+layer_tuple<layer *> operator,(layer_tuple<layer *> lhs, T &rhs) {
   lhs.layers_.push_back(&rhs);
   return lhs;
 }
@@ -207,7 +204,7 @@ layer_tuple<std::shared_ptr<layer>> operator,(
 template <
   typename T,
   typename std::enable_if<std::is_base_of<layer, T>::value>::type * = nullptr>
-layer_tuple<layerptr_t> operator,(T &lhs, layer_tuple<layerptr_t> rhs) {
+layer_tuple<layer *> operator,(T &lhs, layer_tuple<layer *> rhs) {
   rhs.layers_.insert(rhs.layers_.begin(), &lhs);
   return rhs;
 }
@@ -246,7 +243,7 @@ inline const layer_tuple<std::shared_ptr<layer>> &operator<<(
 }
 
 template <typename T>
-inline T &operator<<(const layer_tuple<layerptr_t> &lhs, T &rhs) {
+inline T &operator<<(const layer_tuple<layer *> &lhs, T &rhs) {
   for (size_t i = 0; i < lhs.layers_.size(); i++) {
     connect(lhs.layers_[i], &rhs, 0, i);
   }
@@ -254,8 +251,8 @@ inline T &operator<<(const layer_tuple<layerptr_t> &lhs, T &rhs) {
 }
 
 template <typename T>
-inline const layer_tuple<layerptr_t> &operator<<(
-  T &lhs, const layer_tuple<layerptr_t> &rhs) {
+inline const layer_tuple<layer *> &operator<<(T &lhs,
+                                              const layer_tuple<layer *> &rhs) {
   for (size_t i = 0; i < rhs.layers_.size(); i++) {
     connect(&lhs, rhs.layers_[i], i, 0);
   }

--- a/tiny_dnn/node.h
+++ b/tiny_dnn/node.h
@@ -230,7 +230,7 @@ inline std::shared_ptr<U> &operator<<(std::shared_ptr<T> &lhs,
 
 template <typename T>
 inline T &operator<<(const layer_tuple<std::shared_ptr<layer>> &lhs, T &rhs) {
-  for (size_t i = 0; i < static_cast<size_t>(lhs.layers_.size()); i++) {
+  for (size_t i = 0; i < lhs.layers_.size(); i++) {
     connect(&*lhs.layers_[i], &*rhs, 0, i);
   }
   return rhs;
@@ -239,7 +239,7 @@ inline T &operator<<(const layer_tuple<std::shared_ptr<layer>> &lhs, T &rhs) {
 template <typename T>
 inline const layer_tuple<std::shared_ptr<layer>> &operator<<(
   T &lhs, const layer_tuple<std::shared_ptr<layer>> &rhs) {
-  for (size_t i = 0; i < static_cast<size_t>(rhs.layers_.size()); i++) {
+  for (size_t i = 0; i < rhs.layers_.size(); i++) {
     connect(&*lhs, &*rhs.layers_[i], i, 0);
   }
   return rhs;
@@ -247,7 +247,7 @@ inline const layer_tuple<std::shared_ptr<layer>> &operator<<(
 
 template <typename T>
 inline T &operator<<(const layer_tuple<layerptr_t> &lhs, T &rhs) {
-  for (size_t i = 0; i < static_cast<size_t>(lhs.layers_.size()); i++) {
+  for (size_t i = 0; i < lhs.layers_.size(); i++) {
     connect(lhs.layers_[i], &rhs, 0, i);
   }
   return rhs;
@@ -256,7 +256,7 @@ inline T &operator<<(const layer_tuple<layerptr_t> &lhs, T &rhs) {
 template <typename T>
 inline const layer_tuple<layerptr_t> &operator<<(
   T &lhs, const layer_tuple<layerptr_t> &rhs) {
-  for (size_t i = 0; i < static_cast<size_t>(rhs.layers_.size()); i++) {
+  for (size_t i = 0; i < rhs.layers_.size(); i++) {
     connect(&lhs, rhs.layers_[i], i, 0);
   }
   return rhs;

--- a/tiny_dnn/nodes.h
+++ b/tiny_dnn/nodes.h
@@ -23,7 +23,7 @@
 namespace cereal {
 
 template <typename Archive>
-void save(Archive &ar, const std::vector<tiny_dnn::layerptr_t> &v) {
+void save(Archive &ar, const std::vector<tiny_dnn::layer *> &v) {
 #ifndef CNN_NO_SERIALIZATION
   ar(cereal::make_size_tag(static_cast<cereal::size_type>(v.size())));
   for (auto n : v) {
@@ -78,8 +78,8 @@ namespace tiny_dnn {
  **/
 class nodes {
  public:
-  typedef std::vector<layerptr_t>::iterator iterator;
-  typedef std::vector<layerptr_t>::const_iterator const_iterator;
+  typedef std::vector<layer *>::iterator iterator;
+  typedef std::vector<layer *>::const_iterator const_iterator;
 
   /**
    * propagate gradient
@@ -267,7 +267,7 @@ class nodes {
   /* Nodes which this class has ownership */
   std::vector<std::shared_ptr<layer>> own_nodes_;
   /* List of all nodes which includes own_nodes */
-  std::vector<layerptr_t> nodes_;
+  std::vector<layer *> nodes_;
 };
 
 /**
@@ -410,18 +410,18 @@ class graph : public nodes {
     return merge_outs();
   }
 
-  void construct(const std::vector<layerptr_t> &input,
-                 const std::vector<layerptr_t> &output) {
-    std::vector<layerptr_t> sorted;
-    std::vector<nodeptr_t> input_nodes(input.begin(), input.end());
+  void construct(const std::vector<layer *> &input,
+                 const std::vector<layer *> &output) {
+    std::vector<layer *> sorted;
+    std::vector<node *> input_nodes(input.begin(), input.end());
     std::unordered_map<node *, std::vector<uint8_t>> removed_edge;
 
     // topological-sorting
     while (!input_nodes.empty()) {
-      sorted.push_back(dynamic_cast<layerptr_t>(input_nodes.back()));
+      sorted.push_back(dynamic_cast<layer *>(input_nodes.back()));
       input_nodes.pop_back();
 
-      layerptr_t curr          = sorted.back();
+      layer *curr              = sorted.back();
       std::vector<node *> next = curr->next_nodes();
 
       for (size_t i = 0; i < next.size(); i++) {
@@ -572,15 +572,14 @@ class graph : public nodes {
     return merged;
   }
 
-  serial_size_t find_index(const std::vector<node *> &nodes,
-                           layerptr_t target) {
+  serial_size_t find_index(const std::vector<node *> &nodes, layer *target) {
     for (serial_size_t i = 0; i < nodes.size(); i++) {
       if (nodes[i] == static_cast<node *>(&*target)) return i;
     }
     throw nn_error("invalid connection");
   }
-  std::vector<layerptr_t> input_layers_;
-  std::vector<layerptr_t> output_layers_;
+  std::vector<layer *> input_layers_;
+  std::vector<layer *> output_layers_;
 };
 
 template <typename OutputArchive>


### PR DESCRIPTION
This PR replaces `node_tuple` with a `layer_tuple` and puts a constraint on its formation in such a way that the passed operands to `,` comma operator have layer class as its ancestor.

The comma operator for node_tuple didn't work if both operands were a different type. Hence one couldn't do `(l1, l2) << l3` and form a graph network if l1 and l2 were not the instances of same type of layer.

Fixes #578. 
Resolves #146, #257, #615. 