### PR TITLE
Remove warnings associated with parallel_for

### DIFF
--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -85,7 +85,7 @@ class activation_layer : public layer {
     const tensor_t &x  = *in_data[0];
     const tensor_t &y  = *out_data[0];
     for_i(x.size(),
-          [&](int i) { backward_activation(x[i], y[i], dx[i], dy[i]); });
+          [&](size_t i) { backward_activation(x[i], y[i], dx[i], dy[i]); });
   }
 
   virtual std::string layer_type() const = 0;

--- a/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op_avx.h
@@ -876,7 +876,7 @@ void avx_conv2d_5x5_back_kernel(
   std::vector<std::vector<float, Allocator>> &db,
   std::vector<std::vector<float, Allocator>> &curr_delta,
   std::vector<std::vector<float, Allocator>> &prev_delta) {
-  for_i(prev_out.size(), [&](int sample) {
+  for_i(prev_out.size(), [&](size_t sample) {
     avx_conv2d_5x5_back_kernel_one(params, prev_out[sample], W, dW[sample],
                                    db[sample], curr_delta[sample],
                                    &prev_delta[sample]);

--- a/tiny_dnn/core/kernels/conv2d_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_op_avx.h
@@ -457,7 +457,7 @@ inline void conv2d_op_avx(const tensor_t &in_data,
 #ifdef CNN_USE_AVX
   if (params.weight.height_ == 5 && params.weight.width_ == 5) {
     // @todo consider better parallelization
-    for_i(layer_parallelize, in_data.size(), [&](int i) {
+    for_i(layer_parallelize, in_data.size(), [&](size_t i) {
       avx_conv2d_5x5_kernel(params, in_data[i], W, bias, out_data[i],
                             layer_parallelize);
     });

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -88,9 +88,7 @@ class max_unpooling_layer : public layer {
       for_(parallelize_, 0, in2out_.size(), [&](const blocked_range &r) {
         for (size_t i = r.begin(); i < r.end(); i++) {
           const auto &in_index = out2in_[i];
-          out_vec[i]           = (static_cast<int>(max_idx[in_index]) == i)
-                         ? in_vec[in_index]
-                         : float_t{0};
+          out_vec[i] = (max_idx[in_index] == i) ? in_vec[in_index] : float_t{0};
         }
       });
     }
@@ -112,9 +110,8 @@ class max_unpooling_layer : public layer {
       for_(parallelize_, 0, in2out_.size(), [&](const blocked_range &r) {
         for (size_t i = r.begin(); i != r.end(); i++) {
           serial_size_t outi = out2in_[i];
-          prev_delta_vec[i]  = (static_cast<int>(max_idx[outi]) == i)
-                                ? curr_delta_vec[outi]
-                                : float_t{0};
+          prev_delta_vec[i] =
+            (max_idx[outi] == i) ? curr_delta_vec[outi] : float_t{0};
         }
       });
     }


### PR DESCRIPTION
Hi, this PR removes warnings associated with `parallel_for` function change.

#679 is related.

I checked the warnings with this compiler.
`g++ (Ubuntu 5.4.0-6ubuntu1~16.04.4) 5.4.0 20160609`.
And I see different warnings with CI services job logs, not sure why they don't appear with my computer...
Maybe I should try to fix all the warnings I can find with this PR?