### PR TITLE
Restructure kernels of average pooling layer.

### DIFF
--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -101,12 +101,11 @@ TEST(ave_pool, forward) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  std::vector<const tensor_t*> out;
-  l.forward({{in}}, out);
+  auto out = l.forward({{in}});
   vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
-    EXPECT_FLOAT_EQ(expected[i], res[i]);
+    EXPECT_NEAR(expected[i], res[i], 1E-7);
   }
 }
 
@@ -131,12 +130,11 @@ TEST(ave_pool, forward_stride) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  std::vector<const tensor_t*> out;
-  l.forward({{in}}, out);
+  auto out = l.forward({{in}});
   vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
-    EXPECT_FLOAT_EQ(expected[i], res[i]);
+    EXPECT_NEAR(expected[i], res[i], 1E-7);
   }
 }
 
@@ -155,12 +153,12 @@ TEST(ave_pool, backward) {
       0,-1,-2,-3
   };
 
-  vec_t out_grad = {
+  vec_t curr_delta = {
       1, 2,
       3, 4
   };
 
-  vec_t curr_delta_expected = {
+  vec_t prev_delta_expected = {
       0.25, 0.25, 0.5, 0.5,
       0.25, 0.25, 0.5, 0.5,
       0.75, 0.75, 1.0, 1.0,
@@ -175,21 +173,22 @@ TEST(ave_pool, backward) {
   vec_t db_expected = {10};
   // clang-format on
 
-  std::vector<tensor_t> in_grad = l.backward(std::vector<tensor_t>{{out_grad}});
-  vec_t curr_delta_result       = in_grad[0][0];
-  vec_t dw_result               = in_grad[1][0];
-  vec_t db_result               = in_grad[2][0];
+  std::vector<tensor_t> in_grad =
+    l.backward(std::vector<tensor_t>{{curr_delta}});
+  vec_t prev_delta_result = in_grad[0][0];
+  vec_t dw_result         = in_grad[1][0];
+  vec_t db_result         = in_grad[2][0];
 
-  for (size_t i = 0; i < curr_delta_expected.size(); i++) {
-    EXPECT_FLOAT_EQ(curr_delta_result[i], curr_delta_expected[i]);
+  for (size_t i = 0; i < prev_delta_expected.size(); i++) {
+    EXPECT_NEAR(prev_delta_result[i], prev_delta_expected[i], 1E-7);
   }
 
   for (size_t i = 0; i < dw_expected.size(); i++) {
-    EXPECT_FLOAT_EQ(dw_result[i], dw_expected[i]);
+    EXPECT_NEAR(dw_result[i], dw_expected[i], 1E-7);
   }
 
   for (size_t i = 0; i < db_expected.size(); i++) {
-    EXPECT_FLOAT_EQ(db_result[i], db_expected[i]);
+    EXPECT_NEAR(db_result[i], db_expected[i], 1E-7);
   }
 }
 

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -140,6 +140,59 @@ TEST(ave_pool, forward_stride) {
   }
 }
 
+TEST(ave_pool, backward) {
+  average_pooling_layer l(4, 4, 1, 2);
+
+  l.weight_init(weight_init::constant(1.0));
+  l.bias_init(weight_init::constant(1.0));
+  l.init_weight();
+
+  // clang-format off
+  vec_t in = {
+      0, 1, 2, 3,
+      8, 7, 5, 6,
+      4, 3, 1, 2,
+      0,-1,-2,-3
+  };
+
+  vec_t out_grad = {
+      1, 2,
+      3, 4
+  };
+
+  vec_t curr_delta_expected = {
+      0.25, 0.25, 0.5, 0.5,
+      0.25, 0.25, 0.5, 0.5,
+      0.75, 0.75, 1.0, 1.0,
+      0.75, 0.75, 1.0, 1.0
+  };
+
+  vec_t dw_expected = {
+      0, 0,
+      0, 0
+  };
+
+  vec_t db_expected = {10};
+  // clang-format on
+
+  std::vector<tensor_t> in_grad = l.backward(std::vector<tensor_t>{{out_grad}});
+  vec_t curr_delta_result       = in_grad[0][0];
+  vec_t dw_result               = in_grad[1][0];
+  vec_t db_result               = in_grad[2][0];
+
+  for (size_t i = 0; i < curr_delta_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(curr_delta_result[i], curr_delta_expected[i]);
+  }
+
+  for (size_t i = 0; i < dw_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(dw_result[i], dw_expected[i]);
+  }
+
+  for (size_t i = 0; i < db_expected.size(); i++) {
+    EXPECT_FLOAT_EQ(db_result[i], db_expected[i]);
+  }
+}
+
 TEST(ave_pool, read_write) {
   average_pooling_layer l1(100, 100, 5, 2);
   average_pooling_layer l2(100, 100, 5, 2);

--- a/tiny_dnn/core/params/avepool_params.h
+++ b/tiny_dnn/core/params/avepool_params.h
@@ -1,0 +1,56 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+#include "tiny_dnn/core/params/params.h"
+
+namespace tiny_dnn {
+namespace core {
+
+struct average_pooling_layer_worker_specific_storage {
+  using io_connections = std::vector<std::pair<size_t, size_t>>;
+  using wi_connections = std::vector<std::pair<size_t, size_t>>;
+  using wo_connections = std::vector<std::pair<size_t, size_t>>;
+
+  std::vector<io_connections> weight2io;  // weight_id -> [(in_id, out_id)]
+  std::vector<wi_connections> out2wi;     // out_id -> [(weight_id, in_id)]
+  std::vector<wo_connections> in2wo;      // in_id -> [(weight_id, out_id)]
+
+  std::vector<std::vector<size_t>> bias2out;
+  std::vector<size_t> out2bias;
+
+  average_pooling_layer_worker_specific_storage() {}
+
+  average_pooling_layer_worker_specific_storage(size_t weight2io_size,
+                                                size_t out2wi_size,
+                                                size_t in2wo_size,
+                                                size_t bias2out_size,
+                                                size_t out2bias_size)
+    : weight2io(weight2io_size),
+      out2wi(out2wi_size),
+      in2wo(in2wo_size),
+      bias2out(bias2out_size),
+      out2bias(out2bias_size) {}
+};
+
+class avepool_params : public Params {
+ public:
+  shape3d in;
+  shape3d out;
+  shape3d window;
+  size_t stride_x;
+  size_t stride_y;
+  padding pad_type;
+  float_t scale_factor;
+};
+
+inline avepool_params &Params::avepool() {
+  return *(static_cast<avepool_params *>(this));
+}
+
+}  // namespace core
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -10,6 +10,7 @@
 namespace tiny_dnn {
 namespace core {
 
+class avepool_params;
 class conv_params;
 class deconv_params;
 class fully_params;
@@ -22,6 +23,7 @@ class Params {
  public:
   Params() {}
 
+  avepool_params &avepool();
   conv_params &conv();
   deconv_params &deconv();
   fully_params &fully();

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -574,12 +574,11 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::average_pooling_layer &layer) {
-    arc(ar, make_nvp("in_size", layer.in_),
-        make_nvp("pool_size_x", layer.pool_size_x_),
-        make_nvp("pool_size_y", layer.pool_size_y_),
-        make_nvp("stride_x", layer.stride_x_),
-        make_nvp("stride_y", layer.stride_y_),
-        make_nvp("pad_type", layer.pad_type_));
+    auto &params_ = layer.params_;
+    arc(ar, make_nvp("in_size", params_.in), make_nvp("window", params_.window),
+        make_nvp("stride_x", params_.stride_x),
+        make_nvp("stride_y", params_.stride_y),
+        make_nvp("pad_type", params_.pad_type));
   }
 
   template <class Archive>


### PR DESCRIPTION
This PR declares `avepool_params` and `average_pooling_worker_specific_storage` and passes them accordingly to kernels. Although we are planning to get rid of `params` since most of the information is in `Tensor`, it is beneficial to keep uniformity for easy migration further.

This helps in integrating parameter API within easily.