### PR TITLE
Fix to suppress missing 'override' keyword warning.

### DIFF
--- a/tiny_dnn/activations/activation_layer.h
+++ b/tiny_dnn/activations/activation_layer.h
@@ -88,7 +88,7 @@ class activation_layer : public layer {
           [&](size_t i) { backward_activation(x[i], y[i], dx[i], dy[i]); });
   }
 
-  virtual std::string layer_type() const = 0;
+  virtual std::string layer_type() const override = 0;
 
   /**
    * Populate vec_t of elements 'y' according to activation y = f(x).


### PR DESCRIPTION
Tiny fix to suppress warning about missing override keyword on function layer_type.

```
tiny-dnn/tiny_dnn/activations/activation_layer.h:91:23: warning: 'layer_type' overrides a member function but is not marked 'override'
      [-Winconsistent-missing-override]
  virtual std::string layer_type() const = 0;
                      ^
tiny-dnn/tiny_dnn/layers/layer.h:279:23: note: overridden virtual function is here
  virtual std::string layer_type() const = 0;
```