### PR TITLE
Convolution parameter integration

### DIFF
--- a/tiny_dnn/core/kernels/conv2d_op.h
+++ b/tiny_dnn/core/kernels/conv2d_op.h
@@ -25,10 +25,12 @@ class Conv2dOp : public core::OpKernel {
 
     // TODO(Randl): Remove once layers forward and backward by themself.
     Tensor<float_t> in_data_t(context.input(0));
-    const Tensor<float_t> weights_t(context.input(1)),
-      bias_t =
-        params.has_bias ? Tensor<float_t>(context.input(2)) : Tensor<float_t>();
     Tensor<float_t> out_data_t(context.output(0));
+
+    const Tensor<float_t> weights(*(context.ith_parameter(0)->data()));
+    const Tensor<float_t> bias(params.has_bias
+                                 ? *(context.ith_parameter(1)->data())
+                                 : Tensor<float_t>());
 
     // initialize outputs
     out_data_t.fill(0.0f);
@@ -39,19 +41,19 @@ class Conv2dOp : public core::OpKernel {
     const core::backend_t engine = context.engine();
 
     if (engine == core::backend_t::internal) {
-      kernels::conv2d_op_internal(in_data_t, weights_t, bias_t, out_data_t,
-                                  params, context.parallelize());
+      kernels::conv2d_op_internal(in_data_t, weights, bias, out_data_t, params,
+                                  context.parallelize());
 
       // TODO(Randl): Remove once layers forward and backward by themself.
       context.output(0) = out_data_t.toTensor();
     } else if (engine == core::backend_t::nnpack) {
-      kernels::conv2d_op_nnpack(in_data_t, weights_t, bias_t, out_data_t,
-                                params, context.parallelize());
+      kernels::conv2d_op_nnpack(in_data_t, weights, bias, out_data_t, params,
+                                context.parallelize());
 
       // TODO(Randl): Remove once layers forward and backward by themself.
       context.output(0) = out_data_t.toTensor();
     } else if (engine == core::backend_t::avx) {
-      kernels::conv2d_op_avx(in_data_t, weights_t, bias_t, out_data_t, params,
+      kernels::conv2d_op_avx(in_data_t, weights, bias, out_data_t, params,
                              context.parallelize());
 
       // TODO(Randl): Remove once layers forward and backward by themself.

--- a/tiny_dnn/core/kernels/fully_connected_grad_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_grad_op.h
@@ -56,7 +56,9 @@ class FullyConnectedGradOp : public core::OpKernel {
       throw nn_error("Not supported engine: " + to_string(engine));
     }
     context.ith_parameter(0)->set_grad(weights_grads);
-    context.ith_parameter(1)->set_grad(bias_grads);
+    if (params.has_bias_) {
+      context.ith_parameter(1)->set_grad(bias_grads);
+    }
     context.input_grad(0) = prev_delta.toTensor();
   }
 };

--- a/tiny_dnn/layers/convolutional_layer.h
+++ b/tiny_dnn/layers/convolutional_layer.h
@@ -219,7 +219,12 @@ class convolutional_layer : public layer {
                       size_t w_stride        = 1,
                       size_t h_stride        = 1,
                       backend_t backend_type = core::default_engine())
-    : layer(std_input_order(has_bias), {vector_type::data}) {
+    : layer({vector_type::data}, {vector_type::data}) {
+    layer::add_parameter(out_channels, in_channels, window_height, window_width,
+                         parameter_type::weight, true);
+    if (has_bias) {
+      layer::add_parameter(1, 1, 1, out_channels, parameter_type::bias, true);
+    }
     conv_set_params(shape3d(in_width, in_height, in_channels), window_width,
                     window_height, out_channels, pad_type, has_bias, w_stride,
                     h_stride, connection_table);
@@ -266,6 +271,7 @@ class convolutional_layer : public layer {
     fwd_ctx_.set_in_out(fwd_in_data_, out_data);
     fwd_ctx_.setParallelize(layer::parallelize());
     fwd_ctx_.setEngine(layer::engine());
+    fwd_ctx_.setParameters(parameters());
 
     // launch convolutional kernel
     kernel_fwd_->compute(fwd_ctx_);
@@ -301,6 +307,7 @@ class convolutional_layer : public layer {
     bwd_ctx_.setParams(&params_);
     bwd_ctx_.setParallelize(layer::parallelize());
     bwd_ctx_.setEngine(layer::engine());
+    bwd_ctx_.setParameters(parameters());
 
     // launch convolutional kernel
     kernel_back_->compute(bwd_ctx_);
@@ -316,12 +323,7 @@ class convolutional_layer : public layer {
   }
 
   std::vector<index3d<size_t>> in_shape() const override {
-    if (params_.has_bias) {
-      return {params_.in, params_.weight,
-              index3d<size_t>(1, 1, params_.out.depth_)};
-    } else {
-      return {params_.in, params_.weight};
-    }
+    return {params_.in};
   }
 
   std::vector<index3d<size_t>> out_shape() const override {


### PR DESCRIPTION
This PR integrates `Parameter` API into convolution layer. Convolution layer constructor now adds two parameters directly through its constructor and the forward and backward prop method only accept tensors of data, as opposed to data, weights, bias earlier.

Similar to #803.
