### PR TITLE
Fixing link to the built version of document.

### DIFF
--- a/docs/readme.md
+++ b/docs/readme.md
@@ -1,6 +1,6 @@
 # tiny-dnn documentations
 
-A built version of document is available at [http://tiny-dnn.readthedocs.io/en/latest/index.html](here).
+A built version of document is available at [here](http://tiny-dnn.readthedocs.io/en/latest/index.html).
 
 ## Local build
 


### PR DESCRIPTION
As I reported in #758, docs/readme.md has syntax typo.  
This pull request resolves #758.  