### PR TITLE
Reduce use of C preprocessor

### DIFF
--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -160,14 +160,8 @@ class Tensor {
     //TODO(Randl): Move constructors for Tensor and TensorStorage
     Tensor &operator = (const Tensor& other) {}
 
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
     Tensor(Tensor&& other) = default;        // move ctor
     Tensor &operator = (Tensor&&) = default; // move assign
-#else
-
-    Tensor(Tensor&& other) {}
-    Tensor &operator = (Tensor&& other) {}
-#endif  // CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
 #endif
 
   /**

--- a/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
@@ -79,7 +79,7 @@ inline void accumulate_dw(const core::conv_params &params,
 
   if (out.width_ == 1 && out.height_ == 1) {
     const float *pprev_out = &prev_out[0];
-    VECTORIZE_ALIGN(32) float floats[28];
+    alignas(32) float floats[28];
     for (serial_size_t inc = 0; inc < in.depth_;
          ++inc, pprev_out += in_padded_area) {
       size_t in_padded_width = in_padded.width_;

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -39,11 +39,9 @@ class dropout_layer : public layer {
   dropout_layer(const dropout_layer &obj) = default;
   virtual ~dropout_layer() {}
 
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
   dropout_layer(dropout_layer &&obj) = default;
   dropout_layer &operator=(const dropout_layer &obj) = default;
   dropout_layer &operator=(dropout_layer &&obj) = default;
-#endif
 
   void set_dropout_rate(float_t rate) {
     dropout_rate_ = rate;

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -74,10 +74,8 @@ class layer : public node {
   layer(const layer &) = default;
   layer &operator=(const layer &) = default;
 
-#ifdef CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
   layer(layer &&) = default;
   layer &operator=(layer &&) = default;
-#endif
 
   void set_parallelize(bool parallelize) { parallelize_ = parallelize; }
 

--- a/tiny_dnn/optimizers/optimizer.h
+++ b/tiny_dnn/optimizers/optimizer.h
@@ -21,10 +21,10 @@ namespace tiny_dnn {
 struct optimizer {
   optimizer()                  = default;
   optimizer(const optimizer &) = default;
-  optimizer(optimizer &&) = default;
+  optimizer(optimizer &&)      = default;
   optimizer &operator=(const optimizer &) = default;
   optimizer &operator=(optimizer &&) = default;
-  virtual ~optimizer() = default;
+  virtual ~optimizer()               = default;
   virtual void update(const vec_t &dW, vec_t &W, bool parallelize) = 0;
   virtual void reset() {}  // override to implement pre-learning action
 };

--- a/tiny_dnn/optimizers/optimizer.h
+++ b/tiny_dnn/optimizers/optimizer.h
@@ -21,13 +21,9 @@ namespace tiny_dnn {
 struct optimizer {
   optimizer()                  = default;
   optimizer(const optimizer &) = default;
-#ifndef CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
   optimizer(optimizer &&) = default;
-#endif
   optimizer &operator=(const optimizer &) = default;
-#ifndef CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
   optimizer &operator=(optimizer &&) = default;
-#endif
   virtual ~optimizer() = default;
   virtual void update(const vec_t &dW, vec_t &W, bool parallelize) = 0;
   virtual void reset() {}  // override to implement pre-learning action

--- a/tiny_dnn/util/aligned_allocator.h
+++ b/tiny_dnn/util/aligned_allocator.h
@@ -62,15 +62,11 @@ class aligned_allocator {
     ::new (p) U(value);
   }
 
-#if defined(_MSC_VER) && _MSC_VER <= 1800
-// -vc2013 doesn't support variadic templates
-#else
   template <class U, class... Args>
   void construct(U *ptr, Args &&... args) {
     void *p = ptr;
     ::new (p) U(std::forward<Args>(args)...);
   }
-#endif
 
   template <class U>
   void construct(U *ptr) {

--- a/tiny_dnn/util/deserialization_helper.h
+++ b/tiny_dnn/util/deserialization_helper.h
@@ -127,7 +127,7 @@ template <typename InputArchive>
 template <typename T>
 std::shared_ptr<layer> deserialization_helper<InputArchive>::load_layer_impl(
   InputArchive &ia) {
-  using ST = typename std::aligned_storage<sizeof(T), CNN_ALIGNOF(T)>::type;
+  using ST = typename std::aligned_storage<sizeof(T), alignof(T)>::type;
 
   std::unique_ptr<ST> bn(new ST());
 

--- a/tiny_dnn/util/macro.h
+++ b/tiny_dnn/util/macro.h
@@ -31,25 +31,6 @@
 
 #define CNN_UNREFERENCED_PARAMETER(x) (void)(x)
 
-#if defined(_MSC_VER) && (_MSC_VER <= 1800)
-// msvc2013 doesn't have move constructor
-#define CNN_DEFAULT_MOVE_CONSTRUCTOR_UNAVAILABLE
-#define CNN_DEFAULT_ASSIGNMENT_OPERATOR_UNAVAILABLE
-#endif
-
-#if defined(_MSC_VER) && (_MSC_VER <= 1800)
-// msvc2013 doesn't have alignof operator
-#define CNN_ALIGNOF(x) __alignof(x)
-#else
-#define CNN_ALIGNOF(x) alignof(x)
-#endif
-
-#if !defined(_MSC_VER) || (_MSC_VER >= 1900)  // default generation of move
-                                              // constructor is unsupported in
-                                              // VS2013
-#define CNN_USE_DEFAULT_MOVE_CONSTRUCTORS
-#endif
-
 #if defined _WIN32 && !defined(__MINGW32__)
 #define CNN_WINDOWS
 #endif

--- a/tiny_dnn/util/product.h
+++ b/tiny_dnn/util/product.h
@@ -14,14 +14,6 @@
 #include <cstdint>
 #include <numeric>
 
-#if defined(_MSC_VER)
-#define VECTORIZE_ALIGN(x) __declspec(align(x))
-#elif defined(__GNUC__)
-#define VECTORIZE_ALIGN(x) __attribute__((aligned(x)))
-#else
-#define VECTORIZE_ALIGN(x) __attribute__((aligned(x)))
-#endif
-
 #ifdef CNN_USE_AVX
 #include "tiny_dnn/core/kernels/avx_kernel_common.h"
 #endif
@@ -96,7 +88,7 @@ struct float_sse {
     _mm_storeu_ps(px, v);
   }
   static value_type resemble(const register_type &x) {
-    VECTORIZE_ALIGN(16) float tmp[4];
+    alignas(16) float tmp[4];
     _mm_store_ps(tmp, x);
     return tmp[0] + tmp[1] + tmp[2] + tmp[3];
   }
@@ -128,7 +120,7 @@ struct double_sse {
     _mm_storeu_pd(px, v);
   }
   static value_type resemble(const register_type &x) {
-    VECTORIZE_ALIGN(16) double tmp[2];
+    alignas(16) double tmp[2];
     _mm_store_pd(tmp, x);
     return tmp[0] + tmp[1];
   }
@@ -228,7 +220,7 @@ struct double_avx {
     _mm256_storeu_pd(px, v);
   }
   static value_type resemble(const register_type &x) {
-    VECTORIZE_ALIGN(32) double tmp[4];
+    alignas(32) double tmp[4];
     _mm256_store_pd(tmp, x);
     return std::accumulate(tmp, tmp + 4, 0.0);
   }


### PR DESCRIPTION
Hi, this PR reduces use of C preprocessor.
Since this library doesn't support Visual Studio 2013 anymore, getting rid of some preprocessor macros shouldn't be a problem.
