### PR TITLE
Reduce frequent memory allocation

### DIFF
--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -100,7 +100,9 @@ TEST(ave_pool, forward) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -128,7 +130,9 @@ TEST(ave_pool, forward_stride) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);

--- a/test/test_batch_norm_layer.h
+++ b/test/test_batch_norm_layer.h
@@ -13,9 +13,9 @@
 namespace tiny_dnn {
 
 TEST(batchnorm, gradient_check) {
-  int num         = 4;
-  int spatial_dim = 4;
-  int channels    = 2;
+  size_t num         = 4;
+  size_t spatial_dim = 4;
+  size_t channels    = 2;
   batch_normalization_layer bn(spatial_dim, channels);
 
   /* following values are extracted from caffe
@@ -137,9 +137,9 @@ TEST(batchnorm, gradient_check) {
   tensor_t outd, ing, outg;
   std::vector<tensor_t *> in_data, out_data, in_grad, out_grad;
 
-  for (int i = 0; i < num; i++) {
-    int first = i * spatial_dim * channels;
-    int last  = first + spatial_dim * channels;
+  for (size_t i = 0; i < num; i++) {
+    size_t first = i * spatial_dim * channels;
+    size_t last  = first + spatial_dim * channels;
 
     ing.push_back(vec_t(spatial_dim * channels));
     outg.push_back(vec_t(top_diff + first, top_diff + last));
@@ -153,8 +153,8 @@ TEST(batchnorm, gradient_check) {
   bn.set_stddev(vec_t(stddev, stddev + 2));
   bn.back_propagation(in_data, out_data, out_grad, in_grad);
 
-  for (int i = 0; i < num; i++) {
-    for (int j = 0; j < spatial_dim * channels; j++) {
+  for (size_t i = 0; i < num; i++) {
+    for (size_t j = 0; j < spatial_dim * channels; j++) {
       EXPECT_NEAR(expected_gradients[i * spatial_dim * channels + j],
                   (*in_grad[0])[i][j], 1e-4);
     }
@@ -198,11 +198,12 @@ TEST(batchnorm, forward) {
     };
 
   // clang-format on
-  auto result = bn.forward({in});
+  std::vector<const tensor_t *> result;
+  bn.forward({in}, result);
 
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 3 * 4; j++) {
-      EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
+      EXPECT_NEAR(expect[i][j], (*result[0])[i][j], 1e-3);
     }
   }
 
@@ -210,10 +211,10 @@ TEST(batchnorm, forward) {
 
   // confirming that calculating the moving average doesn't affect the result
   // while we feed the same data
-  result = bn.forward({in});
+  bn.forward({in}, result);
   for (size_t i = 0; i < 2; i++) {
     for (size_t j = 0; j < 3 * 4; j++) {
-      EXPECT_NEAR(expect[i][j], result[0][i][j], 1e-3);
+      EXPECT_NEAR(expect[i][j], (*result[0])[i][j], 1e-3);
     }
   }
 }

--- a/test/test_concat_layer.h
+++ b/test/test_concat_layer.h
@@ -50,21 +50,26 @@ TEST(concat, forward_data) {
 
   // clang-format on
 
-  auto out = cl.forward({in0, in1, in2});
+  {
+    std::vector<const tensor_t*> out;
+    cl.forward({in0, in1, in2}, out);
 
-  for (serial_size_t i = 0; i < 4; i++) {
-    for (serial_size_t j = 0; j < 2; j++) {
-      EXPECT_FLOAT_EQ(out_expected[i][j], out[0][i][j]);
+    for (serial_size_t i = 0; i < 4; i++) {
+      for (serial_size_t j = 0; j < 2; j++) {
+        EXPECT_FLOAT_EQ(out_expected[i][j], (*out[0])[i][j]);
+      }
     }
   }
 
-  out = cl.backward({out_expected});
+  {
+    auto out = cl.backward({out_expected});
 
-  for (serial_size_t i = 0; i < 4; i++) {
-    for (serial_size_t j = 0; j < 2; j++) {
-      EXPECT_FLOAT_EQ(in0[i][j], out[0][i][j]);
-      EXPECT_FLOAT_EQ(in1[i][j], out[1][i][j]);
-      EXPECT_FLOAT_EQ(in2[i][j], out[2][i][j]);
+    for (serial_size_t i = 0; i < 4; i++) {
+      for (serial_size_t j = 0; j < 2; j++) {
+        EXPECT_FLOAT_EQ(in0[i][j], out[0][i][j]);
+        EXPECT_FLOAT_EQ(in1[i][j], out[1][i][j]);
+        EXPECT_FLOAT_EQ(in2[i][j], out[2][i][j]);
+      }
     }
   }
 }

--- a/test/test_dropout_layer.h
+++ b/test/test_dropout_layer.h
@@ -22,10 +22,11 @@ TEST(dropout, randomized) {
   dropout_layer l(num_units, dropout_rate, net_phase::train);
   vec_t v(num_units, 1.0);
 
-  l.forward({{v}});
+  std::vector<const tensor_t*> out;
+  l.forward({{v}}, out);
   const auto mask1 = l.get_mask(0);
 
-  l.forward({{v}});
+  l.forward({{v}}, out);
   const auto mask2 = l.get_mask(0);
 
   // mask should change for each fprop

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -161,8 +161,10 @@ TEST(fully_connected, forward) {
   l.weight_init(weight_init::constant(1.0));
   l.bias_init(weight_init::constant(0.5));
 
-  vec_t in           = {0, 1, 2, 3};
-  vec_t out          = l.forward({{in}})[0][0];
+  vec_t in = {0, 1, 2, 3};
+  std::vector<const tensor_t *> o;
+  l.forward({{in}}, o);
+  vec_t out          = (*o[0])[0];
   vec_t out_expected = {6.5, 6.5};  // 0+1+2+3+0.5
 
   for (size_t i = 0; i < out_expected.size(); i++) {
@@ -195,8 +197,10 @@ TEST(fully_connected, forward_nobias) {
 
   l.weight_init(weight_init::constant(1.0));
 
-  vec_t in           = {0, 1, 2, 3};
-  vec_t out          = l.forward({{in}})[0][0];
+  vec_t in = {0, 1, 2, 3};
+  std::vector<const tensor_t *> o;
+  l.forward({{in}}, o);
+  vec_t out          = (*o[0])[0];
   vec_t out_expected = {6.0, 6.0};  // 0+1+2+3
 
   for (size_t i = 0; i < out_expected.size(); i++) {

--- a/test/test_global_average_pooling_layer.h
+++ b/test/test_global_average_pooling_layer.h
@@ -36,7 +36,9 @@ TEST(global_ave_pool, forward) {
   // clang-format on
 
   vec_t expected = {2.25};
-  vec_t res      = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   EXPECT_FLOAT_EQ(expected[0], res[0]);
 }
@@ -72,7 +74,9 @@ TEST(global_ave_pool, forward_multichannel) {
 
   vec_t expected = {1.5, 6.5, 2.5};
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -94,8 +98,8 @@ TEST(global_ave_pool, backward) {
                             1, 1, 1, 1,
                             1, 1, 1, 1};
   // clang-format on
-
-  l.forward({{in}})[0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
   vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
 
   for (size_t i = 0; i < in_grad.size(); i++) {
@@ -118,8 +122,8 @@ TEST(global_ave_pool, backward_multichannel) {
                                   2, 2, 3, 3,
                                         3, 3};
   // clang-format on
-
-  l.forward({{in}})[0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
   vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
 
   for (size_t i = 0; i < in_grad.size(); i++) {

--- a/test/test_lrn_layer.h
+++ b/test/test_lrn_layer.h
@@ -23,8 +23,9 @@ TEST(lrn, cross) {
     2.0f / 400.0f,        //  2.0 / (1+0.5*(3*3+2*2+5*5))^2
     5.0f / 15.5f / 15.5f  // 5.0 / (1+0.5*(2*2+5*5))^2
   };
-
-  auto out = lrn.forward({{vec_t(in, in + 4)}})[0][0];
+  std::vector<const tensor_t*> o;
+  lrn.forward({{vec_t(in, in + 4)}}, o);
+  auto out = (*o[0])[0];
 
   EXPECT_NEAR(expected[0], out[0], epsilon<float_t>());
   EXPECT_NEAR(expected[1], out[1], epsilon<float_t>());

--- a/test/test_max_pooling_layer.h
+++ b/test/test_max_pooling_layer.h
@@ -31,7 +31,9 @@ TEST(max_pool, forward) {
 
   vec_t expected = {8, 6, 4, 2};
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -80,7 +82,9 @@ TEST(max_pool, forward_stride_internal) {
     };
   // clang-format on
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -107,7 +111,9 @@ TEST(max_pool, forward_padding_same) {
     };
   // clang-format on
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -135,7 +141,9 @@ TEST(max_pool, forward_stride_x) {
   EXPECT_EQ(l.out_shape()[0].width_, static_cast<serial_size_t>(2));
   EXPECT_EQ(l.out_shape()[0].height_, static_cast<serial_size_t>(4));
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -161,7 +169,9 @@ TEST(max_pool, forward_stride_y) {
   EXPECT_EQ(l.out_shape()[0].width_, static_cast<serial_size_t>(4));
   EXPECT_EQ(l.out_shape()[0].height_, static_cast<serial_size_t>(2));
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -236,7 +246,9 @@ TEST(max_pool, forward_stride) {
     };
   // clang-format on
 
-  vec_t res = l.forward({{in}})[0][0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
+  vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
     EXPECT_FLOAT_EQ(expected[i], res[i]);
@@ -266,7 +278,8 @@ TEST(max_pool, backward) {
     };
   // clang-format on
 
-  l.forward({{in}})[0];
+  std::vector<const tensor_t*> out;
+  l.forward({{in}}, out);
   vec_t in_grad = l.backward(std::vector<tensor_t>{{out_grad}})[0][0];
 
   for (size_t i = 0; i < in_grad.size(); i++) {
@@ -294,8 +307,11 @@ TEST(max_pool, serialization) {
     };
   // clang-format on
 
-  vec_t res1 = src.forward({{in}})[0][0];
-  vec_t res2 = dst->forward({{in}})[0][0];
+  std::vector<const tensor_t*> out1, out2;
+  src.forward({{in}}, out1);
+  dst->forward({{in}}, out2);
+  vec_t res1 = (*out1[0])[0];
+  vec_t res2 = (*out2[0])[0];
 
   for (size_t i = 0; i < res1.size(); i++) {
     EXPECT_FLOAT_EQ(res1[i], res2[i]);
@@ -321,8 +337,11 @@ TEST(max_pool, serialization_stride) {
     };
   // clang-format on
 
-  vec_t res1 = src.forward({{in}})[0][0];
-  vec_t res2 = dst->forward({{in}})[0][0];
+  std::vector<const tensor_t*> out1, out2;
+  src.forward({{in}}, out1);
+  dst->forward({{in}}, out2);
+  vec_t res1 = (*out1[0])[0];
+  vec_t res2 = (*out2[0])[0];
 
   for (size_t i = 0; i < res1.size(); i++) {
     EXPECT_FLOAT_EQ(res1[i], res2[i]);
@@ -348,8 +367,11 @@ TEST(max_pool, serialization_padding) {
     };
   // clang-format on
 
-  vec_t res1 = src.forward({{in}})[0][0];
-  vec_t res2 = dst->forward({{in}})[0][0];
+  std::vector<const tensor_t*> out1, out2;
+  src.forward({{in}}, out1);
+  dst->forward({{in}}, out2);
+  vec_t res1 = (*out1[0])[0];
+  vec_t res2 = (*out2[0])[0];
 
   for (size_t i = 0; i < res1.size(); i++) {
     EXPECT_FLOAT_EQ(res1[i], res2[i]);

--- a/test/test_power_layer.h
+++ b/test/test_power_layer.h
@@ -26,11 +26,12 @@ TEST(power, forward) {
                            {5 * 5 * 1.5, 4 * 4 * 1.5, 3 * 3 * 1.5, 2 * 2 * 1.5,
                             1 * 1 * 1.5, 0 * 0 * 1.5}};
 
-  auto out = pw.forward({in});
+  std::vector<const tensor_t*> out;
+  pw.forward({in}, out);
 
   for (serial_size_t i = 0; i < 6; i++) {
-    EXPECT_FLOAT_EQ(out_expected[0][i], out[0][0][i]);
-    EXPECT_FLOAT_EQ(out_expected[1][i], out[0][1][i]);
+    EXPECT_FLOAT_EQ(out_expected[0][i], (*out[0])[0][i]);
+    EXPECT_FLOAT_EQ(out_expected[1][i], (*out[0])[1][i]);
   }
 }
 

--- a/test/test_slice_layer.h
+++ b/test/test_slice_layer.h
@@ -37,20 +37,25 @@ TEST(slice, forward_data) {
     };
   // clang-format on
 
-  auto out = sl.forward({in});
+  {
+    std::vector<const tensor_t*> out;
+    sl.forward({in}, out);
 
-  for (serial_size_t i = 0; i < 6; i++) {
-    EXPECT_FLOAT_EQ(out0_expected[0][i], out[0][0][i]);
-    EXPECT_FLOAT_EQ(out1_expected[0][i], out[1][0][i]);
-    EXPECT_FLOAT_EQ(out2_expected[0][i], out[2][0][i]);
-    EXPECT_FLOAT_EQ(out2_expected[1][i], out[2][1][i]);
+    for (serial_size_t i = 0; i < 6; i++) {
+      EXPECT_FLOAT_EQ(out0_expected[0][i], (*out[0])[0][i]);
+      EXPECT_FLOAT_EQ(out1_expected[0][i], (*out[1])[0][i]);
+      EXPECT_FLOAT_EQ(out2_expected[0][i], (*out[2])[0][i]);
+      EXPECT_FLOAT_EQ(out2_expected[1][i], (*out[2])[1][i]);
+    }
   }
 
-  out = sl.backward({out0_expected, out1_expected, out2_expected});
+  {
+    auto out = sl.backward({out0_expected, out1_expected, out2_expected});
 
-  for (serial_size_t i = 0; i < 4; i++) {
-    for (serial_size_t j = 0; j < 6; j++) {
-      EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
+    for (serial_size_t i = 0; i < 4; i++) {
+      for (serial_size_t j = 0; j < 6; j++) {
+        EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
+      }
     }
   }
 }
@@ -88,21 +93,26 @@ TEST(slice, forward_channels) {
     };
   // clang-format on
 
-  auto out = sl.forward({in});
+  {
+    std::vector<const tensor_t*> out;
+    sl.forward({in}, out);
 
-  for (serial_size_t i = 0; i < 4; i++) {
-    for (serial_size_t j = 0; j < 2; j++) {
-      EXPECT_FLOAT_EQ(out0_expected[i][j], out[0][i][j]);
-      EXPECT_FLOAT_EQ(out1_expected[i][j], out[1][i][j]);
-      EXPECT_FLOAT_EQ(out2_expected[i][j], out[2][i][j]);
+    for (serial_size_t i = 0; i < 4; i++) {
+      for (serial_size_t j = 0; j < 2; j++) {
+        EXPECT_FLOAT_EQ(out0_expected[i][j], (*out[0])[i][j]);
+        EXPECT_FLOAT_EQ(out1_expected[i][j], (*out[1])[i][j]);
+        EXPECT_FLOAT_EQ(out2_expected[i][j], (*out[2])[i][j]);
+      }
     }
   }
 
-  out = sl.backward({out0_expected, out1_expected, out2_expected});
+  {
+    auto out = sl.backward({out0_expected, out1_expected, out2_expected});
 
-  for (serial_size_t i = 0; i < 4; i++) {
-    for (serial_size_t j = 0; j < 6; j++) {
-      EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
+    for (serial_size_t i = 0; i < 4; i++) {
+      for (serial_size_t j = 0; j < 6; j++) {
+        EXPECT_FLOAT_EQ(in[i][j], out[0][i][j]);
+      }
     }
   }
 }

--- a/test/testhelper.h
+++ b/test/testhelper.h
@@ -61,7 +61,9 @@ vec_t forward_pass(layer &src, const vec_t &vec) {
   src.setup(false);
   (*src.inputs()[0]->get_data())[0] = vec;
   src.forward();
-  return src.output()[0][0];
+  std::vector<const tensor_t *> out;
+  src.output(out);
+  return (*out[0])[0];
 }
 
 template <typename N>

--- a/tiny_dnn/core/kernels/conv2d_grad_op.h
+++ b/tiny_dnn/core/kernels/conv2d_grad_op.h
@@ -19,7 +19,7 @@ class Conv2dGradOp : public core::OpKernel {
   explicit Conv2dGradOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto params = OpKernel::params_->conv();
 
     // incoming/outcoming data

--- a/tiny_dnn/core/kernels/conv2d_op.h
+++ b/tiny_dnn/core/kernels/conv2d_op.h
@@ -20,7 +20,7 @@ class Conv2dOp : public core::OpKernel {
   explicit Conv2dOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto params = OpKernel::params_->conv();
 
     // incomimg/outcoming data

--- a/tiny_dnn/core/kernels/conv2d_op_libdnn.h
+++ b/tiny_dnn/core/kernels/conv2d_op_libdnn.h
@@ -32,7 +32,7 @@ class Conv2dLibDNNForwardOp : public core::OpKernel {
     }
   }
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
 #ifdef CNN_USE_LIBDNN
     // incoming/outcoming datm
     const tensor_t &in_data = context.input(0);
@@ -254,7 +254,7 @@ class Conv2dLibDNNBackwardOp : public core::OpKernel {
   explicit Conv2dLibDNNBackwardOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     CNN_UNREFERENCED_PARAMETER(context);
     throw nn_error("Not implemented yet.");
   }

--- a/tiny_dnn/core/kernels/conv2d_op_opencl.h
+++ b/tiny_dnn/core/kernels/conv2d_op_opencl.h
@@ -16,7 +16,7 @@ class Conv2dOpenCLForwardOp : public core::OpKernel {
   explicit Conv2dOpenCLForwardOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
 #if defined(USE_OPENCL) || defined(USE_CUDA)
     auto params = OpKernel::params_->conv();
 
@@ -128,7 +128,7 @@ class Conv2dOpenCLBackwardOp : public core::OpKernel {
   explicit Conv2dOpenCLBackwardOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     CNN_UNREFERENCED_PARAMETER(context);
     nn_error("Not implemented yet.");
   }

--- a/tiny_dnn/core/kernels/fully_connected_grad_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_grad_op.h
@@ -19,7 +19,7 @@ class FullyConnectedGradOp : public core::OpKernel {
   explicit FullyConnectedGradOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto params = OpKernel::params_->fully();
 
     // incoming/outcoming data

--- a/tiny_dnn/core/kernels/fully_connected_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_op.h
@@ -20,7 +20,7 @@ class FullyConnectedOp : public core::OpKernel {
   explicit FullyConnectedOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto params = OpKernel::params_->fully();
 
     // incomimg/outcoming data

--- a/tiny_dnn/core/kernels/global_avepool_grad_op.h
+++ b/tiny_dnn/core/kernels/global_avepool_grad_op.h
@@ -17,7 +17,7 @@ class GlobalAvePoolGradOp : public core::OpKernel {
   explicit GlobalAvePoolGradOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto &params = OpKernel::params_->global_avepool();
 
     // incoming/outcoming data

--- a/tiny_dnn/core/kernels/global_avepool_op.h
+++ b/tiny_dnn/core/kernels/global_avepool_op.h
@@ -17,7 +17,7 @@ class GlobalAvePoolOp : public core::OpKernel {
   explicit GlobalAvePoolOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto &params = OpKernel::params_->global_avepool();
 
     // incomimg / outcoming data

--- a/tiny_dnn/core/kernels/maxpool_grad_op.h
+++ b/tiny_dnn/core/kernels/maxpool_grad_op.h
@@ -19,7 +19,7 @@ class MaxPoolGradOp : public core::OpKernel {
   explicit MaxPoolGradOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto &params = OpKernel::params_->maxpool();
 
     // incoming/outcoming data

--- a/tiny_dnn/core/kernels/maxpool_op.h
+++ b/tiny_dnn/core/kernels/maxpool_op.h
@@ -20,7 +20,7 @@ class MaxPoolOp : public core::OpKernel {
   explicit MaxPoolOp(const core::OpKernelConstruction &context)
     : core::OpKernel(context) {}
 
-  void compute(const core::OpKernelContext &context) override {
+  void compute(core::OpKernelContext &context) override {
     auto &params = OpKernel::params_->maxpool();
 
     // incomimg/outcoming data

--- a/tiny_dnn/core/params/conv_params.h
+++ b/tiny_dnn/core/params/conv_params.h
@@ -83,8 +83,8 @@ class conv_params : public Params {
   }
 };
 
-inline conv_params Params::conv() const {
-  return *(static_cast<const conv_params *>(this));
+inline conv_params &Params::conv() {
+  return *(static_cast<conv_params *>(this));
 }
 
 class Conv2dPadding {

--- a/tiny_dnn/core/params/fully_params.h
+++ b/tiny_dnn/core/params/fully_params.h
@@ -20,8 +20,8 @@ class fully_params : public Params {
 };
 
 // TODO(nyanp): can we do better here?
-inline fully_params Params::fully() const {
-  return *(static_cast<const fully_params *>(this));
+inline fully_params &Params::fully() {
+  return *(static_cast<fully_params *>(this));
 }
 
 }  // namespace core

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -20,8 +20,8 @@ class Params {
  public:
   Params() {}
 
-  conv_params conv() const;
-  fully_params fully() const;
+  conv_params &conv();
+  fully_params &fully();
   maxpool_params &maxpool();
   global_avepool_params &global_avepool();
 };

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -66,12 +66,12 @@ class fully_connected_layer : public layer {
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {
     // forward fully connected op context
-    auto ctx = OpKernelContext(in_data, out_data);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    fwd_ctx_.set_in_out(in_data, out_data);
+    fwd_ctx_.setParallelize(layer::parallelize());
+    fwd_ctx_.setEngine(layer::engine());
 
     // launch fully connected kernel
-    kernel_fwd_->compute(ctx);
+    kernel_fwd_->compute(fwd_ctx_);
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -79,12 +79,12 @@ class fully_connected_layer : public layer {
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
     // backward fully connected op context
-    auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    bwd_ctx_.set_in_out(in_data, out_data, out_grad, in_grad);
+    bwd_ctx_.setParallelize(layer::parallelize());
+    bwd_ctx_.setEngine(layer::engine());
 
     // launch fully connected kernel
-    kernel_back_->compute(ctx);
+    kernel_back_->compute(bwd_ctx_);
   }
 
   std::string layer_type() const override { return "fully-connected"; }
@@ -116,6 +116,12 @@ class fully_connected_layer : public layer {
  private:
   /* The layer parameters */
   fully_params params_;
+
+  /* forward op context */
+  OpKernelContext fwd_ctx_;
+
+  /* backward op context */
+  OpKernelContext bwd_ctx_;
 
   /* Forward and backward ops */
   std::shared_ptr<core::OpKernel> kernel_fwd_;

--- a/tiny_dnn/layers/global_average_pooling_layer.h
+++ b/tiny_dnn/layers/global_average_pooling_layer.h
@@ -61,22 +61,22 @@ class global_average_pooling_layer : public layer {
 
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {
-    auto ctx = OpKernelContext(in_data, out_data);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    fwd_ctx_.set_in_out(in_data, out_data);
+    fwd_ctx_.setParallelize(layer::parallelize());
+    fwd_ctx_.setEngine(layer::engine());
 
-    kernel_fwd_->compute(ctx);
+    kernel_fwd_->compute(fwd_ctx_);
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    bwd_ctx_.set_in_out(in_data, out_data, out_grad, in_grad);
+    bwd_ctx_.setParallelize(layer::parallelize());
+    bwd_ctx_.setEngine(layer::engine());
 
-    kernel_back_->compute(ctx);
+    kernel_back_->compute(bwd_ctx_);
   }
 
   std::vector<index3d<serial_size_t>> in_shape() const override {
@@ -99,6 +99,12 @@ class global_average_pooling_layer : public layer {
 
  private:
   global_avepool_params params_;
+
+  /* forward op context */
+  OpKernelContext fwd_ctx_;
+
+  /* backward op context */
+  OpKernelContext bwd_ctx_;
 
   /* Forward and backward ops */
   std::shared_ptr<core::OpKernel> kernel_fwd_;

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -120,12 +120,12 @@ class max_pooling_layer : public layer {
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {
     // forward convolutional op context
-    auto ctx = OpKernelContext(in_data, out_data);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    fwd_ctx_.set_in_out(in_data, out_data);
+    fwd_ctx_.setParallelize(layer::parallelize());
+    fwd_ctx_.setEngine(layer::engine());
 
     // launch convolutional kernel
-    kernel_fwd_->compute(ctx);
+    kernel_fwd_->compute(fwd_ctx_);
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
@@ -133,12 +133,12 @@ class max_pooling_layer : public layer {
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
     // backward convolutional op context
-    auto ctx = OpKernelContext(in_data, out_data, out_grad, in_grad);
-    ctx.setParallelize(layer::parallelize());
-    ctx.setEngine(layer::engine());
+    bwd_ctx_.set_in_out(in_data, out_data, out_grad, in_grad);
+    bwd_ctx_.setParallelize(layer::parallelize());
+    bwd_ctx_.setEngine(layer::engine());
 
     // launch convolutional kernel
-    kernel_back_->compute(ctx);
+    kernel_back_->compute(bwd_ctx_);
   }
 
   std::vector<index3d<serial_size_t>> in_shape() const override {
@@ -170,6 +170,12 @@ class max_pooling_layer : public layer {
  private:
   /* The Max Poling operation params */
   maxpool_params params_;
+
+  /* forward op context */
+  OpKernelContext fwd_ctx_;
+
+  /* backward op context */
+  OpKernelContext bwd_ctx_;
 
   /* Forward and backward ops */
   std::shared_ptr<core::OpKernel> kernel_fwd_;

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -76,9 +76,9 @@ struct result {
 
   std::set<label_t> labels() const {
     std::set<label_t> all_labels;
-    for (auto r : confusion_matrix) {
+    for (auto const &r : confusion_matrix) {
       all_labels.insert(r.first);
-      for (auto c : r.second) all_labels.insert(c.first);
+      for (auto const &c : r.second) all_labels.insert(c.first);
     }
     return all_labels;
   }


### PR DESCRIPTION
Hi, this PR reduces an amount of memory allocation and copy.

Data layout of mini-batch is reordered after this commit.
https://github.com/tiny-dnn/tiny-dnn/commit/588fc2256116ebce84c9d93ce02a3ca4d24bcca2#diff-0a7e84c2581225319e60be95f342f76bR186

Let me address this comment. @reunanen
https://github.com/tiny-dnn/tiny-dnn/commit/588fc2256116ebce84c9d93ce02a3ca4d24bcca2#diff-0a7e84c2581225319e60be95f342f76bR193 

from : [sample][channel][feature]
to   : [channel][sample][feature]
data layout reoredering takes place in `nodes::reorder_for_layerwise_processing`

and 

from : [channel][sample][feature]
to   : [sample][channel][feature]

backward data layout reoredering takes place in `sequential::normalize_out` and `graph::merge_outs`

The downside of this change is worsened code readability.
