### PR TITLE
Add basic timing benchmarks for fully connected op kernel.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,8 @@ cache:
   pip: true
   directories:
     - $HOME/.pip-cache/
+    # store old benchmarks binary here for comparison
+    - $HOME/.benchmarks/
 
 addons:
   apt:
@@ -48,6 +50,7 @@ env:
     - USE_TBB=ON
     - BUILD_TESTS=ON
     - BUILD_EXAMPLES=ON
+    - BUILD_BENCHMARKS=OFF
     - COVERALLS=ON
 
   matrix:
@@ -59,6 +62,11 @@ matrix:
   exclude: # On OSX g++ is a symlink to clang++ by default
     - os: osx
       compiler: gcc
+
+  include:
+    - os: linux
+      compiler: gcc
+      env: BUILD_BENCHMARKS=ON USE_AVX=ON
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then
@@ -82,7 +90,8 @@ before_script:
             -DBUILD_TESTS=$BUILD_TESTS
             -DCOVERALLS=$COVERALLS
             -DUSE_ASAN=ON
-            -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
+            -DBUILD_EXAMPLES=$BUILD_EXAMPLES
+            -DBUILD_BENCHMARKS=$BUILD_BENCHMARKS .;
     fi
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "clang++" ]; then
       cmake -DUSE_SSE=$USE_SSE
@@ -97,8 +106,24 @@ before_script:
     fi
 
 script:
-  - make -j2
-  - test/tiny_dnn_test
+  - if [ "$BUILD_BENCHMARKS" == "ON" ]; then
+      make tiny_dnn_benchmarks;
+      benchmarks/tiny_dnn_benchmarks;
+
+      if [ -f "$HOME/.benchmarks/tiny_dnn_benchmarks" ]; then
+        ./benchmark-src/tools/compare_bench.py $HOME/.benchmarks/tiny_dnn_benchmarks benchmarks/tiny_dnn_benchmarks;
+      else
+        echo "No previous benchmarks binary to compare with, skipping comparison!";
+      fi
+
+      cp benchmarks/tiny_dnn_benchmarks $HOME/.benchmarks;
+      echo "Saved current benchmarks binary for next build.";
+
+    else
+      make -j2;
+      test/tiny_dnn_test;
+    fi
+
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++-4.8" ] && [ "$USE_SSE" == "ON" ] && [ "$USE_AVX" == "ON" ] && [ "$USE_DOUBLE" == "ON" ]; then
       make clang-format-check;
     fi

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -11,6 +11,7 @@
 #include "benchmark/benchmark.h"
 #include "tiny_dnn/tiny_dnn.h"
 
+#include "bm_fully_connected.h"
 #include "bm_global_avepool.h"
 using namespace tiny_dnn::benchmarks;
 

--- a/benchmarks/benchmarks.cpp
+++ b/benchmarks/benchmarks.cpp
@@ -12,7 +12,10 @@
 #include "tiny_dnn/tiny_dnn.h"
 
 #include "bm_fully_connected.h"
-#include "bm_global_avepool.h"
+
+// todo (karandesai, Randl): refactor needed after xtensor integration
+//#include "bm_global_avepool.h"
+
 using namespace tiny_dnn::benchmarks;
 
 BENCHMARK_MAIN();

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -26,8 +26,8 @@ class BM_FullyConnectedOp : public bm::Fixture {
     out_size = state.range(1);
     samples  = state.range(2);
 
-    in_data.reshape({1, in_size});
-    out_data.reshape({1, out_size});
+    in_data.reshape({samples, in_size});
+    out_data.reshape({samples, out_size});
     weights.reshape({in_size * out_size});
     bias.reshape({out_size});
 
@@ -104,21 +104,36 @@ BENCHMARK_REGISTER_F(BM_FullyConnectedOp, avx_parallel)
 
 #endif
 
-void bm_fully_connected_grad_internal(bm::State& state) {
-  size_t in_size(state.range(0)), out_size(state.range(1));
+class BM_FullyConnectedGradOp : public bm::Fixture {
+ public:
+  void SetUp(const bm::State& state) {
+    in_size  = state.range(0);
+    out_size = state.range(1);
+    samples  = state.range(2);
 
-  Tensor<> prev_out({1, in_size});
-  Tensor<> weights({in_size * out_size});
-  Tensor<> weights_grads({1, in_size * out_size}), bias_grads({1, out_size});
-  Tensor<> curr_delta({1, out_size}), prev_delta({1, in_size});
+    prev_out.reshape({samples, in_size});
+    weights.reshape({in_size * out_size});
+    weights_grads.reshape({samples, in_size * out_size});
+    bias_grads.reshape({samples, out_size});
+    curr_delta.reshape({samples, out_size});
+    prev_delta.reshape({samples, in_size});
 
-  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
-  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
-  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
-  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+    uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
+    uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+    uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
+    uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
+    uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
+    uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+  }
 
+  void TearDown(const bm::State&) {}
+
+  size_t in_size, out_size, samples;
+  Tensor<> prev_out, curr_delta, prev_delta;
+  Tensor<> weights, weights_grads, bias_grads;
+};
+
+BENCHMARK_DEFINE_F(BM_FullyConnectedGradOp, internal)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_internal(prev_out, weights, weights_grads,
                                          bias_grads, curr_delta, prev_delta,
@@ -126,22 +141,16 @@ void bm_fully_connected_grad_internal(bm::State& state) {
   }
 }
 
-void bm_fully_connected_grad_internal_parallelized(bm::State& state) {
-  size_t in_size(64), out_size(64), samples(state.range(0));
+BENCHMARK_REGISTER_F(FullyConnectedGradOp, internal)
+  ->Args({16, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({64, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 16, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 64, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 256, BM_CONST_SAMPLE_SIZE});
 
-  Tensor<> prev_out({samples, in_size});
-  Tensor<> weights({in_size * out_size});
-  Tensor<> weights_grads({samples, in_size * out_size}),
-    bias_grads({samples, out_size});
-  Tensor<> curr_delta({samples, out_size}), prev_delta({samples, in_size});
-
-  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
-  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
-  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
-  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedGradOp, internal_parallel)
+(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_internal(prev_out, weights, weights_grads,
                                          bias_grads, curr_delta, prev_delta,
@@ -149,73 +158,44 @@ void bm_fully_connected_grad_internal_parallelized(bm::State& state) {
   }
 }
 
-BENCHMARK(bm_fully_connected_grad_internal)
-  ->Args({16, 4})
-  ->Args({64, 4})
-  ->Args({256, 4})
-  ->Args({256, 16})
-  ->Args({256, 64})
-  ->Args({256, 256});
-
-BENCHMARK(bm_fully_connected_grad_internal_parallelized)
-  ->RangeMultiplier(2)
-  ->Range(1, 32);
+BENCHMARK_REGISTER_F(BM_FullyConnectedGradOp, internal_parallel)
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 1})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 2})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 4})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 8})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 16})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 32});
 
 #ifdef CNN_USE_AVX
-void bm_fully_connected_grad_avx(bm::State& state) {
-  size_t in_size(state.range(0)), out_size(state.range(1));
-
-  Tensor<> prev_out({1, in_size});
-  Tensor<> weights({in_size * out_size});
-  Tensor<> weights_grads({1, in_size * out_size}), bias_grads({1, out_size});
-  Tensor<> curr_delta({1, out_size}), prev_delta({1, in_size});
-
-  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
-  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
-  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
-  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedGradOp, avx)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_avx(prev_out, weights, weights_grads,
                                     bias_grads, curr_delta, prev_delta, false);
   }
 }
 
-void bm_fully_connected_grad_avx_parallelized(bm::State& state) {
-  size_t in_size(64), out_size(64), samples(state.range(0));
+BENCHMARK_REGISTER_F(FullyConnectedGradOp, avx)
+  ->Args({16, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({64, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 16, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 64, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 256, BM_CONST_SAMPLE_SIZE});
 
-  Tensor<> prev_out({samples, in_size});
-  Tensor<> weights({in_size * out_size});
-  Tensor<> weights_grads({samples, in_size * out_size}),
-    bias_grads({samples, out_size});
-  Tensor<> curr_delta({samples, out_size}), prev_delta({samples, in_size});
-
-  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
-  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
-  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
-  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedGradOp, avx_parallel)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_avx(prev_out, weights, weights_grads,
                                     bias_grads, curr_delta, prev_delta, true);
   }
 }
 
-BENCHMARK(bm_fully_connected_grad_avx)
-  ->Args({16, 4})
-  ->Args({64, 4})
-  ->Args({256, 4})
-  ->Args({256, 16})
-  ->Args({256, 64})
-  ->Args({256, 256});
-
-BENCHMARK(bm_fully_connected_grad_avx_parallelized)
-  ->RangeMultiplier(2)
-  ->Range(1, 32);
+BENCHMARK_REGISTER_F(BM_FullyConnectedGradOp, avx_parallel)
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 1})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 2})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 4})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 8})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 16})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 32});
 #endif
 
 }  // namespace benchmarks

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -32,15 +32,194 @@ void bm_fully_connected_internal(bm::State& state) {
   }
 }
 
+void bm_fully_connected_internal_parallelized(bm::State& state) {
+  size_t in_size(64), out_size(64), samples(state.range(0));
+
+  Tensor<> in_data({samples, in_size}), out_data({samples, out_size});
+  Tensor<> weights({in_size * out_size}), bias({out_size});
+
+  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
+  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_internal(in_data, weights, bias, out_data,
+                                         true);
+  }
+}
+
 BENCHMARK(bm_fully_connected_internal)
   ->Args({16, 4})
   ->Args({64, 4})
   ->Args({256, 4})
-  ->Args({1024, 4})
-  ->Args({1024, 16})
-  ->Args({1024, 64})
-  ->Args({1024, 256})
-  ->Args({1024, 1024});
+  ->Args({256, 16})
+  ->Args({256, 64})
+  ->Args({256, 256});
+
+BENCHMARK(bm_fully_connected_internal_parallelized)
+  ->RangeMultiplier(2)
+  ->Range(1, 32);
+
+#ifdef CNN_USE_AVX
+void bm_fully_connected_avx(bm::State& state) {
+  size_t in_size(state.range(0)), out_size(state.range(1));
+
+  Tensor<> in_data({1, in_size}), out_data({1, out_size});
+  Tensor<> weights({in_size * out_size}), bias({out_size});
+
+  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
+  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_avx(in_data, weights, bias, out_data, false);
+  }
+}
+
+void bm_fully_connected_avx_parallelized(bm::State& state) {
+  size_t in_size(64), out_size(64), samples(state.range(0));
+
+  Tensor<> in_data({samples, in_size}), out_data({samples, out_size});
+  Tensor<> weights({in_size * out_size}), bias({out_size});
+
+  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
+  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_avx(in_data, weights, bias, out_data, true);
+  }
+}
+
+BENCHMARK(bm_fully_connected_avx)
+  ->Args({16, 4})
+  ->Args({64, 4})
+  ->Args({256, 4})
+  ->Args({256, 16})
+  ->Args({256, 64})
+  ->Args({256, 256});
+
+BENCHMARK(bm_fully_connected_avx_parallelized)
+  ->RangeMultiplier(2)
+  ->Range(1, 32);
+#endif
+
+void bm_fully_connected_grad_internal(bm::State& state) {
+  size_t in_size(state.range(0)), out_size(state.range(1));
+
+  Tensor<> prev_out({1, in_size});
+  Tensor<> weights({in_size * out_size});
+  Tensor<> weights_grads({1, in_size * out_size}), bias_grads({1, out_size});
+  Tensor<> curr_delta({1, out_size}), prev_delta({1, in_size});
+
+  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
+  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
+  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
+  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_internal(prev_out, weights, weights_grads,
+                                         bias_grads, curr_delta, prev_delta,
+                                         false);
+  }
+}
+
+void bm_fully_connected_grad_internal_parallelized(bm::State& state) {
+  size_t in_size(64), out_size(64), samples(state.range(0));
+
+  Tensor<> prev_out({samples, in_size});
+  Tensor<> weights({in_size * out_size});
+  Tensor<> weights_grads({samples, in_size * out_size}),
+    bias_grads({samples, out_size});
+  Tensor<> curr_delta({samples, out_size}), prev_delta({samples, in_size});
+
+  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
+  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
+  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
+  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_internal(prev_out, weights, weights_grads,
+                                         bias_grads, curr_delta, prev_delta,
+                                         true);
+  }
+}
+
+BENCHMARK(bm_fully_connected_grad_internal)
+  ->Args({16, 4})
+  ->Args({64, 4})
+  ->Args({256, 4})
+  ->Args({256, 16})
+  ->Args({256, 64})
+  ->Args({256, 256});
+
+BENCHMARK(bm_fully_connected_grad_internal_parallelized)
+  ->RangeMultiplier(2)
+  ->Range(1, 32);
+
+#ifdef CNN_USE_AVX
+void bm_fully_connected_grad_avx(bm::State& state) {
+  size_t in_size(state.range(0)), out_size(state.range(1));
+
+  Tensor<> prev_out({1, in_size});
+  Tensor<> weights({in_size * out_size});
+  Tensor<> weights_grads({1, in_size * out_size}), bias_grads({1, out_size});
+  Tensor<> curr_delta({1, out_size}), prev_delta({1, in_size});
+
+  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
+  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
+  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
+  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_avx(prev_out, weights, weights_grads,
+                                    bias_grads, curr_delta, prev_delta, false);
+  }
+}
+
+void bm_fully_connected_grad_avx_parallelized(bm::State& state) {
+  size_t in_size(64), out_size(64), samples(state.range(0));
+
+  Tensor<> prev_out({samples, in_size});
+  Tensor<> weights({in_size * out_size});
+  Tensor<> weights_grads({samples, in_size * out_size}),
+    bias_grads({samples, out_size});
+  Tensor<> curr_delta({samples, out_size}), prev_delta({samples, in_size});
+
+  uniform_rand(prev_out.host_begin(), prev_out.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(weights_grads.host_begin(), weights_grads.host_end(), -1, 1);
+  uniform_rand(bias_grads.host_begin(), bias_grads.host_end(), -1, 1);
+  uniform_rand(curr_delta.host_begin(), curr_delta.host_end(), -1, 1);
+  uniform_rand(prev_delta.host_begin(), prev_delta.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_avx(prev_out, weights, weights_grads,
+                                    bias_grads, curr_delta, prev_delta, true);
+  }
+}
+
+BENCHMARK(bm_fully_connected_grad_avx)
+  ->Args({16, 4})
+  ->Args({64, 4})
+  ->Args({256, 4})
+  ->Args({256, 16})
+  ->Args({256, 64})
+  ->Args({256, 256});
+
+BENCHMARK(bm_fully_connected_grad_avx_parallelized)
+  ->RangeMultiplier(2)
+  ->Range(1, 32);
+#endif
 
 }  // namespace benchmarks
 }  // namespace tiny_dnn

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -16,7 +16,10 @@ namespace tiny_dnn {
 namespace benchmarks {
 
 void bm_fully_connected_internal(bm::State& state) {
-  Tensor<float_t> in_data({1, 5}), out_data({1, 3}), weights({15}), bias({3});
+  size_t in_size(state.range(0)), out_size(state.range(1));
+
+  Tensor<> in_data({1, in_size}), out_data({1, out_size});
+  Tensor<> weights({in_size * out_size}), bias({out_size});
 
   uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
   uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
@@ -29,7 +32,15 @@ void bm_fully_connected_internal(bm::State& state) {
   }
 }
 
-BENCHMARK(bm_fully_connected_internal);
+BENCHMARK(bm_fully_connected_internal)
+  ->Args({16, 4})
+  ->Args({64, 4})
+  ->Args({256, 4})
+  ->Args({1024, 4})
+  ->Args({1024, 16})
+  ->Args({1024, 64})
+  ->Args({1024, 256})
+  ->Args({1024, 1024});
 
 }  // namespace benchmarks
 }  // namespace tiny_dnn

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -175,10 +175,9 @@ BENCHMARK_REGISTER_F(BM_FullyConnectedGradOp, internal_parallel)
   ->Apply(args_with_same_in_out);
 
 #ifdef CNN_USE_AVX
-BENCHMARK_REGISTER_F(BM_FullyConnectedOp, internal)
-  ->Apply(args_with_same_samples);
+BENCHMARK_REGISTER_F(BM_FullyConnectedOp, avx)->Apply(args_with_same_samples);
 
-BENCHMARK_REGISTER_F(BM_FullyConnectedOp, internal_parallel)
+BENCHMARK_REGISTER_F(BM_FullyConnectedOp, avx_parallel)
   ->Apply(args_with_same_in_out);
 
 BENCHMARK_REGISTER_F(BM_FullyConnectedGradOp, avx)

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -12,99 +12,96 @@
 
 namespace bm = benchmark;
 
+const size_t BM_CONST_IN_SIZE     = 64;
+const size_t BM_CONST_OUT_SIZE    = 64;
+const size_t BM_CONST_SAMPLE_SIZE = 1;
+
 namespace tiny_dnn {
 namespace benchmarks {
 
-void bm_fully_connected_internal(bm::State& state) {
-  size_t in_size(state.range(0)), out_size(state.range(1));
+class BM_FullyConnectedOp : public bm::Fixture {
+ public:
+  void SetUp(const bm::State& state) {
+    in_size  = state.range(0);
+    out_size = state.range(1);
+    samples  = state.range(2);
 
-  Tensor<> in_data({1, in_size}), out_data({1, out_size});
-  Tensor<> weights({in_size * out_size}), bias({out_size});
+    in_data.reshape({1, in_size});
+    out_data.reshape({1, out_size});
+    weights.reshape({in_size * out_size});
+    bias.reshape({out_size});
 
-  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
-  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+    uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
+    uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+    uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
+    uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+  }
 
+  void TearDown(const bm::State&) {}
+
+  size_t in_size, out_size, samples;
+  Tensor<> in_data, out_data, weights, bias;
+};
+
+BENCHMARK_DEFINE_F(BM_FullyConnectedOp, internal)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_internal(in_data, weights, bias, out_data,
                                          false);
   }
 }
 
-void bm_fully_connected_internal_parallelized(bm::State& state) {
-  size_t in_size(64), out_size(64), samples(state.range(0));
+BENCHMARK_REGISTER_F(FullyConnectedOp, internal)
+  ->Args({16, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({64, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 16, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 64, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 256, BM_CONST_SAMPLE_SIZE});
 
-  Tensor<> in_data({samples, in_size}), out_data({samples, out_size});
-  Tensor<> weights({in_size * out_size}), bias({out_size});
-
-  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
-  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedOp, internal_parallel)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_internal(in_data, weights, bias, out_data,
                                          true);
   }
 }
 
-BENCHMARK(bm_fully_connected_internal)
-  ->Args({16, 4})
-  ->Args({64, 4})
-  ->Args({256, 4})
-  ->Args({256, 16})
-  ->Args({256, 64})
-  ->Args({256, 256});
-
-BENCHMARK(bm_fully_connected_internal_parallelized)
-  ->RangeMultiplier(2)
-  ->Range(1, 32);
+BENCHMARK_REGISTER_F(BM_FullyConnectedOp, internal_parallel)
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 1})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 2})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 4})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 8})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 16})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 32});
 
 #ifdef CNN_USE_AVX
-void bm_fully_connected_avx(bm::State& state) {
-  size_t in_size(state.range(0)), out_size(state.range(1));
-
-  Tensor<> in_data({1, in_size}), out_data({1, out_size});
-  Tensor<> weights({in_size * out_size}), bias({out_size});
-
-  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
-  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedOp, avx)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_avx(in_data, weights, bias, out_data, false);
   }
 }
 
-void bm_fully_connected_avx_parallelized(bm::State& state) {
-  size_t in_size(64), out_size(64), samples(state.range(0));
+BENCHMARK_REGISTER_F(FullyConnectedOp, avx)
+  ->Args({16, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({64, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 4, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 16, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 64, BM_CONST_SAMPLE_SIZE})
+  ->Args({256, 256, BM_CONST_SAMPLE_SIZE});
 
-  Tensor<> in_data({samples, in_size}), out_data({samples, out_size});
-  Tensor<> weights({in_size * out_size}), bias({out_size});
-
-  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
-  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
-  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
-  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
-
+BENCHMARK_DEFINE_F(BM_FullyConnectedOp, avx_parallel)(bm::State& state) {
   while (state.KeepRunning()) {
     kernels::fully_connected_op_avx(in_data, weights, bias, out_data, true);
   }
 }
 
-BENCHMARK(bm_fully_connected_avx)
-  ->Args({16, 4})
-  ->Args({64, 4})
-  ->Args({256, 4})
-  ->Args({256, 16})
-  ->Args({256, 64})
-  ->Args({256, 256});
+BENCHMARK_REGISTER_F(BM_FullyConnectedOp, avx_parallel)
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 1})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 2})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 4})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 8})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 16})
+  ->Args({BM_CONST_IN_SIZE, BM_CONST_OUT_SIZE, 32});
 
-BENCHMARK(bm_fully_connected_avx_parallelized)
-  ->RangeMultiplier(2)
-  ->Range(1, 32);
 #endif
 
 void bm_fully_connected_grad_internal(bm::State& state) {

--- a/benchmarks/bm_fully_connected.h
+++ b/benchmarks/bm_fully_connected.h
@@ -1,0 +1,35 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include "benchmark/benchmark.h"
+#include "tiny_dnn/tiny_dnn.h"
+
+namespace bm = benchmark;
+
+namespace tiny_dnn {
+namespace benchmarks {
+
+void bm_fully_connected_internal(bm::State& state) {
+  Tensor<float_t> in_data({1, 5}), out_data({1, 3}), weights({15}), bias({3});
+
+  uniform_rand(in_data.host_begin(), in_data.host_end(), -1, 1);
+  uniform_rand(weights.host_begin(), weights.host_end(), -1, 1);
+  uniform_rand(bias.host_begin(), bias.host_end(), -1, 1);
+  uniform_rand(out_data.host_begin(), out_data.host_end(), -1, 1);
+
+  while (state.KeepRunning()) {
+    kernels::fully_connected_op_internal(in_data, weights, bias, out_data,
+                                         false);
+  }
+}
+
+BENCHMARK(bm_fully_connected_internal);
+
+}  // namespace benchmarks
+}  // namespace tiny_dnn

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -101,7 +101,7 @@ TEST(ave_pool, forward) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  auto out = l.forward({{in}});
+  auto out  = l.forward({{in}});
   vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {
@@ -130,7 +130,7 @@ TEST(ave_pool, forward_stride) {
   l.bias_init(weight_init::constant(0.0));
   l.init_weight();
 
-  auto out = l.forward({{in}});
+  auto out  = l.forward({{in}});
   vec_t res = (*out[0])[0];
 
   for (size_t i = 0; i < expected.size(); i++) {

--- a/tiny_dnn/layers/fully_connected_layer.h
+++ b/tiny_dnn/layers/fully_connected_layer.h
@@ -56,7 +56,7 @@ class fully_connected_layer : public layer {
   fully_connected_layer(size_t in_features,
                         size_t out_features,
                         fully_connected_layer_params params)
-    : layer(std_input_order(params.bias), {vector_type::data}) {
+    : layer({vector_type::data}, {vector_type::data}) {
     set_params(in_features, out_features, params.bias);
     init_backend(params.backend_type);
     layer::set_backend_type(params.backend_type);


### PR DESCRIPTION
This PR introduces timing benchmarks for fully connected op kernel. Benchmarks are evaluated with as well as without parallelization. 

Benchmarks include internal as well as avx backends, and are parametrized based on input sizes. Time of execution is found to linearly increase with increasing size of either input or output data keeping other constant.