### PR TITLE
Shift to container based builds on travis.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: required
+sudo: false
 dist: trusty
 osx_image: xcode8
 
@@ -22,10 +22,13 @@ addons:
     sources:
       - ubuntu-toolchain-r-test
       - llvm-toolchain-precise-3.6
+      - sourceline: 'deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main'
+      - key_url: 'http://apt.llvm.org/llvm-snapshot.gpg.key'
     packages:
       - gcc-4.9
       - g++-4.9
       - clang-3.6
+      - clang-format-4.0
       - cmake
       - git
       # Optional dependencies

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,6 @@
-sudo: false
 dist: trusty
 osx_image: xcode8
-
 language: cpp
-
-os:
-  - linux
-  - osx
-
-compiler:
-  - gcc
-  - clang
 
 cache:
   pip: true
@@ -51,17 +41,59 @@ env:
     - USE_TBB=ON
     - BUILD_TESTS=ON
     - BUILD_EXAMPLES=ON
-    - COVERALLS=ON
-
-  matrix:
-    - USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
-    - USE_SSE=ON  USE_AVX=ON USE_DOUBLE=OFF
-    - USE_SSE=ON  USE_AVX=ON USE_DOUBLE=ON
+    - COVERALLS=OFF           # only ON for gcc on linux
+    - USE_ASAN=OFF            # only ON for gcc on linux
+    - CLANG_FORMAT_CHECK=OFF  # only ON for one job
 
 matrix:
-  exclude: # On OSX g++ is a symlink to clang++ by default
+  include:
+    # Only do a clang format check
+    - os: linux
+      compiler: clang
+      sudo: false
+      env: CLANG_FORMAT_CHECK=ON BUILD_TESTS=OFF BUILD_EXAMPLES=OFF USE_AVX=OFF USE_SSE=OFF USE_DOUBLE=OFF
+
+    # Next three jobs are on linux with clang compiler
+    # Other specifics - USE_TBB=OFF
+    - os: linux
+      compiler: clang
+      sudo: false
+      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF USE_TBB=OFF
+
+    - os: linux
+      compiler: clang
+      sudo: false
+      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=OFF USE_TBB=OFF
+
+    - os: linux
+      compiler: clang
+      sudo: false
+      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=ON USE_TBB=OFF
+
+    # One job are on osx with clang compiler
     - os: osx
+      compiler: clang
+      sudo: false
+      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
+
+    # Next three jobs are on linux with gcc compiler
+    # sudo: required because of higher memory requirement
+    # Container builds provide 4GB memory while VMs provde 7.5GB
+    # Other specifics = COVERALLS=ON, USE_ASAN=ON
+    - os: linux
       compiler: gcc
+      sudo: required
+      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF COVERALLS=ON USE_ASAN=ON
+
+    - os: linux
+      compiler: gcc
+      sudo: required
+      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=OFF COVERALLS=ON USE_ASAN=ON
+
+    - os: linux
+      compiler: gcc
+      sudo: required
+      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=ON COVERALLS=ON USE_ASAN=ON
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then
@@ -76,38 +108,28 @@ install:
   - gem install coveralls-lcov
 
 before_script:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.9" ]; then
+  - if [ "$COVERALLS" = "ON" ]; then
       lcov --directory . --zerocounters;
-      cmake -DUSE_TBB=$USE_TBB
-            -DUSE_SSE=$USE_SSE
-            -DUSE_AVX=$USE_AVX
-            -DUSE_DOUBLE=$USE_DOUBLE
-            -DBUILD_TESTS=$BUILD_TESTS
-            -DCOVERALLS=$COVERALLS
-            -DUSE_ASAN=ON
-            -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ]; then
-      cmake -DUSE_SSE=$USE_SSE
-            -DUSE_AVX=$USE_AVX
-            -DBUILD_TESTS=$BUILD_TESTS
-            -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
-    fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      cmake -DUSE_TBB=$USE_TBB
-            -DUSE_AVX=OFF
-            -DBUILD_TESTS=$BUILD_TESTS .;
-    fi
+  - cmake -DUSE_TBB=$USE_TBB
+          -DUSE_SSE=$USE_SSE
+          -DUSE_AVX=$USE_AVX
+          -DUSE_DOUBLE=$USE_DOUBLE
+          -DBUILD_TESTS=$BUILD_TESTS
+          -DCOVERALLS=$COVERALLS
+          -DUSE_ASAN=$USE_ASAN
+          -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
 
 script:
-  - make -j2
-  - test/tiny_dnn_test
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ] && [ "$USE_SSE" == "ON" ] && [ "$USE_AVX" == "ON" ] && [ "$USE_DOUBLE" == "ON" ]; then
+  - make -j2;
+  - if [ "$CLANG_FORMAT_CHECK" == "ON" ]; then
       make clang-format-check;
+    else
+      test/tiny_dnn_test;
     fi
 
 after_success:
-  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.9" ]; then
+  - if [ "$COVERALLS" == "ON" ]; then
       lcov --directory . --capture --output-file coverage.info;
       lcov --remove coverage.info 'test/*' 'third_party/*' 'cereal/*' '/usr/*' 'tiny_dnn/io/caffe/caffe.pb.*' --output-file coverage.info;
       lcov --list coverage.info;

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,16 @@
 dist: trusty
 osx_image: xcode8
+sudo: false
+
 language: cpp
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
 
 cache:
   pip: true
@@ -38,62 +48,32 @@ branches:
 
 env:
   global:
-    - USE_TBB=ON
-    - BUILD_TESTS=ON
-    - BUILD_EXAMPLES=ON
+    - USE_TBB=ON              # only OFF for clang on linux
+    - USE_SSE=OFF
+    - USE_AVX=OFF
+    - USE_DOUBLE=OFF
+    - BUILD_EXAMPLES=OFF
+    - BUILD_TESTS=OFF
     - COVERALLS=OFF           # only ON for gcc on linux
     - USE_ASAN=OFF            # only ON for gcc on linux
     - CLANG_FORMAT_CHECK=OFF  # only ON for one job
+
+  matrix:
+    - BUILD_TESTS=ON
+    - BUILD_TESTS=ON USE_SSE=ON USE_AVX=ON
+    - BUILD_TESTS=ON USE_SSE=ON USE_AVX=ON USE_DOUBLE=ON
+    - BUILD_EXAMPLES=ON
 
 matrix:
   include:
     # Only do a clang format check
     - os: linux
       compiler: clang
-      sudo: false
-      env: CLANG_FORMAT_CHECK=ON BUILD_TESTS=OFF BUILD_EXAMPLES=OFF USE_AVX=OFF USE_SSE=OFF USE_DOUBLE=OFF
+      env: CLANG_FORMAT_CHECK=ON
 
-    # Next three jobs are on linux with clang compiler
-    # Other specifics - USE_TBB=OFF
-    - os: linux
-      compiler: clang
-      sudo: false
-      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF USE_TBB=OFF
-
-    - os: linux
-      compiler: clang
-      sudo: false
-      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=OFF USE_TBB=OFF
-
-    - os: linux
-      compiler: clang
-      sudo: false
-      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=ON USE_TBB=OFF
-
-    # One job are on osx with clang compiler
+  exclude:
     - os: osx
-      compiler: clang
-      sudo: false
-      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF
-
-    # Next three jobs are on linux with gcc compiler
-    # sudo: required because of higher memory requirement
-    # Container builds provide 4GB memory while VMs provde 7.5GB
-    # Other specifics = COVERALLS=ON, USE_ASAN=ON
-    - os: linux
       compiler: gcc
-      sudo: required
-      env: USE_SSE=OFF USE_AVX=OFF USE_DOUBLE=OFF COVERALLS=ON USE_ASAN=ON
-
-    - os: linux
-      compiler: gcc
-      sudo: required
-      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=OFF COVERALLS=ON USE_ASAN=ON
-
-    - os: linux
-      compiler: gcc
-      sudo: required
-      env: USE_SSE=ON USE_AVX=ON USE_DOUBLE=ON COVERALLS=ON USE_ASAN=ON
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then
@@ -108,24 +88,38 @@ install:
   - gem install coveralls-lcov
 
 before_script:
-  - if [ "$COVERALLS" = "ON" ]; then
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.9" ]; then
+      export USE_ASAN="ON";
+      export COVERALLS="ON";
       lcov --directory . --zerocounters;
     fi
+
+  - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ]; then
+      export USE_TBB="OFF";
+    fi
+
   - cmake -DUSE_TBB=$USE_TBB
           -DUSE_SSE=$USE_SSE
           -DUSE_AVX=$USE_AVX
           -DUSE_DOUBLE=$USE_DOUBLE
+          -DBUILD_EXAMPLES=$BUILD_EXAMPLES
           -DBUILD_TESTS=$BUILD_TESTS
           -DCOVERALLS=$COVERALLS
-          -DUSE_ASAN=$USE_ASAN
-          -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
+          -DUSE_ASAN=$USE_ASAN .;
 
 script:
-  - make -j2;
+  - if [ "$BUILD_TESTS" == "ON" ]; then
+      make -j2 generated_proto;
+      make -j2 tiny_dnn_test;
+      test/tiny_dnn_test;
+    fi
+
+  - if [ "$BUILD_EXAMPLES" == "ON" ]; then
+      make -j2 examples_all;
+    fi
+
   - if [ "$CLANG_FORMAT_CHECK" == "ON" ]; then
       make clang-format-check;
-    else
-      test/tiny_dnn_test;
     fi
 
 after_success:

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -17,10 +17,3 @@ if [ "$TRAVIS_OS_NAME" == "osx" ]; then
     tar -czvf "${HOME}/homebrew-cache/homebrew-cache.tar.gz" --directory /usr/local/Cellar tbb cmake
   fi
 fi
-
-if [ "$TRAVIS_OS_NAME" == "linux" ]; then
-  curl http://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -;
-  echo "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-4.0 main" | sudo tee -a /etc/apt/sources.list;
-  sudo apt-get update -qq;
-  sudo apt-get install clang-format-4.0 -y;
-fi

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -376,6 +376,9 @@ install(DIRECTORY   ${PROJECT_SOURCE_DIR}/${project_library_target_name}
 # Check if protobuf available
 include(cmake/protoc.cmake)
 
+# Clang format checking
+include(cmake/clang-cxx-dev-tools.cmake)
+
 # Subdirectories for examples, testing and documentation
 # TODO: explain in brief about different examples, test and docs.
 if(BUILD_EXAMPLES)

--- a/benchmarks/CMakeLists.txt
+++ b/benchmarks/CMakeLists.txt
@@ -12,6 +12,3 @@ include_directories("${benchmark_SOURCE_DIR}/include")
 add_executable(tiny_dnn_benchmarks benchmarks.cpp)
 target_link_libraries(tiny_dnn_benchmarks
         ${project_library_target_name} ${REQUIRED_LIBRARIES} benchmark)
-
-#### Clang-tidy check
-#include(../cmake/clang-cxx-dev-tools.cmake)

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -64,6 +64,15 @@ if(PROTO_CPP_AVAILABLE)
     cotire(example_caffe_converter)
 endif()
 
+if(USE_SERIALIZER)
+    add_custom_target(examples_all DEPENDS example_mnist_train example_mnist_test
+            example_mnist_quantized_train example_deconv_train
+            example_deconv_visual example_cifar_train example_cifar_test )
+else()
+    add_custom_target(examples_all DEPENDS example_deconv_visual example_cifar_train
+            example_cifar_test )
+endif()
+
 if(PROTO_CPP_GENERATE)
     add_dependencies(example_caffe_converter generated_proto)
 endif()

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -60,7 +60,4 @@ if(PROTO_CPP_GENERATE)
     add_dependencies(tiny_dnn_test generated_proto)
 endif()
 
-### Clang-tidy check
-include(../cmake/clang-cxx-dev-tools.cmake)
-
 cotire(print_device tiny_dnn_test)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -3,6 +3,7 @@ enable_testing()
 
 
 include(../cmake/DownloadProject/DownloadProject.cmake)
+
 #set(gtest_disable_pthreads on) #TODO(randl): Windows?
 download_project(
     PROJ googletest


### PR DESCRIPTION
This PR introduces changes in `.travis.yml` file. Linux jobs required addition of a line in sources list, as well as pulling a gpg key for llvm. Both were done by a bash script ( `.travis/install.sh` ) which used sudo.

Usage of `sudo` enforces travis to use legacy infrastructure and it is comparatively slower. To quickly start the builds on pushing, we must migrate to container based bulds which are through `sudo: false`.

I turned off sudo and performed the earlier tasks directly by specifying suitable config options in yml file.