### PR TITLE
Fix random test failures

### DIFF
--- a/tiny_dnn/core/kernels/conv2d_op_avx.h
+++ b/tiny_dnn/core/kernels/conv2d_op_avx.h
@@ -211,7 +211,7 @@ void avx_conv2d_5x5_kernel(const core::conv_params &params,
                 i1          = _mm256_loadu_ps(pi1 + x);
                 i2          = _mm256_loadu_ps(pi2 + x);
                 i3          = _mm256_loadu_ps(pi3 + x);
-                i4          = _mm256_loadu_ps(pi4 + x);
+                i4          = _mm256_maskload_ps(pi4 + x, imask);
                 __m256 sum0 = _mm256_mul_ps(w0a, i0);
                 __m256 sum1 = _mm256_mul_ps(w1a, i1);
                 sum0        = madd256_ps(w2a, i2, sum0);
@@ -234,7 +234,7 @@ void avx_conv2d_5x5_kernel(const core::conv_params &params,
                 __m256 i1   = _mm256_loadu_ps(pi1 + x);
                 __m256 i2   = _mm256_loadu_ps(pi2 + x);
                 __m256 i3   = _mm256_loadu_ps(pi3 + x);
-                __m256 i4   = _mm256_loadu_ps(pi4 + x);
+                __m256 i4   = _mm256_maskload_ps(pi4 + x, imask);
                 __m256 sum0 = _mm256_mul_ps(w0a, i0);
                 __m256 sum1 = _mm256_mul_ps(w1a, i1);
                 sum0        = madd256_ps(w2a, i2, sum0);
@@ -258,7 +258,7 @@ void avx_conv2d_5x5_kernel(const core::conv_params &params,
               __m256 i1   = _mm256_loadu_ps(pi1);
               __m256 i2   = _mm256_loadu_ps(pi2);
               __m256 i3   = _mm256_loadu_ps(pi3);
-              __m256 i4   = _mm256_loadu_ps(pi4);
+              __m256 i4   = _mm256_maskload_ps(pi4, imask);
               __m256 sum0 = _mm256_mul_ps(w0a, i0);
               __m256 sum1 = _mm256_mul_ps(w1a, i1);
               sum0        = madd256_ps(w2a, i2, sum0);


### PR DESCRIPTION
Hi, this PR fixes random test failures. #689 is related.
I suspect a buffer over-read was the source of the problem.
Checked with `./tiny_dnn_test --gtest_filter=convolutional*` command that the random failures don't occur with the changes in this PR.