### PR TITLE
Introduce parameter class to represent trainable / constant parameters of layer.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -41,7 +41,7 @@ branches:
   only:
     - master
     - feat/xtensor_integration
-    - feat/decouple_activations
+    - feat/parameters_refactor
 
 env:
   global:

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -40,21 +40,7 @@ using namespace tiny_dnn::activation;
 #include "test_target_cost.h"
 #include "test_tensor.h"
 
-#ifndef CNN_NO_SERIALIZATION
-#include "test_serialization.h"
-#endif  // CNN_NO_SERIALIZATION
-
-#ifdef CNN_USE_GEMMLOWP
-#include "test_quantized_fully_connected_layer.h"
-#endif  // CNN_USE_GEMMLOOP
-
-#ifdef CNN_USE_CAFFE_CONVERTER
-#include "test_caffe_converter.h"
-#endif  // CNN_USE_CAFFE_CONVERTER
-
-#ifdef DNN_USE_IMAGE_API
-#include "test_image.h"
-#endif  // DNN_USE_IMAGE_API
+#include "test_parameter.h"
 
 int main(int argc, char **argv) {
   ::testing::InitGoogleTest(&argc, argv);

--- a/test/test.cpp
+++ b/test/test.cpp
@@ -40,6 +40,22 @@ using namespace tiny_dnn::activation;
 #include "test_target_cost.h"
 #include "test_tensor.h"
 
+#ifndef CNN_NO_SERIALIZATION
+#include "test_serialization.h"
+#endif  // CNN_NO_SERIALIZATION
+
+#ifdef CNN_USE_GEMMLOWP
+#include "test_quantized_fully_connected_layer.h"
+#endif  // CNN_USE_GEMMLOOP
+
+#ifdef CNN_USE_CAFFE_CONVERTER
+#include "test_caffe_converter.h"
+#endif  // CNN_USE_CAFFE_CONVERTER
+
+#ifdef DNN_USE_IMAGE_API
+#include "test_image.h"
+#endif  // DNN_USE_IMAGE_API
+
 #include "test_parameter.h"
 
 int main(int argc, char **argv) {

--- a/test/test_parameter.h
+++ b/test/test_parameter.h
@@ -1,0 +1,59 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+#include "gtest/gtest.h"
+#include "testhelper.h"
+#include "tiny_dnn/tiny_dnn.h"
+
+namespace tiny_dnn {
+
+TEST(parameter, init) {
+  parameter p(3, 3, 1, 1, parameter_type::weight, true);
+
+  ASSERT_EQ(p.shape().width_, 3u);
+  ASSERT_EQ(p.shape().height_, 3u);
+  ASSERT_EQ(p.shape().depth_, 1u);
+  ASSERT_EQ(p.size(), 9u);
+  ASSERT_EQ(p.type(), parameter_type::weight);
+
+  ASSERT_TRUE(p.is_trainable());
+}
+
+TEST(parameter, getter_setter) {
+  parameter p(4, 1, 1, 1, parameter_type::bias, false);
+
+  xt::xarray<float_t> xr = {1.0, 2.0, 3.0, 4.0};
+  Tensor<float_t> t{xr};
+
+  p.set_data(t);
+  Tensor<float_t> *pt = p.data();
+
+  for (unsigned int i = 0; i < t.size(); i++) {
+    ASSERT_EQ(pt->host_at(i), t.host_at(i));
+  }
+}
+
+TEST(parameter, merge_grads) {
+  xt::xarray<float_t> xgrad = {{1.0, 2.0, 3.0, 4.0}, {4.0, 3.0, 2.0, 1.0}};
+  Tensor<float_t> grad0{xgrad};
+  Tensor<float_t> gradp{xgrad * 2};
+
+  parameter p(4, 1, 1, 1, parameter_type::bias, false);
+  p.set_grad(gradp);
+  p.merge_grads(&grad0);
+
+  Tensor<float_t> expected{
+    {{10.0, 10.0, 10.0, 10.0}, {10.0, 10.0, 10.0, 10.0}}};
+
+  for (unsigned int i = 0; i < p.size(); i++) {
+    ASSERT_EQ(grad0.host_at(0, i), expected.host_at(0, i));
+    ASSERT_EQ(grad0.host_at(1, i), expected.host_at(1, i));
+  }
+}
+
+}  // namespace tiny_dnn

--- a/test/test_parameter.h
+++ b/test/test_parameter.h
@@ -31,7 +31,7 @@ TEST(parameter, getter_setter) {
   p.set_data(t);
   Tensor<float_t> *pt = p.data();
 
-  for (unsigned int i = 0; i < t.size(); i++) {
+  for (size_t i = 0; i < t.size(); i++) {
     ASSERT_EQ(pt->host_at(i), t.host_at(i));
   }
 }
@@ -46,7 +46,7 @@ TEST(parameter, merge_grads) {
 
   Tensor<float_t> expected{{{6.0, 6.0}, {6.0, 6.0}}};
 
-  for (unsigned int i = 0; i < p.size(); i++) {
+  for (size_t i = 0; i < p.size(); i++) {
     ASSERT_EQ(grad0.host_at(0, i), expected.host_at(0, i));
     ASSERT_EQ(grad0.host_at(1, i), expected.host_at(1, i));
   }

--- a/test/test_parameter.h
+++ b/test/test_parameter.h
@@ -26,9 +26,7 @@ TEST(parameter, init) {
 
 TEST(parameter, getter_setter) {
   parameter p(4, 1, 1, 1, parameter_type::bias, false);
-
-  xt::xarray<float_t> xr = {1.0, 2.0, 3.0, 4.0};
-  Tensor<float_t> t{xr};
+  Tensor<float_t> t{{1.0, 2.0, 3.0, 4.0}};
 
   p.set_data(t);
   Tensor<float_t> *pt = p.data();
@@ -39,16 +37,14 @@ TEST(parameter, getter_setter) {
 }
 
 TEST(parameter, merge_grads) {
-  xt::xarray<float_t> xgrad = {{1.0, 2.0, 3.0, 4.0}, {4.0, 3.0, 2.0, 1.0}};
-  Tensor<float_t> grad0{xgrad};
-  Tensor<float_t> gradp{xgrad * 2};
+  Tensor<float_t> grad0{{{1.0, 2.0}, {2.0, 1.0}}};
+  Tensor<float_t> gradp{{{2.0, 4.0}, {4.0, 2.0}}};
 
-  parameter p(4, 1, 1, 1, parameter_type::bias, false);
+  parameter p(2, 1, 1, 1, parameter_type::bias, false);
   p.set_grad(gradp);
   p.merge_grads(&grad0);
 
-  Tensor<float_t> expected{
-    {{10.0, 10.0, 10.0, 10.0}, {10.0, 10.0, 10.0, 10.0}}};
+  Tensor<float_t> expected{{{6.0, 6.0}, {6.0, 6.0}}};
 
   for (unsigned int i = 0; i < p.size(); i++) {
     ASSERT_EQ(grad0.host_at(0, i), expected.host_at(0, i));

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -46,7 +46,7 @@ class Tensor {
    * @param storage object, can be xtarray.
    * @return
    */
-  explicit Tensor(Storage s) : storage_(s) {}
+  explicit Tensor(const Storage &storage) : storage_(storage) {}
 
   /**
    * Constructor that accepts an initializer list of shape and create a

--- a/tiny_dnn/core/framework/tensor.h
+++ b/tiny_dnn/core/framework/tensor.h
@@ -41,6 +41,14 @@ class Tensor {
   Tensor() {}
 
   /**
+   * Constructor that accepts a storage object and create a Tensor housing
+   * that storage. Commonly used by [] operator.
+   * @param storage object, can be xtarray.
+   * @return
+   */
+  explicit Tensor(Storage s) : storage_(s) {}
+
+  /**
    * Constructor that accepts an initializer list of shape and create a
    * Tensor with that shape. For example, given shape = {2,3,4,5,6}, tensor
    * will be of size 2x3x4x5x6. Note: tensor isn't initialized by default

--- a/tiny_dnn/parameter.h
+++ b/tiny_dnn/parameter.h
@@ -7,11 +7,12 @@
 */
 #pragma once
 
+#include "tiny_dnn/core/framework/tensor.h"
 #include "tiny_dnn/util/util.h"
 
 namespace tiny_dnn {
 
-enum parameter_type : int8_t { weight = 0x0001, bias = 0x0002 };
+enum class parameter_type : int8_t { weight = 0x0001, bias = 0x0002 };
 
 class parameter {
  public:
@@ -19,30 +20,20 @@ class parameter {
             serial_size_t height,
             serial_size_t depth,
             serial_size_t n_fmaps,
-            param_type type,
+            parameter_type type,
             bool trainable = true)
     : type_(type),
       shape_(width, height, depth),
       n_fmaps_(n_fmaps),
       trainable_(trainable),
-      data_(size()),
-      grad_(1) {
-    grad_[0].resize(data_.size());
-  }
+      data_({size()}),
+      grad_({1, size()}) {}
 
   shape3d shape() { return shape_; }
 
   size_t size() { return shape_.size() * n_fmaps_; }
 
-  parameter_type type() { return param_type_; }
-
-  void set_width(serial_size_t width) { shape_.width_ = width; }
-
-  void set_height(serial_size_t height) { shape_.height_ = height; }
-
-  void set_depth(serial_size_t depth) { shape_.depth_ = depth; }
-
-  void set_fmaps(serial_size_t n_fmaps) { n_fmaps_ = n_fmaps; }
+  parameter_type type() { return type_; }
 
   void set_dims(serial_size_t width,
                 serial_size_t height,
@@ -52,6 +43,8 @@ class parameter {
     shape_.height_ = height;
     shape_.depth_  = depth;
     n_fmaps_       = n_fmaps;
+    data_.reshape({size()});
+    grad_.reshape({grad_.shape()[0], size()});
   }
 
   bool is_trainable() { return trainable_; }
@@ -60,52 +53,49 @@ class parameter {
 
   void freeze_trainable() { trainable_ = false; }
 
-  vec_t *data() { return &data_; }
+  Tensor<float_t> *data() { return &data_; }
 
-  const vec_t *data() const { return &data_; }
+  const Tensor<float_t> *data() const { return &data_; }
 
-  void set_data(const vec_t &data) { data_ = data; }
+  void set_data(const Tensor<float_t> &data) { data_ = data; }
 
-  void set_data(const vec_t *data) { data_ = *data; }
+  void set_data(const Tensor<float_t> *data) { data_ = *data; }
 
-  tensor_t *grad() { return &grad_; }
+  Tensor<float_t> *grad() { return &grad_; }
 
-  const tensor_t *grad() const { return &grad_; }
+  const Tensor<float_t> *grad() const { return &grad_; }
 
-  void set_grad(const tensor_t &grad) { grad_ = grad; }
+  void set_grad(const Tensor<float_t> &grad) { grad_ = grad; }
 
-  void set_grad(const tensor_t *grad) { grad_ = *grad; }
+  void set_grad(const Tensor<float_t> *grad) { grad_ = *grad; }
 
   void resize_grad(size_t sample_count) {
-    grad_.resize(sample_count, grad_[0]);
+    grad_.reshape({sample_count, size()});
   }
 
-  void merge_grads(vec_t *dst) {
-    assert(!grad_.empty());
+  void merge_grads(Tensor<float_t> *dst) {
     const auto &grad_head = grad_[0];
     size_t sz             = grad_head.size();
-    dst->resize(sz);
-    float_t *pdst = &(*dst)[0];
+    dst->reshape({sz});
+    //    float_t *pdst = &(*dst)[0];
     // dst = grad_[0]
-    std::copy(grad_head.begin(), grad_head.end(), pdst);
+    std::copy(grad_head.host_begin(), grad_head.host_end(), dst->host_begin());
     // @todo consider adding parallelism
-    for (size_t sample = 1, sample_count = grad_.size(); sample < sample_count;
-         ++sample) {
+    for (size_t sample = 1, sample_count = grad_.shape()[0];
+         sample < sample_count; ++sample) {
       // dst += grad_[sample]
-      vectorize::reduce<float_t>(&grad_[sample][0], sz, pdst);
+      vectorize::reduce<float_t>(&grad_.host_at(sample, 0), sz,
+                                 &dst->host_at(0));
     }
   }
 
-  void clear_grads() {
-    for (size_t sample = 0, sample_count = grad_.size(); sample < sample_count;
-         sample++) {
-      vectorize::fill(&grad_[sample][0], grad_[sample].size(), float_t{0});
-    }
+  void clear_grads() { grad_.fill(float_t{0}); }
+
+  float_t *data_at(size_t i) { return &data_.host_at(i); }
+
+  float_t *grad_at(size_t sample, size_t i) {
+    return &grad_.host_at(sample, i);
   }
-
-  float_t *data_at(size_t i) { return &data_[i]; }
-
-  float_t *grad_at(size_t sample, size_t i) { return &grad_[sample][i]; }
 
  private:
   parameter_type type_;
@@ -113,7 +103,7 @@ class parameter {
   size_t n_fmaps_;
   bool trainable_;
 
-  tensor_t data_;
-  tensor_t grad_;
+  Tensor<float_t> data_;
+  Tensor<float_t> grad_;
 };
 }  // namespace tiny_dnn

--- a/tiny_dnn/parameter.h
+++ b/tiny_dnn/parameter.h
@@ -1,0 +1,119 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include "tiny_dnn/util/util.h"
+
+namespace tiny_dnn {
+
+enum parameter_type : int8_t { weight = 0x0001, bias = 0x0002 };
+
+class parameter {
+ public:
+  parameter(serial_size_t width,
+            serial_size_t height,
+            serial_size_t depth,
+            serial_size_t n_fmaps,
+            param_type type,
+            bool trainable = true)
+    : type_(type),
+      shape_(width, height, depth),
+      n_fmaps_(n_fmaps),
+      trainable_(trainable),
+      data_(size()),
+      grad_(1) {
+    grad_[0].resize(data_.size());
+  }
+
+  shape3d shape() { return shape_; }
+
+  size_t size() { return shape_.size() * n_fmaps_; }
+
+  parameter_type type() { return param_type_; }
+
+  void set_width(serial_size_t width) { shape_.width_ = width; }
+
+  void set_height(serial_size_t height) { shape_.height_ = height; }
+
+  void set_depth(serial_size_t depth) { shape_.depth_ = depth; }
+
+  void set_fmaps(serial_size_t n_fmaps) { n_fmaps_ = n_fmaps; }
+
+  void set_dims(serial_size_t width,
+                serial_size_t height,
+                serial_size_t depth,
+                serial_size_t n_fmaps) {
+    shape_.width_  = width;
+    shape_.height_ = height;
+    shape_.depth_  = depth;
+    n_fmaps_       = n_fmaps;
+  }
+
+  bool is_trainable() { return trainable_; }
+
+  void set_trainable() { trainable_ = true; }
+
+  void freeze_trainable() { trainable_ = false; }
+
+  vec_t *data() { return &data_; }
+
+  const vec_t *data() const { return &data_; }
+
+  void set_data(const vec_t &data) { data_ = data; }
+
+  void set_data(const vec_t *data) { data_ = *data; }
+
+  tensor_t *grad() { return &grad_; }
+
+  const tensor_t *grad() const { return &grad_; }
+
+  void set_grad(const tensor_t &grad) { grad_ = grad; }
+
+  void set_grad(const tensor_t *grad) { grad_ = *grad; }
+
+  void resize_grad(size_t sample_count) {
+    grad_.resize(sample_count, grad_[0]);
+  }
+
+  void merge_grads(vec_t *dst) {
+    assert(!grad_.empty());
+    const auto &grad_head = grad_[0];
+    size_t sz             = grad_head.size();
+    dst->resize(sz);
+    float_t *pdst = &(*dst)[0];
+    // dst = grad_[0]
+    std::copy(grad_head.begin(), grad_head.end(), pdst);
+    // @todo consider adding parallelism
+    for (size_t sample = 1, sample_count = grad_.size(); sample < sample_count;
+         ++sample) {
+      // dst += grad_[sample]
+      vectorize::reduce<float_t>(&grad_[sample][0], sz, pdst);
+    }
+  }
+
+  void clear_grads() {
+    for (size_t sample = 0, sample_count = grad_.size(); sample < sample_count;
+         sample++) {
+      vectorize::fill(&grad_[sample][0], grad_[sample].size(), float_t{0});
+    }
+  }
+
+  float_t *data_at(size_t i) { return &data_[i]; }
+
+  float_t *grad_at(size_t sample, size_t i) { return &grad_[sample][i]; }
+
+ private:
+  parameter_type type_;
+  shape3d shape_;
+  size_t n_fmaps_;
+  bool trainable_;
+
+  tensor_t data_;
+  tensor_t grad_;
+};
+}  // namespace tiny_dnn

--- a/tiny_dnn/parameter.h
+++ b/tiny_dnn/parameter.h
@@ -16,6 +16,22 @@ enum class parameter_type : int8_t { weight = 0x0001, bias = 0x0002 };
 
 class parameter {
  public:
+  /**
+   * Initializes an empty parameter taking in the dimensions of weights and
+   * biases of a layer. Currently supported for maximum 4-dimensions, and
+   * stored as a flat ``Tensor``.
+   *
+   * todo (karandesai) : generalize to n-dimensions
+   * todo (karandesai) : add an n-dimensional view for easy indexing
+   *
+   * @param width      [in] filter width
+   * @param height     [in] filter height
+   * @param depth      [in] filter depth / input channels
+   * @param n_fmaps    [in] number of output feature maps
+   * @param type       [in] whether parameter is a weight or a bias
+   * @param trainable  [in] whether parameter will be updated while training or
+   * not
+   */
   parameter(serial_size_t width,
             serial_size_t height,
             serial_size_t depth,

--- a/tiny_dnn/parameter.h
+++ b/tiny_dnn/parameter.h
@@ -19,7 +19,8 @@ class parameter {
   /**
    * Initializes an empty parameter taking in the dimensions of weights and
    * biases of a layer. Currently supported for maximum 4-dimensions, and
-   * stored as a flat ``Tensor``.
+   * stored as a flat ``Tensor``. Parameters are flat and represented in NCHW
+   * format.
    *
    * todo (karandesai) : generalize to n-dimensions
    * todo (karandesai) : add an n-dimensional view for easy indexing
@@ -32,36 +33,24 @@ class parameter {
    * @param trainable  [in] whether parameter will be updated while training or
    * not
    */
-  parameter(serial_size_t width,
-            serial_size_t height,
-            serial_size_t depth,
-            serial_size_t n_fmaps,
+  parameter(size_t width,
+            size_t height,
+            size_t depth,
+            size_t n_fmaps,
             parameter_type type,
             bool trainable = true)
     : type_(type),
       shape_(width, height, depth),
       n_fmaps_(n_fmaps),
       trainable_(trainable),
-      data_({size()}),
-      grad_({1, size()}) {}
+      data_({shape_.size() * n_fmaps}),
+      grad_({1, shape_.size() * n_fmaps}) {}
 
   shape3d shape() { return shape_; }
 
-  size_t size() { return shape_.size() * n_fmaps_; }
+  size_t size() { return data_.size(); }
 
   parameter_type type() { return type_; }
-
-  void set_dims(serial_size_t width,
-                serial_size_t height,
-                serial_size_t depth,
-                serial_size_t n_fmaps) {
-    shape_.width_  = width;
-    shape_.height_ = height;
-    shape_.depth_  = depth;
-    n_fmaps_       = n_fmaps;
-    data_.reshape({size()});
-    grad_.reshape({grad_.shape()[0], size()});
-  }
 
   bool is_trainable() { return trainable_; }
 
@@ -115,11 +104,17 @@ class parameter {
 
  private:
   parameter_type type_;
+
+  // todo (karandesai) : replace with vector<size_t> for n-dimensional
+  // parameters
   shape3d shape_;
   size_t n_fmaps_;
+
   bool trainable_;
 
   Tensor<float_t> data_;
   Tensor<float_t> grad_;
-};
+
+};  // class parameter
+
 }  // namespace tiny_dnn

--- a/tiny_dnn/parameter.h
+++ b/tiny_dnn/parameter.h
@@ -12,7 +12,7 @@
 
 namespace tiny_dnn {
 
-enum class parameter_type : int8_t { weight = 0x0001, bias = 0x0002 };
+enum class parameter_type : int8_t { weight = 0x1, bias = 0x2 };
 
 class parameter {
  public:
@@ -54,9 +54,7 @@ class parameter {
 
   bool is_trainable() { return trainable_; }
 
-  void set_trainable() { trainable_ = true; }
-
-  void freeze_trainable() { trainable_ = false; }
+  void set_trainable(bool trainable) { trainable_ = trainable; }
 
   Tensor<float_t> *data() { return &data_; }
 
@@ -64,15 +62,11 @@ class parameter {
 
   void set_data(const Tensor<float_t> &data) { data_ = data; }
 
-  void set_data(const Tensor<float_t> *data) { data_ = *data; }
-
   Tensor<float_t> *grad() { return &grad_; }
 
   const Tensor<float_t> *grad() const { return &grad_; }
 
   void set_grad(const Tensor<float_t> &grad) { grad_ = grad; }
-
-  void set_grad(const Tensor<float_t> *grad) { grad_ = *grad; }
 
   void resize_grad(size_t sample_count) {
     grad_.reshape({sample_count, size()});

--- a/tiny_dnn/tiny_dnn.h
+++ b/tiny_dnn/tiny_dnn.h
@@ -10,6 +10,7 @@
 #include "tiny_dnn/config.h"
 #include "tiny_dnn/network.h"
 #include "tiny_dnn/nodes.h"
+#include "tiny_dnn/parameter.h"
 
 #include "tiny_dnn/core/framework/tensor.h"
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -395,7 +395,7 @@ struct LoadAndConstruct<tiny_dnn::recurrent_cell_layer> {
     Archive &ar, cereal::construct<tiny_dnn::recurrent_cell_layer> &construct) {
     size_t in_dim, out_dim;
     bool has_bias;
-    std::shared_ptr<tiny_dnn::activation_layer> activation{};
+
     arc(ar, make_nvp("in_size", in_dim), make_nvp("out_size", out_dim),
         make_nvp("has_bias", has_bias));
     auto al = tiny_dnn::layer::load_layer(ar);
@@ -568,14 +568,12 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::elementwise_add_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("num_args", layer.num_args_), make_nvp("dim", layer.dim_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::average_pooling_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_),
         make_nvp("pool_size_x", layer.pool_size_x_),
         make_nvp("pool_size_y", layer.pool_size_y_),
@@ -587,7 +585,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::average_unpooling_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_),
         make_nvp("pool_size", layer.w_.width_),
         make_nvp("stride", layer.stride_));
@@ -596,7 +593,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::batch_normalization_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_spatial_size", layer.in_spatial_size_),
         make_nvp("in_channels", layer.in_channels_),
         make_nvp("epsilon", layer.eps_), make_nvp("momentum", layer.momentum_),
@@ -606,15 +602,12 @@ struct serialization_buddy {
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::concat_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shapes_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::convolutional_layer &layer) {
-    layer.serialize_prolog(ar);
-
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in),
         make_nvp("window_width", params_.weight.width_),
@@ -630,7 +623,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::deconvolutional_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in),
         make_nvp("window_width", params_.weight.width_),
@@ -645,7 +637,6 @@ struct serialization_buddy {
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::dropout_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_size_),
         make_nvp("dropout_rate", layer.dropout_rate_),
         make_nvp("phase", layer.phase_));
@@ -654,7 +645,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::fully_connected_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in_size_),
         make_nvp("out_size", params_.out_size_),
@@ -664,27 +654,23 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::global_average_pooling_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_shape", params_.in));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::input_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("shape", layer.shape_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::linear_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.dim_), make_nvp("scale", layer.scale_),
         make_nvp("bias", layer.bias_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::lrn_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_shape", layer.in_shape_),
         make_nvp("size", layer.size_), make_nvp("alpha", layer.alpha_),
         make_nvp("beta", layer.beta_), make_nvp("region", layer.region_));
@@ -693,7 +679,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::max_pooling_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in),
         make_nvp("pool_size_x", params_.pool_size_x),
@@ -706,7 +691,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::max_unpooling_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_),
         make_nvp("unpool_size", layer.unpool_size_),
         make_nvp("stride", layer.stride_));
@@ -714,7 +698,6 @@ struct serialization_buddy {
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::power_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape_),
         make_nvp("factor", layer.factor_), make_nvp("scale", layer.scale_));
   }
@@ -722,7 +705,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::quantized_convolutional_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in),
         make_nvp("window_width", params_.weight.width_),
@@ -738,7 +720,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(
     Archive &ar, tiny_dnn::quantized_deconvolutional_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in),
         make_nvp("window_width", params_.weight.width_),
@@ -754,7 +735,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(
     Archive &ar, tiny_dnn::quantized_fully_connected_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in_size_),
         make_nvp("out_size", params_.out_size_),
@@ -764,7 +744,6 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::recurrent_cell_layer &layer) {
-    layer.serialize_prolog(ar);
     auto &params_ = layer.params_;
     arc(ar, make_nvp("in_size", params_.in_size_),
         make_nvp("out_size", params_.out_size_),
@@ -774,7 +753,6 @@ struct serialization_buddy {
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::slice_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape_),
         make_nvp("slice_type", layer.slice_type_),
         make_nvp("num_outputs", layer.num_outputs_));
@@ -782,65 +760,55 @@ struct serialization_buddy {
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::sigmoid_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::tanh_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::relu_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::softmax_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::leaky_relu_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]),
         make_nvp("epsilon", layer.epsilon_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::elu_layer &layer) {
-    layer.serialize_prolog(ar);
     tiny_dnn::shape3d shape = layer.in_shape()[0];
     arc(ar, make_nvp("in_size", shape));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::selu_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]),
         make_nvp("lambda", layer.lambda_), make_nvp("alpha", layer.alpha_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::tanh_p1m2_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::softplus_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]),
         make_nvp("beta", layer.beta_), make_nvp("threshold", layer.threshold_));
   }
 
   template <class Archive>
   static inline void serialize(Archive &ar, tiny_dnn::softsign_layer &layer) {
-    layer.serialize_prolog(ar);
     arc(ar, make_nvp("in_size", layer.in_shape()[0]));
   }
 
@@ -850,7 +818,10 @@ struct serialization_buddy {
 template <class Archive, typename T>
 typename std::enable_if<std::is_base_of<tiny_dnn::layer, T>::value>::type
 serialize(Archive &ar, T &layer) {
-  serialization_buddy::serialize(ar, layer);
+  auto &inconstant_layer =
+    const_cast<typename std::remove_const<T>::type &>(layer);
+  inconstant_layer.serialize_prolog(ar);
+  serialization_buddy::serialize(ar, inconstant_layer);
 }
 
 template <class Archive, typename T>

--- a/tiny_dnn/util/serialization_helper.h
+++ b/tiny_dnn/util/serialization_helper.h
@@ -117,9 +117,9 @@ void layer::save_layer(OutputArchive &oa, const layer &l) {
 
 template <class Archive>
 void layer::serialize_prolog(Archive &ar) {
-  ar(cereal::make_nvp(
-    "type",
-    serialization_helper<Archive>::get_instance().type_name(typeid(*this))));
+  std::string name =
+    serialization_helper<Archive>::get_instance().type_name(typeid(*this));
+  ar(cereal::make_nvp("type", name));
 }
 
 }  // namespace tiny_dnn


### PR DESCRIPTION
This PR is the first one to refactor underlying mechanism of representation of trainable weights of a layer. We have a class named `edge` which holds `tensor_t` of data and grad. `edge` represents the incoming and outgoing data to / from a layer. The end game is to make this `edge` hold only references to nodes instead of actual tensors with numbers.

* `edge` was a generic class to represent data, labels, weights, biases and auxiliary tensors, but now a separate class named `parameter` has been made to represent weights and biases.

* `parameter` class contains members to hold dimensions and number of filters of weights and biases, a boolean to check whether trainable or not and tensors of data and gradients, complete with their getters and setters.

### Roadmap Further:

* Layer constructors shall not accept weights and biases in their input type constructors, rather they shall call `layer::add_parameter` method in the constructor to add weights and biases. Same for forward and backward propagation methods. 

* Layers will have suitable getter - setters to load pre trained weights and save them effectively. 

### Requirement of parameter class:

Please refer the discussion starting from https://github.com/tiny-dnn/tiny-dnn/pull/754#issuecomment-309910155
