### PR TITLE
Removed redundant clang-check and coveralls from travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -97,12 +97,12 @@ before_script:
 script:
   - make -j2
   - test/tiny_dnn_test
-  - if [ "$TRAVIS_OS_NAME" == "linux" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ] && [ "$USE_SSE" == "ON" ] && [ "$USE_AVX" == "ON" ] && [ "$USE_DOUBLE" == "ON" ]; then
       make clang-format-check;
     fi
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ] && [ "$USE_SSE" == "ON" ] && [ "$USE_AVX" == "ON" ] && [ "$USE_DOUBLE" == "ON" ]; then
       lcov --directory . --capture --output-file coverage.info;
       lcov --remove coverage.info 'test/*' 'third_party/*' 'cereal/*' '/usr/*' 'tiny_dnn/io/caffe/caffe.pb.*' --output-file coverage.info;
       lcov --list coverage.info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -102,7 +102,7 @@ script:
     fi
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ] && [ "$USE_SSE" == "ON" ] && [ "$USE_AVX" == "ON" ] && [ "$USE_DOUBLE" == "ON" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ]; then
       lcov --directory . --capture --output-file coverage.info;
       lcov --remove coverage.info 'test/*' 'third_party/*' 'cereal/*' '/usr/*' 'tiny_dnn/io/caffe/caffe.pb.*' --output-file coverage.info;
       lcov --list coverage.info;


### PR DESCRIPTION
Calculating coveralls was taking around 10s-20s for each run.
So doing it only once is a better option.

Same goes for clang-check.

Now these both would be done only once.

Results:
#699 (the latest commit) took 29 minutes to run
this takes less than 20 minutes (I ran travis on my repo) ([here](https://travis-ci.org/nishnik/tiny-dnn/builds/231088931) and [here](https://travis-ci.org/nishnik/tiny-dnn/builds/231094418))