### PR TITLE
Make API for getting and setting parameters more convenient.

### DIFF
--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -177,8 +177,8 @@ TEST(ave_pool, backward) {
   std::vector<tensor_t> in_grad =
     l.backward(std::vector<tensor_t>{{curr_delta}});
   vec_t prev_delta_result = in_grad[0][0];
-  vec_t dw_result         = l.ith_parameter(0).data()->toTensor()[0];
-  vec_t db_result         = l.ith_parameter(1).data()->toTensor()[0];
+  vec_t dw_result         = l.weights_at().data()->toTensor()[0];
+  vec_t db_result         = l.bias_at().data()->toTensor()[0];
 
   for (size_t i = 0; i < prev_delta_expected.size(); i++) {
     EXPECT_NEAR(prev_delta_result[i], prev_delta_expected[i], 1E-7);

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -177,8 +177,8 @@ TEST(ave_pool, backward) {
   std::vector<tensor_t> in_grad =
     l.backward(std::vector<tensor_t>{{curr_delta}});
   vec_t prev_delta_result = in_grad[0][0];
-  vec_t dw_result         = l.weights_at().data()->toTensor()[0];
-  vec_t db_result         = l.bias_at().data()->toTensor()[0];
+  vec_t dw_result         = l.weights_at()[0]->data()->toTensor()[0];
+  vec_t db_result         = l.bias_at()[0]->data()->toTensor()[0];
 
   for (size_t i = 0; i < prev_delta_expected.size(); i++) {
     EXPECT_NEAR(prev_delta_result[i], prev_delta_expected[i], 1E-7);

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -25,8 +25,8 @@ TEST(convolutional, setup_internal) {
   EXPECT_EQ(l.out_data_size(), 18u);             // size of output tensors
   EXPECT_EQ(l.fan_in_size(), 9u);                // num of incoming connections
   EXPECT_EQ(l.fan_out_size(), 18u);              // num of outgoing connections
-  EXPECT_EQ(l.weights_at().size(), 18u);         // size of weights
-  EXPECT_EQ(l.bias_at().size(), 2u);             // size of bias
+  EXPECT_EQ(l.weights_at()[0]->size(), 18u);     // size of weights
+  EXPECT_EQ(l.bias_at()[0]->size(), 2u);         // size of bias
   EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
   EXPECT_STREQ(l.layer_type().c_str(), "conv");  // string with layer type
 }
@@ -139,7 +139,7 @@ TEST(convolutional, forward) {
   };
   // clang-format on
 
-  l.weights_at().set_data(Tensor<float_t>(weight));
+  l.weights_at()[0]->set_data(Tensor<float_t>(weight));
   auto out     = l.forward({{in}});
   vec_t result = (*out[0])[0];
 
@@ -178,8 +178,8 @@ TEST(convolutional, with_stride) {
   };
   // clang-format on
 
-  l.weights_at().set_data(Tensor<float_t>(weight));
-  l.bias_at().set_data(Tensor<float_t>(bias));
+  l.weights_at()[0]->set_data(Tensor<float_t>(weight));
+  l.bias_at()[0]->set_data(Tensor<float_t>(bias));
 
   auto out         = l.forward({{in}});
   vec_t result_out = (*out[0])[0];
@@ -213,13 +213,13 @@ TEST(convolutional, with_stride) {
   };
   // clang-format on
 
-  l.weights_at().clear_grads();
-  l.bias_at().clear_grads();
+  l.weights_at()[0]->clear_grads();
+  l.bias_at()[0]->clear_grads();
 
   vec_t result_prev_delta =
     l.backward(std::vector<tensor_t>{{curr_delta}})[0][0];
-  vec_t result_dw = l.weights_at().grad()->toTensor()[0];
-  vec_t result_db = l.bias_at().grad()->toTensor()[0];
+  vec_t result_dw = l.weights_at()[0]->grad()->toTensor()[0];
+  vec_t result_db = l.bias_at()[0]->grad()->toTensor()[0];
 
   for (size_t i = 0; i < result_prev_delta.size(); i++) {
     EXPECT_FLOAT_EQ(expected_prev_delta[i], result_prev_delta[i]);
@@ -249,15 +249,15 @@ TEST(convolutional, bprop_avx) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.weights_at().grad();
-  Tensor<> *b_grads_noavx = l.bias_at().grad();
+  Tensor<> *w_grads_noavx = l.weights_at()[0]->grad();
+  Tensor<> *b_grads_noavx = l.bias_at()[0]->grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.weights_at().grad();
-  Tensor<> *b_grads_avx = l.bias_at().grad();
+  Tensor<> *w_grads_avx = l.weights_at()[0]->grad();
+  Tensor<> *b_grads_avx = l.bias_at()[0]->grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {
@@ -306,13 +306,13 @@ TEST(convolutional, bprop_avx_1x1out) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.weights_at().grad();
+  Tensor<> *w_grads_noavx = l.weights_at()[0]->grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.weights_at().grad();
+  Tensor<> *w_grads_avx = l.weights_at()[0]->grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {
@@ -358,13 +358,13 @@ TEST(convolutional, bprop_avx_hstride) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.weights_at().grad();
+  Tensor<> *w_grads_noavx = l.weights_at()[0]->grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.weights_at().grad();
+  Tensor<> *w_grads_avx = l.weights_at()[0]->grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {

--- a/test/test_convolutional_layer.h
+++ b/test/test_convolutional_layer.h
@@ -25,8 +25,8 @@ TEST(convolutional, setup_internal) {
   EXPECT_EQ(l.out_data_size(), 18u);             // size of output tensors
   EXPECT_EQ(l.fan_in_size(), 9u);                // num of incoming connections
   EXPECT_EQ(l.fan_out_size(), 18u);              // num of outgoing connections
-  EXPECT_EQ(l.ith_parameter(0).size(), 18u);     // size of weights
-  EXPECT_EQ(l.ith_parameter(1).size(), 2u);      // size of bias
+  EXPECT_EQ(l.weights_at().size(), 18u);         // size of weights
+  EXPECT_EQ(l.bias_at().size(), 2u);             // size of bias
   EXPECT_EQ(l.parallelize(), true);              // if layer can be parallelized
   EXPECT_STREQ(l.layer_type().c_str(), "conv");  // string with layer type
 }
@@ -139,7 +139,7 @@ TEST(convolutional, forward) {
   };
   // clang-format on
 
-  l.ith_parameter(0).set_data(Tensor<float_t>(weight));
+  l.weights_at().set_data(Tensor<float_t>(weight));
   auto out     = l.forward({{in}});
   vec_t result = (*out[0])[0];
 
@@ -178,8 +178,8 @@ TEST(convolutional, with_stride) {
   };
   // clang-format on
 
-  l.ith_parameter(0).set_data(Tensor<float_t>(weight));
-  l.ith_parameter(1).set_data(Tensor<float_t>(bias));
+  l.weights_at().set_data(Tensor<float_t>(weight));
+  l.bias_at().set_data(Tensor<float_t>(bias));
 
   auto out         = l.forward({{in}});
   vec_t result_out = (*out[0])[0];
@@ -213,13 +213,13 @@ TEST(convolutional, with_stride) {
   };
   // clang-format on
 
-  l.ith_parameter(0).clear_grads();
-  l.ith_parameter(1).clear_grads();
+  l.weights_at().clear_grads();
+  l.bias_at().clear_grads();
 
   vec_t result_prev_delta =
     l.backward(std::vector<tensor_t>{{curr_delta}})[0][0];
-  vec_t result_dw = l.ith_parameter(0).grad()->toTensor()[0];
-  vec_t result_db = l.ith_parameter(1).grad()->toTensor()[0];
+  vec_t result_dw = l.weights_at().grad()->toTensor()[0];
+  vec_t result_db = l.bias_at().grad()->toTensor()[0];
 
   for (size_t i = 0; i < result_prev_delta.size(); i++) {
     EXPECT_FLOAT_EQ(expected_prev_delta[i], result_prev_delta[i]);
@@ -249,15 +249,15 @@ TEST(convolutional, bprop_avx) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.ith_parameter(0).grad();
-  Tensor<> *b_grads_noavx = l.ith_parameter(1).grad();
+  Tensor<> *w_grads_noavx = l.weights_at().grad();
+  Tensor<> *b_grads_noavx = l.bias_at().grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.ith_parameter(0).grad();
-  Tensor<> *b_grads_avx = l.ith_parameter(1).grad();
+  Tensor<> *w_grads_avx = l.weights_at().grad();
+  Tensor<> *b_grads_avx = l.bias_at().grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {
@@ -306,13 +306,13 @@ TEST(convolutional, bprop_avx_1x1out) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.ith_parameter(0).grad();
+  Tensor<> *w_grads_noavx = l.weights_at().grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.ith_parameter(0).grad();
+  Tensor<> *w_grads_avx = l.weights_at().grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {
@@ -358,13 +358,13 @@ TEST(convolutional, bprop_avx_hstride) {
   l.set_backend_type(core::backend_t::internal);
   auto prev_grads_noavx   = l.backward({{out_grads}});
   vec_t result_noavx      = prev_grads_noavx[0][0];
-  Tensor<> *w_grads_noavx = l.ith_parameter(0).grad();
+  Tensor<> *w_grads_noavx = l.weights_at().grad();
 
   l.clear_grads();
   l.set_backend_type(core::backend_t::avx);
   auto prev_grads_avx   = l.backward({{out_grads}});
   vec_t result_avx      = prev_grads_avx[0][0];
-  Tensor<> *w_grads_avx = l.ith_parameter(0).grad();
+  Tensor<> *w_grads_avx = l.weights_at().grad();
 
   EXPECT_EQ(result_avx.size(), result_noavx.size());
   for (size_t i = 0; i < result_avx.size(); i++) {

--- a/test/test_deconvolutional_layer.h
+++ b/test/test_deconvolutional_layer.h
@@ -19,22 +19,22 @@ TEST(deconvolutional, setup_tiny) {
   deconvolutional_layer l(2, 2, 3, 1, 2, padding::valid, true, 1, 1,
                           core::backend_t::internal);
 
-  EXPECT_EQ(l.parallelize(), true);          // if layer can be parallelized
-  EXPECT_EQ(l.in_channels(), 1u);            // num of input tensors
-  EXPECT_EQ(l.out_channels(), 1u);           // num of output tensors
-  EXPECT_EQ(l.in_data_size(), 4u);           // size of input tensors
-  EXPECT_EQ(l.out_data_size(), 32u);         // size of output tensors
-  EXPECT_EQ(l.in_data_shape().size(), 1u);   // number of inputs shapes
-  EXPECT_EQ(l.out_data_shape().size(), 1u);  // num of output shapes
-  EXPECT_EQ(l.inputs().size(), 1u);          // num of input edges
-  EXPECT_EQ(l.outputs().size(), 1u);         // num of outpus edges
-  EXPECT_EQ(l.in_types().size(), 1u);        // num of input data types
-  EXPECT_EQ(l.out_types().size(), 1u);       // num of output data types
-  EXPECT_EQ(l.fan_in_size(), 9u);            // num of incoming connections
-  EXPECT_EQ(l.fan_out_size(), 18u);          // num of outgoing connections
-  EXPECT_EQ(l.parameters().size(), 2u);      // num of trainable parameters
-  EXPECT_EQ(l.weights_at().size(), 18u);     // size of weight parameter
-  EXPECT_EQ(l.bias_at().size(), 2u);         // size of bias parameter
+  EXPECT_EQ(l.parallelize(), true);           // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);             // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);            // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 4u);            // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 32u);          // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(), 1u);    // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), 1u);   // num of output shapes
+  EXPECT_EQ(l.inputs().size(), 1u);           // num of input edges
+  EXPECT_EQ(l.outputs().size(), 1u);          // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), 1u);         // num of input data types
+  EXPECT_EQ(l.out_types().size(), 1u);        // num of output data types
+  EXPECT_EQ(l.fan_in_size(), 9u);             // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 18u);           // num of outgoing connections
+  EXPECT_EQ(l.parameters().size(), 2u);       // num of trainable parameters
+  EXPECT_EQ(l.weights_at()[0]->size(), 18u);  // size of weight parameter
+  EXPECT_EQ(l.bias_at()[0]->size(), 2u);      // size of bias parameter
   EXPECT_STREQ(l.layer_type().c_str(), "deconv");  // string with layer type
 }
 
@@ -107,7 +107,7 @@ TEST(deconvolutional, fprop) {
   };
   // clang-format on
 
-  l.weights_at().set_data(Tensor<float_t>(weight));
+  l.weights_at()[0]->set_data(Tensor<float_t>(weight));
   out        = l.forward({{in}});
   out_result = (*out[0])[0];
 
@@ -157,7 +157,7 @@ TEST(deconvolutional, fprop_padding_same) {
   // clang-format on
 
   // resize tensor because its dimension changed in above used test case
-  l.weights_at().set_data(Tensor<float_t>(weight));
+  l.weights_at()[0]->set_data(Tensor<float_t>(weight));
   out        = l.forward({{in}});
   out_result = (*out[0])[0];
 

--- a/test/test_deconvolutional_layer.h
+++ b/test/test_deconvolutional_layer.h
@@ -19,22 +19,22 @@ TEST(deconvolutional, setup_tiny) {
   deconvolutional_layer l(2, 2, 3, 1, 2, padding::valid, true, 1, 1,
                           core::backend_t::internal);
 
-  EXPECT_EQ(l.parallelize(), true);           // if layer can be parallelized
-  EXPECT_EQ(l.in_channels(), 1u);             // num of input tensors
-  EXPECT_EQ(l.out_channels(), 1u);            // num of output tensors
-  EXPECT_EQ(l.in_data_size(), 4u);            // size of input tensors
-  EXPECT_EQ(l.out_data_size(), 32u);          // size of output tensors
-  EXPECT_EQ(l.in_data_shape().size(), 1u);    // number of inputs shapes
-  EXPECT_EQ(l.out_data_shape().size(), 1u);   // num of output shapes
-  EXPECT_EQ(l.inputs().size(), 1u);           // num of input edges
-  EXPECT_EQ(l.outputs().size(), 1u);          // num of outpus edges
-  EXPECT_EQ(l.in_types().size(), 1u);         // num of input data types
-  EXPECT_EQ(l.out_types().size(), 1u);        // num of output data types
-  EXPECT_EQ(l.fan_in_size(), 9u);             // num of incoming connections
-  EXPECT_EQ(l.fan_out_size(), 18u);           // num of outgoing connections
-  EXPECT_EQ(l.parameters().size(), 2u);       // num of trainable parameters
-  EXPECT_EQ(l.ith_parameter(0).size(), 18u);  // size of weight parameter
-  EXPECT_EQ(l.ith_parameter(1).size(), 2u);   // size of bias parameter
+  EXPECT_EQ(l.parallelize(), true);          // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);            // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);           // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 4u);           // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 32u);         // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(), 1u);   // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), 1u);  // num of output shapes
+  EXPECT_EQ(l.inputs().size(), 1u);          // num of input edges
+  EXPECT_EQ(l.outputs().size(), 1u);         // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), 1u);        // num of input data types
+  EXPECT_EQ(l.out_types().size(), 1u);       // num of output data types
+  EXPECT_EQ(l.fan_in_size(), 9u);            // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 18u);          // num of outgoing connections
+  EXPECT_EQ(l.parameters().size(), 2u);      // num of trainable parameters
+  EXPECT_EQ(l.weights_at().size(), 18u);     // size of weight parameter
+  EXPECT_EQ(l.bias_at().size(), 2u);         // size of bias parameter
   EXPECT_STREQ(l.layer_type().c_str(), "deconv");  // string with layer type
 }
 
@@ -43,22 +43,22 @@ TEST(deconvolutional, setup_nnp) {
   deconvolutional_layer l(2, 2, 3, 1, 2, padding::valid, true, 1, 1,
                           backend_t::nnpack);
 
-  EXPECT_EQ(l.parallelize(), true);           // if layer can be parallelized
-  EXPECT_EQ(l.in_channels(), 1u);             // num of input tensors
-  EXPECT_EQ(l.out_channels(), 1u);            // num of output tensors
-  EXPECT_EQ(l.in_data_size(), 4u);            // size of input tensors
-  EXPECT_EQ(l.out_data_size(), 32u);          // size of output tensors
-  EXPECT_EQ(l.in_data_shape().size(), 1u);    // number of inputs shapes
-  EXPECT_EQ(l.out_data_shape().size(), 1u);   // num of output shapes
-  EXPECT_EQ(l.inputs().size(), 1u);           // num of input edges
-  EXPECT_EQ(l.outputs().size(), 1u);          // num of outpus edges
-  EXPECT_EQ(l.in_types().size(), 1u);         // num of input data types
-  EXPECT_EQ(l.out_types().size(), 1u);        // num of output data types
-  EXPECT_EQ(l.fan_in_size(), 9u);             // num of incoming connections
-  EXPECT_EQ(l.fan_out_size(), 18u);           // num of outgoing connections
-  EXPECT_EQ(l.parameters().size(), 2u);       // num of trainable parameters
-  EXPECT_EQ(l.ith_parameter(0).size(), 18u);  // size of weight parameter
-  EXPECT_EQ(l.ith_parameter(1).size(), 2u);   // size of bias parameter
+  EXPECT_EQ(l.parallelize(), true);          // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);            // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);           // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 4u);           // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 32u);         // size of output tensors
+  EXPECT_EQ(l.in_data_shape().size(), 1u);   // number of inputs shapes
+  EXPECT_EQ(l.out_data_shape().size(), 1u);  // num of output shapes
+  EXPECT_EQ(l.inputs().size(), 1u);          // num of input edges
+  EXPECT_EQ(l.outputs().size(), 1u);         // num of outpus edges
+  EXPECT_EQ(l.in_types().size(), 1u);        // num of input data types
+  EXPECT_EQ(l.out_types().size(), 1u);       // num of output data types
+  EXPECT_EQ(l.fan_in_size(), 9u);            // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 18u);          // num of outgoing connections
+  EXPECT_EQ(l.parameters().size(), 2u);      // num of trainable parameters
+  EXPECT_EQ(l.weights_at().size(), 18u);     // size of weight parameter
+  EXPECT_EQ(l.bias_at().size(), 2u);         // size of bias parameter
   EXPECT_STREQ(l.layer_type().c_str(), "deconv");  // string with layer type
 }
 #endif
@@ -107,7 +107,7 @@ TEST(deconvolutional, fprop) {
   };
   // clang-format on
 
-  l.ith_parameter(0).set_data(Tensor<float_t>(weight));
+  l.weights_at().set_data(Tensor<float_t>(weight));
   out        = l.forward({{in}});
   out_result = (*out[0])[0];
 
@@ -157,7 +157,7 @@ TEST(deconvolutional, fprop_padding_same) {
   // clang-format on
 
   // resize tensor because its dimension changed in above used test case
-  l.ith_parameter(0).set_data(Tensor<float_t>(weight));
+  l.weights_at().set_data(Tensor<float_t>(weight));
   out        = l.forward({{in}});
   out_result = (*out[0])[0];
 

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -20,16 +20,16 @@ namespace tiny_dnn {
 TEST(fully_connected, setup_internal) {
   fully_connected_layer l(32, 10, true, core::backend_t::internal);
 
-  EXPECT_EQ(l.parallelize(), true);        // if layer can be parallelized
-  EXPECT_EQ(l.in_channels(), 1u);          // num of input tensors
-  EXPECT_EQ(l.out_channels(), 1u);         // num of output tensors
-  EXPECT_EQ(l.in_data_size(), 32u);        // size of input tensors
-  EXPECT_EQ(l.out_data_size(), 10u);       // size of output tensors
-  EXPECT_EQ(l.fan_in_size(), 32u);         // num of incoming connections
-  EXPECT_EQ(l.fan_out_size(), 10u);        // num of outgoing connections
-  EXPECT_EQ(l.parameters().size(), 2u);    // num of trainable parameters
-  EXPECT_EQ(l.weights_at().size(), 320u);  // size of weight parameter
-  EXPECT_EQ(l.bias_at().size(), 10u);      // size of bias parameter
+  EXPECT_EQ(l.parallelize(), true);            // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);              // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);             // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 32u);            // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 10u);           // size of output tensors
+  EXPECT_EQ(l.fan_in_size(), 32u);             // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 10u);            // num of outgoing connections
+  EXPECT_EQ(l.parameters().size(), 2u);        // num of trainable parameters
+  EXPECT_EQ(l.weights_at()[0]->size(), 320u);  // size of weight parameter
+  EXPECT_EQ(l.bias_at()[0]->size(), 10u);      // size of bias parameter
   EXPECT_STREQ(l.layer_type().c_str(),
                "fully-connected");  // string with layer type
 }
@@ -47,8 +47,8 @@ TEST(fully_connected, forward) {
   // clang-format on
   vec_t expected = {24, 42};
 
-  l.weights_at().set_data(Tensor<float_t>(weights));
-  l.bias_at().set_data(Tensor<float_t>(bias));
+  l.weights_at()[0]->set_data(Tensor<float_t>(weights));
+  l.bias_at()[0]->set_data(Tensor<float_t>(bias));
 
   auto out     = l.forward({{in}});
   vec_t result = (*out[0])[0];

--- a/test/test_fully_connected_layer.h
+++ b/test/test_fully_connected_layer.h
@@ -20,16 +20,16 @@ namespace tiny_dnn {
 TEST(fully_connected, setup_internal) {
   fully_connected_layer l(32, 10, true, core::backend_t::internal);
 
-  EXPECT_EQ(l.parallelize(), true);            // if layer can be parallelized
-  EXPECT_EQ(l.in_channels(), 1u);              // num of input tensors
-  EXPECT_EQ(l.out_channels(), 1u);             // num of output tensors
-  EXPECT_EQ(l.in_data_size(), 32u);            // size of input tensors
-  EXPECT_EQ(l.out_data_size(), 10u);           // size of output tensors
-  EXPECT_EQ(l.fan_in_size(), 32u);             // num of incoming connections
-  EXPECT_EQ(l.fan_out_size(), 10u);            // num of outgoing connections
-  EXPECT_EQ(l.parameters().size(), 2u);        // num of trainable parameters
-  EXPECT_EQ(l.ith_parameter(0).size(), 320u);  // size of weight parameter
-  EXPECT_EQ(l.ith_parameter(1).size(), 10u);   // size of bias parameter
+  EXPECT_EQ(l.parallelize(), true);        // if layer can be parallelized
+  EXPECT_EQ(l.in_channels(), 1u);          // num of input tensors
+  EXPECT_EQ(l.out_channels(), 1u);         // num of output tensors
+  EXPECT_EQ(l.in_data_size(), 32u);        // size of input tensors
+  EXPECT_EQ(l.out_data_size(), 10u);       // size of output tensors
+  EXPECT_EQ(l.fan_in_size(), 32u);         // num of incoming connections
+  EXPECT_EQ(l.fan_out_size(), 10u);        // num of outgoing connections
+  EXPECT_EQ(l.parameters().size(), 2u);    // num of trainable parameters
+  EXPECT_EQ(l.weights_at().size(), 320u);  // size of weight parameter
+  EXPECT_EQ(l.bias_at().size(), 10u);      // size of bias parameter
   EXPECT_STREQ(l.layer_type().c_str(),
                "fully-connected");  // string with layer type
 }
@@ -47,8 +47,8 @@ TEST(fully_connected, forward) {
   // clang-format on
   vec_t expected = {24, 42};
 
-  l.ith_parameter(0).set_data(Tensor<float_t>(weights));
-  l.ith_parameter(1).set_data(Tensor<float_t>(bias));
+  l.weights_at().set_data(Tensor<float_t>(weights));
+  l.bias_at().set_data(Tensor<float_t>(bias));
 
   auto out     = l.forward({{in}});
   vec_t result = (*out[0])[0];

--- a/tiny_dnn/core/backend_tiny.h
+++ b/tiny_dnn/core/backend_tiny.h
@@ -95,9 +95,9 @@ class tiny_backend : public backend {
   void conv2d_q(const std::vector<tensor_t *> &in_data,
                 std::vector<tensor_t *> &out_data) override {
     copy_and_pad_input(*in_data[0]);
-    const vec_t W = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W = layer_->parameter_at(0).data()->toVec();
     const vec_t b =
-      params_c_->has_bias ? layer_->ith_parameter(1).data()->toVec() : vec_t();
+      params_c_->has_bias ? layer_->parameter_at(1).data()->toVec() : vec_t();
     tensor_t &out = *out_data[0];
     const std::vector<const vec_t *> &in =
       (*conv_layer_worker_storage_).prev_out_padded_;  // input // NOLINT
@@ -114,15 +114,15 @@ class tiny_backend : public backend {
   void conv2d_eq(const std::vector<tensor_t *> &in_data,
                  std::vector<tensor_t *> &out_data) override {
     copy_and_pad_input(*in_data[0]);
-    const vec_t W = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W = layer_->parameter_at(0).data()->toVec();
     const vec_t b =
-      params_c_->has_bias ? layer_->ith_parameter(1).data()->toVec() : vec_t();
+      params_c_->has_bias ? layer_->parameter_at(1).data()->toVec() : vec_t();
     const tensor_t &in_r = *in_data[1];
     const vec_t W_r      = params_c_->has_bias
-                        ? layer_->ith_parameter(2).data()->toVec()
-                        : layer_->ith_parameter(1).data()->toVec();
+                        ? layer_->parameter_at(2).data()->toVec()
+                        : layer_->parameter_at(1).data()->toVec();
     const vec_t b_r =
-      params_c_->has_bias ? layer_->ith_parameter(3).data()->toVec() : vec_t();
+      params_c_->has_bias ? layer_->parameter_at(3).data()->toVec() : vec_t();
     tensor_t &out   = *out_data[0];
     tensor_t &out_r = *out_data[1];
 
@@ -144,9 +144,9 @@ class tiny_backend : public backend {
     conv_layer_worker_specific_storage &cws = (*conv_layer_worker_storage_);
 
     std::vector<const vec_t *> &prev_out = cws.prev_out_padded_;
-    const vec_t W        = layer_->ith_parameter(0).data()->toVec();
-    tensor_t dW          = layer_->ith_parameter(0).grad()->toTensor();
-    tensor_t db          = layer_->ith_parameter(1).grad()->toTensor();
+    const vec_t W        = layer_->parameter_at(0).data()->toVec();
+    tensor_t dW          = layer_->parameter_at(0).grad()->toTensor();
+    tensor_t db          = layer_->parameter_at(1).grad()->toTensor();
     tensor_t &curr_delta = *out_grad[0];
     tensor_t *prev_delta = (params_c_->pad_type == padding::same)
                              ? &cws.prev_delta_padded_
@@ -164,8 +164,8 @@ class tiny_backend : public backend {
       kernels::tiny_quantized_conv2d_back_kernel(*params_c_, *prev_out[i], W,
                                                  dW[i], db[i], curr_delta[i],
                                                  &(*prev_delta)[i]);
-      layer_->ith_parameter(0).set_grad(Tensor<>(dW));
-      layer_->ith_parameter(1).set_grad(Tensor<>(db));
+      layer_->parameter_at(0).set_grad(Tensor<>(dW));
+      layer_->parameter_at(1).set_grad(Tensor<>(db));
     }
 
     if (params_c_->pad_type == padding::same) {
@@ -178,9 +178,9 @@ class tiny_backend : public backend {
                   std::vector<tensor_t *> &out_data) override {
     (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
     const tensor_t &in                        = *in_data[0];  // input
-    const vec_t W = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W = layer_->parameter_at(0).data()->toVec();
     const vec_t b =
-      params_d_->has_bias ? layer_->ith_parameter(1).data()->toVec() : vec_t();
+      params_d_->has_bias ? layer_->parameter_at(1).data()->toVec() : vec_t();
     tensor_t &out = *out_data[0];
 
     fill_tensor(
@@ -201,15 +201,15 @@ class tiny_backend : public backend {
                    std::vector<tensor_t *> &out_data) override {
     (*deconv_layer_worker_storage_).prev_out_ = in_data[0];
     const tensor_t &in                        = *in_data[0];  // input
-    const vec_t W = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W = layer_->parameter_at(0).data()->toVec();
     const vec_t b =
-      params_d_->has_bias ? layer_->ith_parameter(1).data()->toVec() : vec_t();
+      params_d_->has_bias ? layer_->parameter_at(1).data()->toVec() : vec_t();
     const tensor_t &in_r = *in_data[1];
     const vec_t W_r      = params_d_->has_bias
-                        ? layer_->ith_parameter(2).data()->toVec()
-                        : layer_->ith_parameter(1).data()->toVec();
+                        ? layer_->parameter_at(2).data()->toVec()
+                        : layer_->parameter_at(1).data()->toVec();
     const vec_t b_r =
-      params_d_->has_bias ? layer_->ith_parameter(3).data()->toVec() : vec_t();
+      params_d_->has_bias ? layer_->parameter_at(3).data()->toVec() : vec_t();
     tensor_t &out   = *out_data[0];
     tensor_t &out_r = *out_data[1];
 
@@ -236,9 +236,9 @@ class tiny_backend : public backend {
       copy_and_pad_delta(cws.curr_delta_padded, *in_grad[0]);
 
     const tensor_t &prev_out = *(cws.prev_out_);
-    const vec_t W            = layer_->ith_parameter(0).data()->toVec();
-    tensor_t dW              = layer_->ith_parameter(0).grad()->toTensor();
-    tensor_t db              = layer_->ith_parameter(1).grad()->toTensor();
+    const vec_t W            = layer_->parameter_at(0).data()->toVec();
+    tensor_t dW              = layer_->parameter_at(0).grad()->toTensor();
+    tensor_t db              = layer_->parameter_at(1).grad()->toTensor();
     tensor_t &curr_delta     = (params_d_->pad_type == padding::same)
                              ? cws.curr_delta_padded
                              : *out_grad[1];
@@ -256,8 +256,8 @@ class tiny_backend : public backend {
       kernels::tiny_quantized_deconv2d_back_kernel(*params_d_, prev_out[i], W,
                                                    dW[i], db[i], curr_delta[i],
                                                    &(*prev_delta)[i]);
-      layer_->ith_parameter(0).set_grad(Tensor<>(dW));
-      layer_->ith_parameter(1).set_grad(Tensor<>(db));
+      layer_->parameter_at(0).set_grad(Tensor<>(dW));
+      layer_->parameter_at(1).set_grad(Tensor<>(db));
     }
   }
 
@@ -265,7 +265,7 @@ class tiny_backend : public backend {
                std::vector<tensor_t *> &out_data) override {
 #ifdef CNN_USE_GEMMLOWP
     const tensor_t &in = *in_data[0];
-    const vec_t W      = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W      = layer_->parameter_at(0).data()->toVec();
     tensor_t &out      = *out_data[0];
 
     for (size_t i = 0; i < in.size(); i++) {
@@ -286,15 +286,15 @@ class tiny_backend : public backend {
                 std::vector<tensor_t *> &out_data) override {
 #ifdef CNN_USE_GEMMLOWP
     const tensor_t &in = *in_data[0];
-    const vec_t W      = layer_->ith_parameter(0).data()->toVec();
+    const vec_t W      = layer_->parameter_at(0).data()->toVec();
     vec_t b =
-      params_f_->has_bias_ ? layer_->ith_parameter(1).data()->toVec() : vec_t();
+      params_f_->has_bias_ ? layer_->parameter_at(1).data()->toVec() : vec_t();
     const tensor_t &in_r = *in_data[1];
     const vec_t W_r      = params_f_->has_bias_
-                        ? layer_->ith_parameter(2).data()->toVec()
-                        : layer_->ith_parameter(1).data()->toVec();
+                        ? layer_->parameter_at(2).data()->toVec()
+                        : layer_->parameter_at(1).data()->toVec();
     const vec_t b_r =
-      params_f_->has_bias_ ? layer_->ith_parameter(3).data()->toVec() : vec_t();
+      params_f_->has_bias_ ? layer_->parameter_at(3).data()->toVec() : vec_t();
     tensor_t &out   = *out_data[0];
     tensor_t &out_r = *out_data[1];
 
@@ -318,9 +318,9 @@ class tiny_backend : public backend {
                std::vector<tensor_t *> &in_grad) override {
 #ifdef CNN_USE_GEMMLOWP
     const tensor_t &prev_out = *in_data[0];
-    const vec_t W            = layer_->ith_parameter(0).data()->toVec();
-    tensor_t dW              = layer_->ith_parameter(0).grad()->toTensor();
-    tensor_t db              = layer_->ith_parameter(1).grad()->toTensor();
+    const vec_t W            = layer_->parameter_at(0).data()->toVec();
+    tensor_t dW              = layer_->parameter_at(0).grad()->toTensor();
+    tensor_t db              = layer_->parameter_at(1).grad()->toTensor();
     tensor_t &prev_delta     = *in_grad[0];
     tensor_t &curr_delta     = *out_grad[0];
 
@@ -330,8 +330,8 @@ class tiny_backend : public backend {
       kernels::tiny_quantized_fully_connected_back_kernel(
         *params_f_, prev_out[i], W, dW[i], prev_delta[i], curr_delta[i], db[i],
         layer_->parallelize());
-      layer_->ith_parameter(0).set_grad(Tensor<>(dW));
-      layer_->ith_parameter(1).set_grad(Tensor<>(db));
+      layer_->parameter_at(0).set_grad(Tensor<>(dW));
+      layer_->parameter_at(1).set_grad(Tensor<>(db));
     }
 #else
     CNN_UNREFERENCED_PARAMETER(in_data);

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -198,8 +198,8 @@ class average_pooling_layer : public layer {
     Tensor<> out      = Tensor<>(*out_data[0]);
     out.fill(0);
 
-    const Tensor<> weights = *(layer::ith_parameter(0).data());
-    const Tensor<> bias    = *(layer::ith_parameter(1).data());
+    const Tensor<> weights = *(layer::parameter_at(0).data());
+    const Tensor<> bias    = *(layer::parameter_at(1).data());
 
     tiny_average_pooling_kernel(in, weights, bias, out, params_, aws_,
                                 parallelize_);
@@ -216,10 +216,10 @@ class average_pooling_layer : public layer {
     Tensor<> prev_delta     = Tensor<>(*in_grad[0]);
     Tensor<> curr_delta     = Tensor<>(*out_grad[0]);
 
-    const Tensor<> weights = *(layer::ith_parameter(0).data());
-    const Tensor<> bias    = *(layer::ith_parameter(1).data());
-    Tensor<> weights_grads = *(layer::ith_parameter(0).grad());
-    Tensor<> bias_grads    = *(layer::ith_parameter(1).grad());
+    const Tensor<> weights = *(layer::parameter_at(0).data());
+    const Tensor<> bias    = *(layer::parameter_at(1).data());
+    Tensor<> weights_grads = *(layer::parameter_at(0).grad());
+    Tensor<> bias_grads    = *(layer::parameter_at(1).grad());
 
     prev_delta.fill(0);
 
@@ -227,8 +227,8 @@ class average_pooling_layer : public layer {
                                      bias_grads, curr_delta, prev_delta,
                                      params_, aws_, parallelize_);
     *in_grad[0] = prev_delta.toTensor();
-    layer::ith_parameter(0).set_data(weights_grads);
-    layer::ith_parameter(1).set_data(bias_grads);
+    layer::parameter_at(0).set_data(weights_grads);
+    layer::parameter_at(1).set_data(bias_grads);
   }
 
   std::pair<size_t, size_t> pool_size() const {

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -150,8 +150,8 @@ class average_unpooling_layer : public layer {
     Tensor<> out      = Tensor<>(*out_data[0]);
     out.fill(0);
 
-    const Tensor<> weights = *(layer::weights_at().data());
-    const Tensor<> biases  = *(layer::bias_at().data());
+    const Tensor<> weights = *(layer::weights_at()[0]->data());
+    const Tensor<> biases  = *(layer::bias_at()[0]->data());
 
     tiny_average_unpooling_kernel(in, weights, biases, out, params_, auws_,
                                   parallelize());
@@ -168,10 +168,10 @@ class average_unpooling_layer : public layer {
     Tensor<> prev_delta     = Tensor<>(*in_grad[0]);
     Tensor<> curr_delta     = Tensor<>(*out_grad[0]);
 
-    const Tensor<> weights = *(layer::weights_at().data());
-    const Tensor<> bias    = *(layer::bias_at().data());
-    Tensor<> weights_grads = *(layer::weights_at().grad());
-    Tensor<> bias_grads    = *(layer::bias_at().grad());
+    const Tensor<> weights = *(layer::weights_at()[0]->data());
+    const Tensor<> bias    = *(layer::bias_at()[0]->data());
+    Tensor<> weights_grads = *(layer::weights_at()[0]->grad());
+    Tensor<> bias_grads    = *(layer::bias_at()[0]->grad());
 
     prev_delta.fill(0);
 
@@ -179,8 +179,8 @@ class average_unpooling_layer : public layer {
                                        bias_grads, curr_delta, prev_delta,
                                        params_, auws_, parallelize_);
     *in_grad[0] = prev_delta.toTensor();
-    layer::weights_at().set_data(weights_grads);
-    layer::bias_at().set_data(bias_grads);
+    layer::weights_at()[0]->set_data(weights_grads);
+    layer::bias_at()[0]->set_data(bias_grads);
   }
 
   friend struct serialization_buddy;

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -150,8 +150,8 @@ class average_unpooling_layer : public layer {
     Tensor<> out      = Tensor<>(*out_data[0]);
     out.fill(0);
 
-    const Tensor<> weights = *(layer::ith_parameter(0).data());
-    const Tensor<> biases  = *(layer::ith_parameter(1).data());
+    const Tensor<> weights = *(layer::weights_at().data());
+    const Tensor<> biases  = *(layer::bias_at().data());
 
     tiny_average_unpooling_kernel(in, weights, biases, out, params_, auws_,
                                   parallelize());
@@ -168,10 +168,10 @@ class average_unpooling_layer : public layer {
     Tensor<> prev_delta     = Tensor<>(*in_grad[0]);
     Tensor<> curr_delta     = Tensor<>(*out_grad[0]);
 
-    const Tensor<> weights = *(layer::ith_parameter(0).data());
-    const Tensor<> bias    = *(layer::ith_parameter(1).data());
-    Tensor<> weights_grads = *(layer::ith_parameter(0).grad());
-    Tensor<> bias_grads    = *(layer::ith_parameter(1).grad());
+    const Tensor<> weights = *(layer::weights_at().data());
+    const Tensor<> bias    = *(layer::bias_at().data());
+    Tensor<> weights_grads = *(layer::weights_at().grad());
+    Tensor<> bias_grads    = *(layer::bias_at().grad());
 
     prev_delta.fill(0);
 
@@ -179,8 +179,8 @@ class average_unpooling_layer : public layer {
                                        bias_grads, curr_delta, prev_delta,
                                        params_, auws_, parallelize_);
     *in_grad[0] = prev_delta.toTensor();
-    layer::ith_parameter(0).set_data(weights_grads);
-    layer::ith_parameter(1).set_data(bias_grads);
+    layer::weights_at().set_data(weights_grads);
+    layer::bias_at().set_data(bias_grads);
   }
 
   friend struct serialization_buddy;

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -412,10 +412,9 @@ class layer : public node {
    */
   Parameters parameters(bool trainable_only = false) {
     Parameters parameters;
-    for (size_t i = 0; i < parameters_.size(); i++) {
-      if (!trainable_only ||
-          (parameter_at(i).is_trainable() && trainable_only)) {
-        parameters.push_back(&parameter_at(i));
+    for (auto &parameter : parameters_) {
+      if (!trainable_only || (parameter->is_trainable() && trainable_only)) {
+        parameters.push_back(parameter.get());
       }
     }
     return parameters;
@@ -423,10 +422,9 @@ class layer : public node {
 
   ConstParameters parameters(bool trainable_only = false) const {
     ConstParameters parameters;
-    for (size_t i = 0; i < parameters_.size(); i++) {
-      if (!trainable_only ||
-          (parameter_at(i).is_trainable() && trainable_only)) {
-        parameters.push_back(&parameter_at(i));
+    for (auto &parameter : parameters_) {
+      if (!trainable_only || (parameter->is_trainable() && trainable_only)) {
+        parameters.push_back(parameter.get());
       }
     }
     return parameters;
@@ -449,8 +447,8 @@ class layer : public node {
           fetched   = true;
         } else {
           nn_warn("Layer " + layer_type() +
-                  " contains more than "
-                  "one weights parameters, returning first only!\n");
+                  " contains more than one weights"
+                  " parameters, returning first only!\n");
         }
       }
     }
@@ -469,9 +467,9 @@ class layer : public node {
         bias_p  = parameter.get();
         fetched = true;
       } else if (fetched) {
-        nn_warn(
-          "Layer " + layer_type() +
-          "contains more than one bias parameters, returning first only!");
+        nn_warn("Layer " + layer_type() +
+                " contains more than one bias"
+                " parameters, returning first only!\n");
       }
     }
     return *bias_p;

--- a/tiny_dnn/layers/layer.h
+++ b/tiny_dnn/layers/layer.h
@@ -437,46 +437,48 @@ class layer : public node {
   const Parameter &parameter_at(size_t i) const { return *parameters_[i]; }
 
   /** Convenience method to access and manipulate weights. */
-  Parameter &weights_at() {
-    Parameter *weights_p = nullptr;
-    bool fetched         = false;
+  Parameters weights_at() {
+    Parameters weights;
     for (auto &parameter : parameters_) {
       if (parameter->type() == parameter_type::weight) {
-        if (!fetched) {
-          weights_p = parameter.get();
-          fetched   = true;
-        } else {
-          nn_warn("Layer " + layer_type() +
-                  " contains more than one weights"
-                  " parameters, returning first only!\n");
-        }
+        weights.push_back(parameter.get());
       }
     }
-    return *weights_p;
+    return weights;
   }
 
   /** Convenience method to access and analyze particular weights. */
-  const Parameter &weights_at() const { return weights_at(); }
-
-  /** Convenience method to access and manipulate particular bias. */
-  Parameter &bias_at() {
-    Parameter *bias_p = nullptr;
-    bool fetched      = false;
+  ConstParameters weights_at() const {
+    ConstParameters weights;
     for (auto &parameter : parameters_) {
-      if (parameter->type() == parameter_type::bias && !fetched) {
-        bias_p  = parameter.get();
-        fetched = true;
-      } else if (fetched) {
-        nn_warn("Layer " + layer_type() +
-                " contains more than one bias"
-                " parameters, returning first only!\n");
+      if (parameter->type() == parameter_type::weight) {
+        weights.push_back(parameter.get());
       }
     }
-    return *bias_p;
+    return weights;
+  }
+
+  /** Convenience method to access and manipulate particular bias. */
+  Parameters bias_at() {
+    Parameters biases;
+    for (auto &parameter : parameters_) {
+      if (parameter->type() == parameter_type::bias) {
+        biases.push_back(parameter.get());
+      }
+    }
+    return biases;
   }
 
   /** Convenience method to access and analyze particular biases. */
-  const Parameter &bias_at() const { return bias_at(); }
+  ConstParameters bias_at() const {
+    ConstParameters biases;
+    for (auto &parameter : parameters_) {
+      if (parameter->type() == parameter_type::bias) {
+        biases.push_back(parameter.get());
+      }
+    }
+    return biases;
+  }
 
   /** @} */  // Parameter Getters and Setters
 


### PR DESCRIPTION
This PR introduces certain convenient getters setters for avoiding confusions. Generic getters setters related to parameters continue to be there for internal usage (kernels and optimizers). 