### PR TITLE
Add protected layer::for_i method that uses layer_::parallelize_ member

### DIFF
--- a/examples/mnist/test.cpp
+++ b/examples/mnist/test.cpp
@@ -72,7 +72,7 @@ void recognize(const std::string &dictionary, const std::string &src_filename) {
 
 int main(int argc, char **argv) {
   if (argc != 2) {
-    cout << "please specify image file";
+    cout << "please specify image file" << std::endl;
     return 0;
   }
   recognize("LeNet-model", argv[1]);

--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -121,4 +121,5 @@ class activation_layer : public layer {
  private:
   shape3d in_shape_;
 };
+
 }  // namespace tiny_dnn

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -28,8 +28,7 @@ inline void tiny_average_pooling_kernel(
   const shape3d &out_dim,
   float_t scale_factor,
   std::vector<typename partial_connected_layer::wi_connections> &out2wi) {
-  CNN_UNREFERENCED_PARAMETER(parallelize);
-  for_i(in_data[0]->size(), [&](size_t sample) {
+  for_i(parallelize, in_data[0]->size(), [&](size_t sample) {
     const vec_t &in = (*in_data[0])[sample];
     const vec_t &W  = (*in_data[1])[0];
     const vec_t &b  = (*in_data[2])[0];
@@ -56,6 +55,7 @@ inline void tiny_average_pooling_kernel(
 
 // back_propagation
 inline void tiny_average_pooling_back_kernel(
+  bool parallelize,
   const std::vector<tensor_t *> &in_data,
   const std::vector<tensor_t *> &out_data,
   std::vector<tensor_t *> &out_grad,
@@ -66,7 +66,7 @@ inline void tiny_average_pooling_back_kernel(
   std::vector<typename partial_connected_layer::wo_connections> &in2wo,
   std::vector<std::vector<serial_size_t>> &bias2out) {
   CNN_UNREFERENCED_PARAMETER(out_data);
-  for_i(in_data[0]->size(), [&](size_t sample) {
+  for_i(parallelize, in_data[0]->size(), [&](size_t sample) {
     const vec_t &prev_out = (*in_data[0])[sample];
     const vec_t &W        = (*in_data[1])[0];
     vec_t &dW             = (*in_grad[1])[sample];
@@ -110,7 +110,6 @@ inline void tiny_average_pooling_back_kernel(
 class average_pooling_layer : public partial_connected_layer {
  public:
   using Base = partial_connected_layer;
-  using layer::parallelize_;
 
   /**
    * @param in_width     [in] width of input image
@@ -220,9 +219,9 @@ class average_pooling_layer : public partial_connected_layer {
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    tiny_average_pooling_back_kernel(in_data, out_data, out_grad, in_grad, in_,
-                                     Base::scale_factor_, Base::weight2io_,
-                                     Base::in2wo_, Base::bias2out_);
+    tiny_average_pooling_back_kernel(
+      parallelize_, in_data, out_data, out_grad, in_grad, in_,
+      Base::scale_factor_, Base::weight2io_, Base::in2wo_, Base::bias2out_);
   }
 
   std::pair<serial_size_t, serial_size_t> pool_size() const {

--- a/tiny_dnn/layers/batch_normalization_layer.h
+++ b/tiny_dnn/layers/batch_normalization_layer.h
@@ -143,7 +143,7 @@ class batch_normalization_layer : public layer {
     // y = (x - mean) ./ sqrt(variance + eps)
     calc_stddev(variance);
 
-    for_i(parallelize_, in_data[0]->size(), [&](int i) {
+    for_i(in_data[0]->size(), [&](int i) {
       const float_t *inptr = &in[i][0];
       float_t *outptr      = &out[i][0];
 

--- a/tiny_dnn/layers/concat_layer.h
+++ b/tiny_dnn/layers/concat_layer.h
@@ -65,7 +65,7 @@ class concat_layer : public layer {
     serial_size_t num_samples =
       static_cast<serial_size_t>((*out_data[0]).size());
 
-    for (serial_size_t s = 0; s < num_samples; s++) {
+    for_i(num_samples, [&](size_t s) {
       float_t *outs = &(*out_data[0])[s][0];
 
       for (serial_size_t i = 0; i < in_shapes_.size(); i++) {
@@ -73,7 +73,7 @@ class concat_layer : public layer {
         serial_size_t dim  = in_shapes_[i].size();
         outs               = std::copy(ins, ins + dim, outs);
       }
-    }
+    });
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -85,7 +85,7 @@ class concat_layer : public layer {
 
     size_t num_samples = (*out_grad[0]).size();
 
-    for (size_t s = 0; s < num_samples; s++) {
+    for_i(num_samples, [&](size_t s) {
       const float_t *outs = &(*out_grad[0])[s][0];
 
       for (serial_size_t i = 0; i < in_shapes_.size(); i++) {
@@ -94,7 +94,7 @@ class concat_layer : public layer {
         std::copy(outs, outs + dim, ins);
         outs += dim;
       }
-    }
+    });
   }
 
   friend struct serialization_buddy;

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -33,8 +33,6 @@ namespace tiny_dnn {
  **/
 class convolutional_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
   * constructing convolutional layer
   *

--- a/tiny_dnn/layers/deconvolutional_layer.h
+++ b/tiny_dnn/layers/deconvolutional_layer.h
@@ -33,8 +33,6 @@ namespace tiny_dnn {
  **/
 class deconvolutional_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
   * constructing deconvolutional layer
   *

--- a/tiny_dnn/layers/dropout_layer.h
+++ b/tiny_dnn/layers/dropout_layer.h
@@ -74,14 +74,14 @@ class dropout_layer : public layer {
     CNN_UNREFERENCED_PARAMETER(in_data);
     CNN_UNREFERENCED_PARAMETER(out_data);
 
-    for (size_t sample = 0; sample < prev_delta.size(); ++sample) {
+    for_i(prev_delta.size(), [&](size_t sample) {
       // assert(prev_delta[sample].size() == curr_delta[sample].size());
       // assert(mask_[sample].size() == prev_delta[sample].size());
       size_t sz = prev_delta[sample].size();
       for (size_t i = 0; i < sz; ++i) {
         prev_delta[sample][i] = mask_[sample][i] * curr_delta[sample][i];
       }
-    }
+    });
   }
 
   void forward_propagation(const std::vector<tensor_t *> &in_data,
@@ -95,7 +95,7 @@ class dropout_layer : public layer {
       mask_.resize(sample_count, mask_[0]);
     }
 
-    for (size_t sample = 0; sample < sample_count; ++sample) {
+    for_i(sample_count, [&](size_t sample) {
       std::vector<uint8_t> &mask = mask_[sample];
 
       const vec_t &in_vec = in[sample];
@@ -111,7 +111,7 @@ class dropout_layer : public layer {
         for (size_t i = 0, end = in_vec.size(); i < end; i++)
           out_vec[i] = in_vec[i];
       }
-    }
+    });
   }
 
   /**

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -18,8 +18,6 @@ namespace tiny_dnn {
  **/
 class fully_connected_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
    * @param in_dim [in] number of elements of the input
    * @param out_dim [in] number of elements of the output

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -24,8 +24,6 @@ namespace tiny_dnn {
  **/
 class global_average_pooling_layer : public layer {
  public:
-  using layer::parallelize_;
-
   global_average_pooling_layer(const shape3d &in_shape,
                                backend_t backend_type = core::default_engine())
     : global_average_pooling_layer(

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -20,6 +20,7 @@
 #include "tiny_dnn/core/framework/device.fwd.h"
 #include "tiny_dnn/node.h"
 
+#include "tiny_dnn/util/parallel_for.h"
 #include "tiny_dnn/util/product.h"
 #include "tiny_dnn/util/util.h"
 #include "tiny_dnn/util/weight_init.h"
@@ -709,6 +710,11 @@ class layer : public node {
    * frequent
    * memory allocation */
   vec_t weights_diff_;
+
+  template <typename T, typename Func>
+  inline void for_i(T size, Func f, size_t grainsize = 100) {
+    tiny_dnn::for_i(parallelize_, size, f, grainsize);
+  }
 
  private:
   /** Flag indicating whether the layer/node parameters are trainable */

--- a/tiny_dnn/layers/linear_layer.h
+++ b/tiny_dnn/layers/linear_layer.h
@@ -18,8 +18,6 @@ namespace tiny_dnn {
  */
 class linear_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
    * @param dim   [in] number of elements
    * @param scale [in] factor by which to multiply
@@ -52,7 +50,7 @@ class linear_layer : public layer {
     CNN_UNREFERENCED_PARAMETER(out);
 
     // @todo revise the parallelism strategy
-    for_i(parallelize_, dim_, [&](int i) {
+    for_i(dim_, [&](size_t i) {
       for (serial_size_t sample       = 0,
                          sample_count = static_cast<serial_size_t>(in.size());
            sample < sample_count; ++sample)
@@ -72,7 +70,7 @@ class linear_layer : public layer {
     // @todo revise parallelism strategy
     for (serial_size_t sample = 0;
          sample < static_cast<serial_size_t>(prev_delta.size()); ++sample) {
-      for_i(parallelize_, dim_, [&](int i) {
+      for_i(dim_, [&](size_t i) {
         prev_delta[sample][i] = curr_delta[sample][i] * scale_;
       });
     }

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -20,8 +20,6 @@ enum class norm_region { across_channels, within_channels };
  */
 class lrn_layer : public layer {
  public:
-  using layer::parallelize_;
-
   lrn_layer(const shape3d &in_shape,
             serial_size_t local_size,
             float_t alpha      = 1.0,

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -27,8 +27,6 @@ namespace tiny_dnn {
  **/
 class max_pooling_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image

--- a/tiny_dnn/layers/max_unpooling_layer.h
+++ b/tiny_dnn/layers/max_unpooling_layer.h
@@ -19,8 +19,6 @@ namespace tiny_dnn {
  **/
 class max_unpooling_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image
@@ -85,11 +83,9 @@ class max_unpooling_layer : public layer {
 
       std::vector<serial_size_t> &max_idx = worker_storage_.in2outmax_;
 
-      for_(parallelize_, 0, in2out_.size(), [&](const blocked_range &r) {
-        for (size_t i = r.begin(); i < r.end(); i++) {
-          const auto &in_index = out2in_[i];
-          out_vec[i] = (max_idx[in_index] == i) ? in_vec[in_index] : float_t{0};
-        }
+      for_i(in2out_.size(), [&](size_t i) {
+        const auto &in_index = out2in_[i];
+        out_vec[i] = (max_idx[in_index] == i) ? in_vec[in_index] : float_t{0};
       });
     }
   }

--- a/tiny_dnn/layers/quantized_convolutional_layer.h
+++ b/tiny_dnn/layers/quantized_convolutional_layer.h
@@ -33,8 +33,6 @@ namespace tiny_dnn {
  **/
 class quantized_convolutional_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
   * constructing convolutional layer
   *

--- a/tiny_dnn/layers/quantized_deconvolutional_layer.h
+++ b/tiny_dnn/layers/quantized_deconvolutional_layer.h
@@ -33,8 +33,6 @@ namespace tiny_dnn {
  **/
 class quantized_deconvolutional_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
   * constructing deconvolutional layer
   *

--- a/tiny_dnn/layers/quantized_fully_connected_layer.h
+++ b/tiny_dnn/layers/quantized_fully_connected_layer.h
@@ -17,8 +17,6 @@ namespace tiny_dnn {
  **/
 class quantized_fully_connected_layer : public layer {
  public:
-  using layer::parallelize_;
-
   /**
    * @param in_dim [in] number of elements of the input
    * @param out_dim [in] number of elements of the output

--- a/tiny_dnn/util/parallel_for.h
+++ b/tiny_dnn/util/parallel_for.h
@@ -201,22 +201,27 @@ inline void for_(
 }
 
 template <typename T, typename Func>
-void for_i(bool parallelize, T size, Func f, size_t grainsize = 100) {
+inline void for_i(bool parallelize, T size, Func f, size_t grainsize = 100) {
 #ifdef CNN_SINGLE_THREAD
-  parallelize = false;
-#endif
+  for (size_t i = 0; i < size; ++i) {
+    f(i);
+  }
+#else  // #ifdef CNN_SINGLE_THREAD
   for_(parallelize, 0, size,
        [&](const blocked_range &r) {
 #ifdef CNN_USE_OMP
 #pragma omp parallel for
 #endif
-         for (size_t i = r.begin(); i < r.end(); i++) f(i);
+         for (size_t i = r.begin(); i < r.end(); i++) {
+           f(i);
+         }
        },
        grainsize);
+#endif  // #ifdef CNN_SINGLE_THREAD
 }
 
 template <typename T, typename Func>
-void for_i(T size, Func f, size_t grainsize = 100) {
+inline void for_i(T size, Func f, size_t grainsize = 100) {
   for_i(true, size, f, grainsize);
 }
 


### PR DESCRIPTION
Hi, this PR adds protected `layer::for_i` method that uses `layer_::parallelize_` member.
The method calls `for_i` function defined in `tiny_dnn/util/parallel_for.h` file.
The benefit of the method is it automatically uses `layer_::parallelize_` member as a first parameter of `for_i` function.

This PR also adds other changes such as
- Add a missing new line character in the error message of `example_mnist_test` program.
- Remove using-declarations that introduce `layer::parallelize_` member into derived class public scope. (I concluded they aren't necessary but please correct me if I'm wrong about this)

I briefly checked if there's any performance improvement with the changes, and it seems very little.
Though, I didn't check the effect of all the changes. So there can be negative effects in some cases.

#714 is somehow related.