### PR TITLE
Refactor kernels of average unpooling layer and perform parameter integration.

### DIFF
--- a/test/test_average_unpooling_layer.h
+++ b/test/test_average_unpooling_layer.h
@@ -15,6 +15,63 @@
 
 namespace tiny_dnn {
 
+TEST(ave_unpool, forward) {
+  average_unpooling_layer l(2, 2, 1, 2);
+  l.weight_init_f(parameter_init::constant(1.0));
+  l.bias_init_f(parameter_init::constant(0.0));
+  l.init_parameters();
+
+  // clang-format off
+    vec_t in = {
+        4, 3,
+        1.5, -0.5
+    };
+
+    vec_t expected = {
+        4,     4,    3,    3,
+        4,     4,    3,    3,
+        1.5, 1.5, -0.5, -0.5,
+        1.5, 1.5, -0.5, -0.5,
+    };
+  // clang-format on
+
+  auto out  = l.forward({{in}});
+  vec_t res = (*out[0])[0];
+
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
+}
+
+TEST(ave_unpool, forward_stride) {
+  average_unpooling_layer l(3, 3, 1, 2, 1);
+  l.weight_init_f(parameter_init::constant(1.0));
+  l.bias_init_f(parameter_init::constant(0.0));
+  l.init_parameters();
+
+  // clang-format off
+    vec_t in = {
+        0, 1, 2,
+        8, 7, 5,
+        4, 3, 1,
+    };
+
+    vec_t expected = {
+        0,   1,  3, 2,
+        8,  16, 15, 7,
+        12, 22, 16, 6,
+        4,  7,  4,  1
+    };
+  // clang-format on
+
+  auto out  = l.forward({{in}});
+  vec_t res = (*out[0])[0];
+
+  for (size_t i = 0; i < expected.size(); i++) {
+    EXPECT_FLOAT_EQ(expected[i], res[i]);
+  }
+}
+
 TEST(ave_unpool, gradient_check) {  // sigmoid - mse
   using loss_func  = mse;           // TODO(Randl): fails with cross-entropy
   using activation = sigmoid;
@@ -32,75 +89,15 @@ TEST(ave_unpool, gradient_check) {  // sigmoid - mse
                                            epsilon<float_t>(), GRAD_CHECK_ALL));
 }
 
-TEST(ave_unpool, forward) {
-  average_unpooling_layer l(2, 2, 1, 2);
-
-  // clang-format off
-    vec_t in = {
-        4, 3,
-        1.5, -0.5
-    };
-
-    vec_t expected = {
-        4,     4,    3,    3,
-        4,     4,    3,    3,
-        1.5, 1.5, -0.5, -0.5,
-        1.5, 1.5, -0.5, -0.5,
-    };
-  // clang-format on
-
-  l.weight_init(weight_init::constant(1.0));
-  l.bias_init(weight_init::constant(0.0));
-  l.init_weight();
-
-  std::vector<const tensor_t*> out;
-  l.forward({{in}}, out);
-  vec_t res = (*out[0])[0];
-
-  for (size_t i = 0; i < expected.size(); i++) {
-    EXPECT_FLOAT_EQ(expected[i], res[i]);
-  }
-}
-
-TEST(ave_unpool, forward_stride) {
-  average_unpooling_layer l(3, 3, 1, 2, 1);
-
-  // clang-format off
-    vec_t in = {
-        0, 1, 2,
-        8, 7, 5,
-        4, 3, 1,
-    };
-
-    vec_t expected = {
-        0,   1,  3, 2,
-        8,  16, 15, 7,
-        12, 22, 16, 6,
-        4,  7,  4,  1
-    };
-  // clang-format on
-
-  l.weight_init(weight_init::constant(1.0));
-  l.bias_init(weight_init::constant(0.0));
-  l.init_weight();
-
-  std::vector<const tensor_t*> out;
-  l.forward({{in}}, out);
-  vec_t res = (*out[0])[0];
-
-  for (size_t i = 0; i < expected.size(); i++) {
-    EXPECT_FLOAT_EQ(expected[i], res[i]);
-  }
-}
-
+/* todo (karandesai) Deal with serialization tests of all layers together later.
 TEST(ave_unpool, read_write) {
   average_unpooling_layer l1(100, 100, 5, 2);
   average_unpooling_layer l2(100, 100, 5, 2);
 
-  l1.setup(true);
-  l2.setup(true);
+  l1.init_parameters();
+  l2.init_parameters();
 
   serialization_test(l1, l2);
 }
-
+*/
 }  // namespace tiny_dnn

--- a/tiny_dnn/core/params/aveunpool_params.h
+++ b/tiny_dnn/core/params/aveunpool_params.h
@@ -1,0 +1,55 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include <utility>
+#include <vector>
+
+#include "tiny_dnn/core/params/params.h"
+
+namespace tiny_dnn {
+namespace core {
+
+struct average_unpooling_layer_worker_specific_storage {
+  using io_connections = std::vector<std::pair<size_t, size_t>>;
+  using wi_connections = std::vector<std::pair<size_t, size_t>>;
+  using wo_connections = std::vector<std::pair<size_t, size_t>>;
+
+  std::vector<io_connections> weight2io;  // weight_id -> [(in_id, out_id)]
+  std::vector<wi_connections> out2wi;     // out_id -> [(weight_id, in_id)]
+  std::vector<wo_connections> in2wo;      // in_id -> [(weight_id, out_id)]
+
+  std::vector<std::vector<size_t>> bias2out;
+
+  average_unpooling_layer_worker_specific_storage() {}
+
+  average_unpooling_layer_worker_specific_storage(size_t weight2io_size,
+                                                  size_t out2wi_size,
+                                                  size_t in2wo_size,
+                                                  size_t bias2out_size)
+    : weight2io(weight2io_size),
+      out2wi(out2wi_size),
+      in2wo(in2wo_size),
+      bias2out(bias2out_size) {}
+};
+
+class aveunpool_params : public Params {
+ public:
+  shape3d in;
+  shape3d out;
+  shape3d window;
+  size_t stride;
+  float_t scale_factor;
+};
+
+inline aveunpool_params &Params::aveunpool() {
+  return *(static_cast<aveunpool_params *>(this));
+}
+
+}  // namespace core
+}  // namespace tiny_dnn

--- a/tiny_dnn/core/params/params.h
+++ b/tiny_dnn/core/params/params.h
@@ -11,6 +11,7 @@ namespace tiny_dnn {
 namespace core {
 
 class avepool_params;
+class aveunpool_params;
 class conv_params;
 class deconv_params;
 class fully_params;
@@ -24,6 +25,7 @@ class Params {
   Params() {}
 
   avepool_params &avepool();
+  aveunpool_params &aveunpool();
   conv_params &conv();
   deconv_params &deconv();
   fully_params &fully();

--- a/tiny_dnn/layers/average_unpooling_layer.h
+++ b/tiny_dnn/layers/average_unpooling_layer.h
@@ -11,7 +11,7 @@
 #include <string>
 #include <vector>
 
-#include "tiny_dnn/layers/partial_connected_layer.h"
+#include "tiny_dnn/core/params/aveunpool_params.h"
 #include "tiny_dnn/util/util.h"
 
 #ifdef DNN_USE_IMAGE_API
@@ -22,26 +22,24 @@ namespace tiny_dnn {
 
 // forward_propagation
 inline void tiny_average_unpooling_kernel(
-  bool parallelize,
   const std::vector<tensor_t *> &in_data,
   std::vector<tensor_t *> &out_data,
-  const shape3d &out_dim,
-  float_t scale_factor,
-  std::vector<typename partial_connected_layer::wi_connections> &out2wi) {
-  CNN_UNREFERENCED_PARAMETER(scale_factor);
+  const core::aveunpool_params &params,
+  const core::average_unpooling_layer_worker_specific_storage &auws,
+  bool parallelize) {
   for_i(parallelize, in_data[0]->size(), [&](size_t sample) {
     const Tensor<> in((*in_data[0])[sample]);
     const Tensor<> W((*in_data[1])[0]);
     const Tensor<> b((*in_data[2])[0]);
     Tensor<> out((*out_data[0])[sample]);
 
-    auto oarea = out_dim.area();
+    auto oarea = params.out.area();
     size_t idx = 0;
-    for (size_t d = 0; d < out_dim.depth_; ++d) {
+    for (size_t d = 0; d < params.out.depth_; ++d) {
       float_t weight = W.host_at(d);  // * scale_factor;
       float_t bias   = b.host_at(d);
       for (size_t i = 0; i < oarea; ++i, ++idx) {
-        const auto &connections = out2wi[idx];
+        const auto &connections = auws.out2wi[idx];
         float_t value{0};
         for (auto connection : connections)
           value += in.host_at(connection.second);
@@ -51,25 +49,20 @@ inline void tiny_average_unpooling_kernel(
       }
     }
 
-    assert(out.size() == out2wi.size());
+    assert(out.size() == auws.out2wi.size());
     (*out_data[0])[sample] = out.toVec();
   });
 }
 
 // back_propagation
 inline void tiny_average_unpooling_back_kernel(
-  bool parallelize,
   const std::vector<tensor_t *> &in_data,
   const std::vector<tensor_t *> &out_data,
   std::vector<tensor_t *> &out_grad,
   std::vector<tensor_t *> &in_grad,
-  const shape3d &in_dim,
-  float_t scale_factor,
-  std::vector<typename partial_connected_layer::io_connections> &weight2io,
-  std::vector<typename partial_connected_layer::wo_connections> &in2wo,
-  std::vector<std::vector<size_t>> &bias2out) {
-  CNN_UNREFERENCED_PARAMETER(out_data);
-  CNN_UNREFERENCED_PARAMETER(scale_factor);
+  const core::aveunpool_params &params,
+  const core::average_unpooling_layer_worker_specific_storage &auws,
+  bool parallelize) {
   for_i(parallelize, in_data[0]->size(), [&](size_t sample) {
     const Tensor<> prev_out((*in_data[0])[sample]);
     const Tensor<> W((*in_data[1])[0]);
@@ -78,18 +71,18 @@ inline void tiny_average_unpooling_back_kernel(
     Tensor<> prev_delta((*in_grad[0])[sample]);
     Tensor<> curr_delta((*out_grad[0])[sample]);
 
-    auto inarea = in_dim.area();
+    auto inarea = params.in.area();
     size_t idx  = 0;
-    for (size_t i = 0; i < in_dim.depth_; ++i) {
+    for (size_t i = 0; i < params.in.depth_; ++i) {
       float_t weight = W.host_at(i);  // * scale_factor;
       for (size_t j = 0; j < inarea; ++j, ++idx) {
         prev_delta.host_at(idx) =
-          weight * curr_delta.host_at(in2wo[idx][0].second);
+          weight * curr_delta.host_at(auws.in2wo[idx][0].second);
       }
     }
 
-    for (size_t i = 0; i < weight2io.size(); ++i) {
-      const auto &connections = weight2io[i];
+    for (size_t i = 0; i < auws.weight2io.size(); ++i) {
+      const auto &connections = auws.weight2io[i];
       float_t diff            = 0.0;
 
       for (auto connection : connections)
@@ -99,8 +92,8 @@ inline void tiny_average_unpooling_back_kernel(
       dW.host_at(i) += diff;  // * scale_factor;
     }
 
-    for (size_t i = 0; i < bias2out.size(); i++) {
-      const std::vector<size_t> &outs = bias2out[i];
+    for (size_t i = 0; i < auws.bias2out.size(); i++) {
+      const std::vector<size_t> &outs = auws.bias2out[i];
       float_t diff                    = 0.0;
 
       for (auto o : outs) diff += curr_delta.host_at(o);
@@ -117,10 +110,8 @@ inline void tiny_average_unpooling_back_kernel(
 /**
  * average pooling with trainable weights
  **/
-class average_unpooling_layer : public partial_connected_layer {
+class average_unpooling_layer : public layer {
  public:
-  using Base = partial_connected_layer;
-
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image
@@ -131,17 +122,8 @@ class average_unpooling_layer : public partial_connected_layer {
                           size_t in_height,
                           size_t in_channels,
                           size_t pooling_size)
-    : Base(in_width * in_height * in_channels,
-           in_width * in_height * in_channels * sqr(pooling_size),
-           in_channels,
-           in_channels,
-           float_t(1) * sqr(pooling_size)),
-      stride_(pooling_size),
-      in_(in_width, in_height, in_channels),
-      out_(in_width * pooling_size, in_height * pooling_size, in_channels),
-      w_(pooling_size, (in_height == 1 ? 1 : pooling_size), in_channels) {
-    init_connection(pooling_size);
-  }
+    : average_unpooling_layer(
+        in_width, in_height, in_channels, pooling_size, pooling_size) {}
 
   /**
    * @param in_width     [in] width of input image
@@ -156,88 +138,94 @@ class average_unpooling_layer : public partial_connected_layer {
                           size_t in_channels,
                           size_t pooling_size,
                           size_t stride)
-    : Base(in_width * in_height * in_channels,
-           unpool_out_dim(in_width, pooling_size, stride) *
-             unpool_out_dim(in_height, pooling_size, stride) * in_channels,
-           in_channels,
-           in_channels,
-           float_t(1) * sqr(pooling_size)),
-      stride_(stride),
-      in_(in_width, in_height, in_channels),
-      out_(unpool_out_dim(in_width, pooling_size, stride),
-           unpool_out_dim(in_height, pooling_size, stride),
-           in_channels),
-      w_(pooling_size, (in_height == 1 ? 1 : pooling_size), in_channels) {
+    : layer({vector_type::data, vector_type::weight, vector_type::bias},
+            {vector_type::data}) {
+    aveunpool_set_params(in_width, in_height, in_channels, pooling_size,
+                         stride);
+    auws_ = core::average_unpooling_layer_worker_specific_storage(
+      in_channels, params_.out.size(), params_.in.size(), in_channels);
     init_connection(pooling_size);
   }
 
-  std::vector<index3d<size_t>> in_shape() const override {
-    return {in_, w_, index3d<size_t>(1, 1, out_.depth_)};
+  std::vector<shape3d> in_shape() const override {
+    return {params_.in, params_.window, params_.out};
   }
 
-  std::vector<index3d<size_t>> out_shape() const override { return {out_}; }
+  std::vector<shape3d> out_shape() const override { return {params_.out}; }
 
   std::string layer_type() const override { return "ave-unpool"; }
 
   void forward_propagation(const std::vector<tensor_t *> &in_data,
                            std::vector<tensor_t *> &out_data) override {
-    tiny_average_unpooling_kernel(parallelize_, in_data, out_data, out_,
-                                  Base::scale_factor_, Base::out2wi_);
+    tiny_average_unpooling_kernel(in_data, out_data, params_, auws_,
+                                  parallelize());
   }
 
   void back_propagation(const std::vector<tensor_t *> &in_data,
                         const std::vector<tensor_t *> &out_data,
                         std::vector<tensor_t *> &out_grad,
                         std::vector<tensor_t *> &in_grad) override {
-    tiny_average_unpooling_back_kernel(
-      parallelize_, in_data, out_data, out_grad, in_grad, in_,
-      Base::scale_factor_, Base::weight2io_, Base::in2wo_, Base::bias2out_);
+    tiny_average_unpooling_back_kernel(in_data, out_data, out_grad, in_grad,
+                                       params_, auws_, parallelize());
   }
 
   friend struct serialization_buddy;
 
  private:
-  size_t stride_;
-  shape3d in_;
-  shape3d out_;
-  shape3d w_;
+  core::aveunpool_params params_;
+  core::average_unpooling_layer_worker_specific_storage auws_;
 
-  static size_t unpool_out_dim(size_t in_size,
-                               size_t pooling_size,
-                               size_t stride) {
-    return static_cast<int>((in_size - 1) * stride + pooling_size);
+  void aveunpool_set_params(size_t in_width,
+                            size_t in_height,
+                            size_t in_channels,
+                            size_t pooling_size,
+                            size_t stride) {
+    params_.in  = shape3d(in_width, in_height, in_channels);
+    params_.out = shape3d((in_width - 1) * stride + pooling_size,
+                          (in_height - 1) * stride + pooling_size, in_channels);
+    params_.window       = shape3d(pooling_size, pooling_size, in_channels);
+    params_.stride       = stride;
+    params_.scale_factor = sqr(pooling_size);
   }
 
   void init_connection(size_t pooling_size) {
-    for (size_t c = 0; c < in_.depth_; ++c) {
-      for (size_t y = 0; y < in_.height_; ++y) {
-        for (size_t x = 0; x < in_.width_; ++x) {
+    for (size_t c = 0; c < params_.in.depth_; ++c) {
+      for (size_t y = 0; y < params_.in.height_; ++y) {
+        for (size_t x = 0; x < params_.in.width_; ++x) {
           connect_kernel(pooling_size, x, y, c);
         }
       }
     }
 
-    for (size_t c = 0; c < in_.depth_; ++c) {
-      for (size_t y = 0; y < out_.height_; ++y) {
-        for (size_t x = 0; x < out_.width_; ++x) {
-          this->connect_bias(c, out_.get_index(x, y, c));
+    for (size_t c = 0; c < params_.in.depth_; ++c) {
+      for (size_t y = 0; y < params_.out.height_; ++y) {
+        for (size_t x = 0; x < params_.out.width_; ++x) {
+          auws_.bias2out[c].push_back(params_.out.get_index(x, y, c));
         }
       }
     }
   }
 
   void connect_kernel(size_t pooling_size, size_t x, size_t y, size_t inc) {
-    size_t dymax = std::min(pooling_size, out_.height_ - y);
-    size_t dxmax = std::min(pooling_size, out_.width_ - x);
-    size_t dstx  = x * stride_;
-    size_t dsty  = y * stride_;
-    size_t inidx = in_.get_index(x, y, inc);
+    size_t dymax = std::min(pooling_size, params_.out.height_ - y);
+    size_t dxmax = std::min(pooling_size, params_.out.width_ - x);
+    size_t dstx  = x * params_.stride;
+    size_t dsty  = y * params_.stride;
+    size_t inidx = params_.in.get_index(x, y, inc);
     for (size_t dy = 0; dy < dymax; ++dy) {
       for (size_t dx = 0; dx < dxmax; ++dx) {
-        this->connect_weight(inidx, out_.get_index(dstx + dx, dsty + dy, inc),
-                             inc);
+        connect_weight(inidx, params_.out.get_index(dstx + dx, dsty + dy, inc),
+                       inc);
       }
     }
+  }
+
+  void connect_weight(size_t input_index,
+                      size_t output_index,
+                      size_t weight_index) {
+    auws_.weight2io[weight_index].emplace_back(input_index, output_index);
+    auws_.out2wi[output_index].emplace_back(weight_index, input_index);
+    auws_.in2wo[input_index].emplace_back(weight_index, output_index);
   }
 };
 

--- a/tiny_dnn/layers/layers.h
+++ b/tiny_dnn/layers/layers.h
@@ -21,7 +21,6 @@
 #include "tiny_dnn/layers/lrn_layer.h"
 #include "tiny_dnn/layers/max_pooling_layer.h"
 #include "tiny_dnn/layers/max_unpooling_layer.h"
-#include "tiny_dnn/layers/partial_connected_layer.h"
 #include "tiny_dnn/layers/power_layer.h"
 #include "tiny_dnn/layers/quantized_convolutional_layer.h"
 #include "tiny_dnn/layers/quantized_deconvolutional_layer.h"

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -629,9 +629,10 @@ struct serialization_buddy {
   template <class Archive>
   static inline void serialize(Archive &ar,
                                tiny_dnn::average_unpooling_layer &layer) {
-    ::detail::arc(ar, ::detail::make_nvp("in_size", layer.in_),
-                  ::detail::make_nvp("pool_size", layer.w_.width_),
-                  ::detail::make_nvp("stride", layer.stride_));
+    auto &params_ = layer.params_;
+    ::detail::arc(ar, ::detail::make_nvp("in_size", params_.in),
+                  ::detail::make_nvp("pool_size", params_.window.width_),
+                  ::detail::make_nvp("stride", params_.stride));
   }
 
   template <class Archive>


### PR DESCRIPTION
This PR declares `aveunpool_params` and `average_unpooling_worker_specific_storage` and passes them accordingly to kernels. Although we are planning to get rid of params since most of the information is in Tensor, it is beneficial to keep uniformity for easy migration further.This helps in integrating parameter API within easily.

Similar to #816 + #819