### PR TITLE
Add a new layer: Global Average Pooling

### DIFF
--- a/test/test.cpp
+++ b/test/test.cpp
@@ -24,6 +24,7 @@ using namespace tiny_dnn::activation;
 #include "test_deconvolutional_layer.h"
 #include "test_dropout_layer.h"
 #include "test_fully_connected_layer.h"
+#include "test_global_average_pooling_layer.h"
 #include "test_large_thread_count.h"
 #include "test_lrn_layer.h"
 #include "test_max_pooling_layer.h"

--- a/test/test_global_average_pooling_layer.h
+++ b/test/test_global_average_pooling_layer.h
@@ -15,6 +15,16 @@
 
 namespace tiny_dnn {
 
+TEST(global_ave_pool, read_write) {
+  global_average_pooling_layer l1(100, 100, 5);
+  global_average_pooling_layer l2(100, 100, 5);
+
+  l1.init_weight();
+  l2.init_weight();
+
+  serialization_test(l1, l2);
+}
+
 TEST(global_ave_pool, forward) {
   global_average_pooling_layer l(4, 4, 1);
 

--- a/test/test_global_average_pooling_layer.h
+++ b/test/test_global_average_pooling_layer.h
@@ -1,0 +1,119 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include <string>
+
+#include "gtest/gtest.h"
+#include "testhelper.h"
+#include "tiny_dnn/tiny_dnn.h"
+
+namespace tiny_dnn {
+
+TEST(global_ave_pool, forward) {
+  global_average_pooling_layer l(4, 4, 1);
+
+  // clang-format off
+  vec_t in = {0, 1, 2, 3,
+              8, 7, 5, 6,
+              4, 3, 1, 2,
+              0,-1,-2,-3};
+  // clang-format on
+
+  vec_t expected = {2.25};
+  vec_t res      = l.forward({{in}})[0][0];
+
+  EXPECT_FLOAT_EQ(expected[0], res[0]);
+}
+
+TEST(global_ave_pool, setup_internal) {
+  global_average_pooling_layer l(4, 4, 1, core::backend_t::internal);
+
+  EXPECT_EQ(l.parallelize(), true);          // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);            // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);           // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 16u);          // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 1u);          // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(), 1u);   // num of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), 1u);  // num of output shapes
+  EXPECT_EQ(l.inputs().size(), 1u);          // num of input edges
+  EXPECT_EQ(l.outputs().size(), 1u);         // num of output edges
+  EXPECT_EQ(l.in_types().size(), 1u);        // num of input data types
+  EXPECT_EQ(l.out_types().size(), 1u);       // num of output data types
+  EXPECT_EQ(l.fan_in_size(), 16u);           // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 1u);           // num of outgoing connections
+  EXPECT_STREQ(l.layer_type().c_str(),
+               "global-ave-pool");  // string with layer type
+}
+
+TEST(global_ave_pool, forward_multichannel) {
+  global_average_pooling_layer l(2, 2, 3);
+  // clang-format off
+  vec_t in = {0, 1,
+              2, 3, 8, 7,
+                    5, 6, 4, 3,
+                          1, 2};
+  // clang-format on
+
+  vec_t expected = {1.5, 6.5, 2.5};
+
+  vec_t res = l.forward({{in}})[0][0];
+
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
+}
+
+TEST(global_ave_pool, backward) {
+  global_average_pooling_layer l(4, 4, 1);
+  // clang-format off
+  vec_t in = {0, 1, 2, 3,
+              8, 7, 5, 6,
+              4, 3, 1, 2,
+              0,-1,-2,-3};
+
+  vec_t out_grad = {16};
+
+  vec_t in_grad_expected = {1, 1, 1, 1,
+                            1, 1, 1, 1,
+                            1, 1, 1, 1,
+                            1, 1, 1, 1};
+  // clang-format on
+
+  l.forward({{in}})[0];
+  vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
+
+  for (size_t i = 0; i < in_grad.size(); i++) {
+    EXPECT_FLOAT_EQ(in_grad_expected[i], in_grad[i]);
+  }
+}
+
+TEST(global_ave_pool, backward_multichannel) {
+  global_average_pooling_layer l(2, 2, 3);
+  // clang-format off
+  vec_t in = {0, 1,
+              2, 3, 8, 7,
+                    5, 6, 4, 3,
+                          1, 2};
+
+  vec_t out_grad = {4, 8, 12};
+
+  vec_t in_grad_expected = {1, 1,
+                            1, 1, 2, 2,
+                                  2, 2, 3, 3,
+                                        3, 3};
+  // clang-format on
+
+  l.forward({{in}})[0];
+  vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
+
+  for (size_t i = 0; i < in_grad.size(); i++) {
+    EXPECT_FLOAT_EQ(in_grad_expected[i], in_grad[i]);
+  }
+}
+}  // namespace tiny_dnn

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -233,6 +233,31 @@ TEST(serialization, serialize_fully) {
   EXPECT_EQ(net[0]->out_shape()[0], shape3d(20, 1, 1));
 }
 
+TEST(serialization, serialize_global_average_pooling) {
+  network<sequential> net;
+
+  std::string json = R"(
+    {
+        "nodes": [
+            {
+                "type": "global_average_pooling",
+                "in_shape": {
+                    "width": 5,
+                    "height": 4,
+                    "depth": 6
+                }
+            }
+        ]
+    }
+    )";
+
+  net.from_json(json);
+
+  EXPECT_EQ(net[0]->layer_type(), "global-ave-pool");
+  EXPECT_EQ(net[0]->in_shape()[0], shape3d(5, 4, 6));
+  EXPECT_EQ(net[0]->out_shape()[0], shape3d(6, 1, 1));
+}
+
 TEST(serialization, serialize_lrn) {
   network<sequential> net;
 

--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -10,6 +10,7 @@
 #include "tiny_dnn/core/params/conv_params.h"
 #include "tiny_dnn/core/params/deconv_params.h"
 #include "tiny_dnn/core/params/fully_params.h"
+#include "tiny_dnn/core/params/global_avepool_params.h"
 #include "tiny_dnn/core/params/maxpool_params.h"
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/node.h"

--- a/tiny_dnn/core/kernels/global_avepool_grad_op.h
+++ b/tiny_dnn/core/kernels/global_avepool_grad_op.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include "tiny_dnn/core/framework/op_kernel.h"
+#include "tiny_dnn/core/kernels/global_avepool_op_internal.h"
+
+namespace tiny_dnn {
+
+class GlobalAvePoolGradOp : public core::OpKernel {
+ public:
+  explicit GlobalAvePoolGradOp(const core::OpKernelConstruction &context)
+    : core::OpKernel(context) {}
+
+  void compute(const core::OpKernelContext &context) override {
+    auto &params = OpKernel::params_->global_avepool();
+
+    // incoming/outcoming data
+    tensor_t &prev_delta = context.input_grad(0);
+    tensor_t &curr_delta = context.output_grad(0);
+
+    // initialize outputs
+    fill_tensor(prev_delta, float_t{0});
+
+    // only internal kernel op implemented yet, so use it regardless
+    // of the specified backend engine
+    kernels::global_avepool_grad_op_internal(prev_delta, curr_delta, params,
+                                             context.parallelize());
+  }
+};
+
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/global_avepool_op.h
+++ b/tiny_dnn/core/kernels/global_avepool_op.h
@@ -1,0 +1,37 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include "tiny_dnn/core/framework/op_kernel.h"
+#include "tiny_dnn/core/kernels/global_avepool_op_internal.h"
+
+namespace tiny_dnn {
+
+class GlobalAvePoolOp : public core::OpKernel {
+ public:
+  explicit GlobalAvePoolOp(const core::OpKernelConstruction &context)
+    : core::OpKernel(context) {}
+
+  void compute(const core::OpKernelContext &context) override {
+    auto &params = OpKernel::params_->global_avepool();
+
+    // incomimg / outcoming data
+    const tensor_t &in_data = context.input(0);
+    tensor_t &out_data      = context.output(0);
+
+    // initialize outputs
+    fill_tensor(out_data, float_t{0});
+
+    // only internal kernel op implemented yet, so use it regardless
+    // of the specified backend engine
+    kernels::global_avepool_op_internal(in_data, out_data, params,
+                                        context.parallelize());
+  }
+};
+
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/kernels/global_avepool_op_internal.h
+++ b/tiny_dnn/core/kernels/global_avepool_op_internal.h
@@ -1,0 +1,52 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+namespace tiny_dnn {
+namespace kernels {
+
+inline void global_avepool_op_internal(
+  const tensor_t &in_data,
+  tensor_t &out_data,
+  const core::global_avepool_params &params,
+  const bool layer_parallelize) {
+  for_i(layer_parallelize, in_data.size(), [&](int sample) {
+    const vec_t &in = in_data[sample];
+    vec_t &out      = out_data[sample];
+
+    const size_t pool_area = params.in.width_ * params.in.height_;
+    for (size_t i = 0; i < params.in.depth_; i++) {
+      for (size_t j = 0; j < pool_area; j++) {
+        out[i] += in[i * pool_area + j];
+      }
+      out[i] /= pool_area;
+    }
+  });
+}
+
+inline void global_avepool_grad_op_internal(
+  tensor_t &prev_delta,
+  const tensor_t &curr_delta,
+  const core::global_avepool_params &params,
+  const bool layer_parallelize) {
+  for_i(layer_parallelize, prev_delta.size(), [&](int sample) {
+    vec_t &prev       = prev_delta[sample];
+    const vec_t &curr = curr_delta[sample];
+
+    const size_t pool_area = params.in.width_ * params.in.height_;
+    for (size_t i = 0; i < params.in.depth_; i++) {
+      const float_t pi = curr[i] / pool_area;
+      for (size_t j = 0; j < pool_area; j++) {
+        prev[i * pool_area + j] = pi;
+      }
+    }
+  });
+}
+
+}  // namespace kernels
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/params/global_avepool_params.h
+++ b/tiny_dnn/core/params/global_avepool_params.h
@@ -13,8 +13,8 @@ namespace core {
 
 class global_avepool_params : public Params {
  public:
-  index3d<serial_size_t> in;
-  index3d<serial_size_t> out;
+  shape3d in;
+  shape3d out;
 };
 
 inline global_avepool_params &Params::global_avepool() {

--- a/tiny_dnn/core/params/global_avepool_params.h
+++ b/tiny_dnn/core/params/global_avepool_params.h
@@ -1,0 +1,25 @@
+/*
+    Copyright (c) 2017, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+#include "tiny_dnn/core/params/params.h"
+
+namespace tiny_dnn {
+namespace core {
+
+class global_avepool_params : public Params {
+ public:
+  index3d<serial_size_t> in;
+  index3d<serial_size_t> out;
+};
+
+inline global_avepool_params &Params::global_avepool() {
+  return *(static_cast<global_avepool_params *>(this));
+}
+
+}  // namespace core
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -13,6 +13,7 @@ namespace core {
 class conv_params;
 class fully_params;
 class maxpool_params;
+class global_avepool_params;
 
 /* Base class to model operation parameters */
 class Params {
@@ -22,6 +23,7 @@ class Params {
   conv_params conv() const;
   fully_params fully() const;
   maxpool_params &maxpool();
+  global_avepool_params &global_avepool();
 };
 
 }  // namespace core

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -109,7 +109,7 @@ class global_average_pooling_layer : public layer {
       core::OpKernelConstruction(layer::device(), &params_);
 
     layer::set_backend_type(backend_type);
-    if (backend_type == backend_t::internal) {
+    if (backend_type == backend_t::internal || backend_type == backend_t::avx || backend_type == backend_t::nnpack) {
       kernel_fwd_.reset(new GlobalAvePoolOp(ctx));
       kernel_back_.reset(new GlobalAvePoolGradOp(ctx));
       return;

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -1,0 +1,130 @@
+/*
+    Copyright (c) 2015, Taiga Nomi
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include "tiny_dnn/layers/layer.h"
+#include "tiny_dnn/util/util.h"
+
+#include "tiny_dnn/core/kernels/global_avepool_grad_op.h"
+#include "tiny_dnn/core/kernels/global_avepool_op.h"
+
+namespace tiny_dnn {
+
+/**
+ * applies channel-wise global average pooling to spatial data.
+ **/
+class global_average_pooling_layer : public layer {
+ public:
+  using layer::parallelize_;
+
+  global_average_pooling_layer(const shape3d &in_shape,
+                               backend_t backend_type = core::default_engine())
+    : global_average_pooling_layer(
+        in_shape.width_, in_shape.height_, in_shape.depth_, backend_type) {}
+
+  /**
+   * @param in_width     [in] width of input image
+   * @param in_height    [in] height of input image
+   * @param in_channels  [in] the number of input image channels (depth)
+  **/
+  global_average_pooling_layer(serial_size_t in_width,
+                               serial_size_t in_height,
+                               serial_size_t in_channels,
+                               backend_t backend_type = core::default_engine())
+    : layer({vector_type::data}, {vector_type::data}) {
+    set_global_avepool_params(shape3d(in_width, in_height, in_channels),
+                              shape3d(in_channels, 1, 1));
+
+    init_backend(backend_type);
+    layer::set_backend_type(backend_type);
+  }
+
+  // move constructor
+  global_average_pooling_layer(global_average_pooling_layer &&other)  // NOLINT
+    : layer(std::move(other)), params_(std::move(other.params_)) {
+    init_backend(std::move(layer::engine()));
+  }
+
+  serial_size_t fan_in_size() const override {
+    return static_cast<serial_size_t>(params_.in.width_ * params_.in.height_);
+  }
+
+  serial_size_t fan_out_size() const override { return 1; }
+
+  void forward_propagation(const std::vector<tensor_t *> &in_data,
+                           std::vector<tensor_t *> &out_data) override {
+    auto ctx = OpKernelContext(in_data, out_data);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
+
+    kernel_fwd_->compute(ctx);
+  }
+
+  void back_propagation(const std::vector<tensor_t *> &in_data,
+                        const std::vector<tensor_t *> &out_data,
+                        std::vector<tensor_t *> &out_grad,
+                        std::vector<tensor_t *> &in_grad) override {
+    auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
+    ctx.setParallelize(layer::parallelize());
+    ctx.setEngine(layer::engine());
+
+    kernel_back_->compute(ctx);
+  }
+
+  std::vector<index3d<serial_size_t>> in_shape() const override {
+    return {params_.in};
+  }
+
+  std::vector<index3d<serial_size_t>> out_shape() const override {
+    return {params_.out};
+  }
+
+  std::string layer_type() const override {
+    return std::string("global-ave-pool");
+  }
+
+  std::pair<serial_size_t, serial_size_t> pool_size() const {
+    return std::make_pair(params_.in.width_, params_.in.height_);
+  }
+
+#ifndef CNN_NO_SERIALIZATION
+  friend struct serialization_buddy;
+#endif
+
+ private:
+  global_avepool_params params_;
+
+  /* Forward and backward ops */
+  std::shared_ptr<core::OpKernel> kernel_fwd_;
+  std::shared_ptr<core::OpKernel> kernel_back_;
+
+  void init_backend(backend_t backend_type) {
+    core::OpKernelConstruction ctx =
+      core::OpKernelConstruction(layer::device(), &params_);
+
+    if (backend_type == backend_t::internal ||
+        backend_type == backend_t::nnpack || backend_type == backend_t::avx) {
+      kernel_fwd_.reset(new GlobalAvePoolOp(ctx));
+      kernel_back_.reset(new GlobalAvePoolGradOp(ctx));
+      return;
+    } else {
+      throw nn_error("Not supported engine: " + to_string(backend_type));
+    }
+  }
+
+  void set_global_avepool_params(const shape3d &in, const shape3d &out) {
+    params_.in  = in;
+    params_.out = out;
+  }
+};
+
+}  // namespace tiny_dnn

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -45,7 +45,6 @@ class global_average_pooling_layer : public layer {
                               shape3d(in_channels, 1, 1));
 
     init_backend(backend_type);
-    layer::set_backend_type(backend_type);
   }
 
   // move constructor
@@ -96,9 +95,7 @@ class global_average_pooling_layer : public layer {
     return std::make_pair(params_.in.width_, params_.in.height_);
   }
 
-#ifndef CNN_NO_SERIALIZATION
   friend struct serialization_buddy;
-#endif
 
  private:
   global_avepool_params params_;
@@ -111,8 +108,8 @@ class global_average_pooling_layer : public layer {
     core::OpKernelConstruction ctx =
       core::OpKernelConstruction(layer::device(), &params_);
 
-    if (backend_type == backend_t::internal ||
-        backend_type == backend_t::nnpack || backend_type == backend_t::avx) {
+    layer::set_backend_type(backend_type);
+    if (backend_type == backend_t::internal) {
       kernel_fwd_.reset(new GlobalAvePoolOp(ctx));
       kernel_back_.reset(new GlobalAvePoolGradOp(ctx));
       return;

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -109,7 +109,8 @@ class global_average_pooling_layer : public layer {
       core::OpKernelConstruction(layer::device(), &params_);
 
     layer::set_backend_type(backend_type);
-    if (backend_type == backend_t::internal || backend_type == backend_t::avx || backend_type == backend_t::nnpack) {
+    if (backend_type == backend_t::internal || backend_type == backend_t::avx ||
+        backend_type == backend_t::nnpack) {
       kernel_fwd_.reset(new GlobalAvePoolOp(ctx));
       kernel_back_.reset(new GlobalAvePoolGradOp(ctx));
       return;

--- a/tiny_dnn/layers/layers.h
+++ b/tiny_dnn/layers/layers.h
@@ -15,6 +15,7 @@
 #include "tiny_dnn/layers/deconvolutional_layer.h"
 #include "tiny_dnn/layers/dropout_layer.h"
 #include "tiny_dnn/layers/fully_connected_layer.h"
+#include "tiny_dnn/layers/global_average_pooling_layer.h"
 #include "tiny_dnn/layers/layer.h"
 #include "tiny_dnn/layers/linear_layer.h"
 #include "tiny_dnn/layers/lrn_layer.h"

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -139,6 +139,19 @@ struct LoadAndConstruct<tiny_dnn::fully_connected_layer> {
   }
 };
 
+    template <>
+    struct LoadAndConstruct<tiny_dnn::global_average_pooling_layer> {
+        template <class Archive>
+        static void load_and_construct(
+                Archive &ar,
+                cereal::construct<tiny_dnn::global_average_pooling_layer> &construct) {
+          tiny_dnn::shape3d in_shape;
+
+          ar(cereal::make_nvp("in_shape", in_shape));
+          construct(in_shape);
+        }
+    };
+
 template <>
 struct LoadAndConstruct<tiny_dnn::linear_layer> {
   template <class Archive>
@@ -356,6 +369,11 @@ struct specialize<Archive,
                   tiny_dnn::fully_connected_layer,
                   cereal::specialization::non_member_serialize> {};
 
+    template <class Archive>
+    struct specialize<Archive,
+            tiny_dnn::global_average_pooling_layer,
+            cereal::specialization::non_member_serialize> {};
+
 template <class Archive>
 struct specialize<Archive,
                   tiny_dnn::linear_layer,
@@ -500,6 +518,14 @@ struct serialization_buddy {
        cereal::make_nvp("has_bias", params_.has_bias_));
   }
 
+        template <class Archive>
+        static inline void serialize(Archive &ar,
+                                     tiny_dnn::global_average_pooling_layer &layer) {
+          layer.serialize_prolog(ar);
+          auto &params_ = layer.params_;
+          ar(cereal::make_nvp("in_shape", params_.in));
+        }
+
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {
     layer.serialize_prolog(ar);
@@ -634,6 +660,11 @@ template <class Archive>
 void serialize(Archive &ar, tiny_dnn::fully_connected_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
+
+    template <class Archive>
+    void serialize(Archive &ar, tiny_dnn::global_average_pooling_layer &layer) {
+      serialization_buddy::serialize(ar, layer);
+    }
 
 template <class Archive>
 void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -139,18 +139,18 @@ struct LoadAndConstruct<tiny_dnn::fully_connected_layer> {
   }
 };
 
-    template <>
-    struct LoadAndConstruct<tiny_dnn::global_average_pooling_layer> {
-        template <class Archive>
-        static void load_and_construct(
-                Archive &ar,
-                cereal::construct<tiny_dnn::global_average_pooling_layer> &construct) {
-          tiny_dnn::shape3d in_shape;
+template <>
+struct LoadAndConstruct<tiny_dnn::global_average_pooling_layer> {
+  template <class Archive>
+  static void load_and_construct(
+    Archive &ar,
+    cereal::construct<tiny_dnn::global_average_pooling_layer> &construct) {
+    tiny_dnn::shape3d in_shape;
 
-          ar(cereal::make_nvp("in_shape", in_shape));
-          construct(in_shape);
-        }
-    };
+    ar(cereal::make_nvp("in_shape", in_shape));
+    construct(in_shape);
+  }
+};
 
 template <>
 struct LoadAndConstruct<tiny_dnn::linear_layer> {
@@ -369,10 +369,10 @@ struct specialize<Archive,
                   tiny_dnn::fully_connected_layer,
                   cereal::specialization::non_member_serialize> {};
 
-    template <class Archive>
-    struct specialize<Archive,
-            tiny_dnn::global_average_pooling_layer,
-            cereal::specialization::non_member_serialize> {};
+template <class Archive>
+struct specialize<Archive,
+                  tiny_dnn::global_average_pooling_layer,
+                  cereal::specialization::non_member_serialize> {};
 
 template <class Archive>
 struct specialize<Archive,
@@ -518,13 +518,13 @@ struct serialization_buddy {
        cereal::make_nvp("has_bias", params_.has_bias_));
   }
 
-        template <class Archive>
-        static inline void serialize(Archive &ar,
-                                     tiny_dnn::global_average_pooling_layer &layer) {
-          layer.serialize_prolog(ar);
-          auto &params_ = layer.params_;
-          ar(cereal::make_nvp("in_shape", params_.in));
-        }
+  template <class Archive>
+  static inline void serialize(Archive &ar,
+                               tiny_dnn::global_average_pooling_layer &layer) {
+    layer.serialize_prolog(ar);
+    auto &params_ = layer.params_;
+    ar(cereal::make_nvp("in_shape", params_.in));
+  }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {
@@ -661,10 +661,10 @@ void serialize(Archive &ar, tiny_dnn::fully_connected_layer &layer) {
   serialization_buddy::serialize(ar, layer);
 }
 
-    template <class Archive>
-    void serialize(Archive &ar, tiny_dnn::global_average_pooling_layer &layer) {
-      serialization_buddy::serialize(ar, layer);
-    }
+template <class Archive>
+void serialize(Archive &ar, tiny_dnn::global_average_pooling_layer &layer) {
+  serialization_buddy::serialize(ar, layer);
+}
 
 template <class Archive>
 void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -13,7 +13,8 @@ void register_layers(T* h) {
   h->template register_layer<convolutional_layer>("conv");
   h->template register_layer<dropout_layer>("dropout");
   h->template register_layer<fully_connected_layer>("fully_connected");
-  h->template register_layer<global_average_pooling_layer>("global_average_pooling");
+  h->template register_layer<global_average_pooling_layer>(
+    "global_average_pooling");
   h->template register_layer<linear_layer>("linear");
   h->template register_layer<lrn_layer>("lrn");
   h->template register_layer<max_pooling_layer>("maxpool");

--- a/tiny_dnn/util/serialization_layer_list.h
+++ b/tiny_dnn/util/serialization_layer_list.h
@@ -13,6 +13,7 @@ void register_layers(T* h) {
   h->template register_layer<convolutional_layer>("conv");
   h->template register_layer<dropout_layer>("dropout");
   h->template register_layer<fully_connected_layer>("fully_connected");
+  h->template register_layer<global_average_pooling_layer>("global_average_pooling");
   h->template register_layer<linear_layer>("linear");
   h->template register_layer<lrn_layer>("lrn");
   h->template register_layer<max_pooling_layer>("maxpool");


### PR DESCRIPTION
Global Average Pooling layer was introduced in the paper "Network in Network" (2013). It is an alternative to keeping fully connected layers at the end of a deep convolutional neural network.

Global Average Pooling layer has been used in recent architectures such as Inception Network, ResNet and Xception Network. It performs channel wise pooling and hence a layer with `c` channels will produce an output of `c` units, which is usually followed by softmax, giving classification scores.

#### Figure:
![image](https://cloud.githubusercontent.com/assets/10494087/25570669/ebeea8a8-2e44-11e7-834c-c3dd0d99019b.png)

#### Content in this PR:

- [x] Add forward and backward op kernels for internal backend.
- [x] Add a class for global average pooling params.
- [x] Layer class implementation ( `class global_average_pooling_layer : public layer` ).
- [x] Relevant tests.
- [x] Serialization helpers and their tests.

#### References:

1. **"Network In Network"** by Min Lin, Qiang Chen, Shuicheng Yan, 2013. ( [arXiv:1312.4400v3 cs.NE](https://arxiv.org/abs/1312.4400v3) ) 
2. **"Going Deeper with Convolutions"** by Szegedy et. al., 2014. ( [arXiv:1409.4842 cs.CV](https://arxiv.org/abs/1409.4842) ).
