### PR TITLE
Add class for VGG16 and VGG19 models.

### DIFF
--- a/tiny_dnn/models/vgg16.h
+++ b/tiny_dnn/models/vgg16.h
@@ -1,0 +1,60 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include <string>
+
+namespace models {
+
+class vgg16 : public tiny_dnn::network<tiny_dnn::sequential> {
+ public:
+  explicit vgg16(const std::string &name = "vgg16", bool include_top = true)
+    : tiny_dnn::network<tiny_dnn::sequential>(name) {
+    using conv     = tiny_dnn::layers::conv;
+    using relu     = tiny_dnn::activation::relu;
+    using max_pool = tiny_dnn::layers::max_pool;
+    using dense    = tiny_dnn::layers::dense;
+
+    // Block 1
+    *this << conv(224, 224, 3, 3, 3, 64, padding::same) << relu();
+    *this << conv(224, 224, 3, 3, 64, 64, padding::same) << relu();
+    *this << max_pool(224, 224, 64, 2) << relu();
+
+    // Block 2
+    *this << conv(112, 112, 3, 3, 64, 128, padding::same) << relu();
+    *this << conv(112, 112, 3, 3, 128, 128, padding::same) << relu();
+    *this << max_pool(112, 112, 128, 2) << relu();
+
+    // Block 3
+    *this << conv(56, 56, 3, 3, 128, 256, padding::same) << relu();
+    *this << conv(56, 56, 3, 3, 256, 256, padding::same) << relu();
+    *this << conv(56, 56, 3, 3, 256, 256, padding::same) << relu();
+    *this << max_pool(56, 56, 256, 2) << relu();
+
+    // Block 4
+    *this << conv(28, 28, 3, 3, 256, 512, padding::same) << relu();
+    *this << conv(28, 28, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(28, 28, 3, 3, 512, 512, padding::same) << relu();
+    *this << max_pool(28, 28, 512, 2) << relu();
+
+    // Block 5
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << max_pool(14, 14, 512, 2) << relu();
+
+    if (include_top) {
+      *this << dense(7 * 7 * 512, 4096) << relu();
+      *this << dense(4096, 4096) << relu();
+      *this << dense(4096, 1000) << relu();
+      *this << softmax();
+    }
+  }
+};
+
+}  // namespace models

--- a/tiny_dnn/models/vgg19.h
+++ b/tiny_dnn/models/vgg19.h
@@ -1,0 +1,89 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include <string>
+#include "tiny_dnn/tiny_dnn.h"
+
+#include "tiny_dnn/util/nn_error.h"
+#include "tiny_dnn/util/parameter_init.h"
+
+namespace tiny_dnn {
+namespace models {
+
+/**
+ * VGG19 architecture for tiny-dnn model zoo.
+ *
+ * Reference:
+ * Very Deep Convolutional Networks for Large-Scale Image Recognition
+ * - (https://arxiv.org/abs/1409.1556)
+ */
+class vgg19 : public tiny_dnn::network<tiny_dnn::sequential> {
+ public:
+  explicit vgg19(const std::string &name = "vgg19", bool include_top = true)
+    : tiny_dnn::network<tiny_dnn::sequential>(name) {
+    using conv     = convolutional_layer;
+    using relu     = relu_layer;
+    using max_pool = max_pooling_layer;
+    using dense    = fully_connected_layer;
+
+    // Block 1
+    *this << conv(224, 224, 3, 3, 3, 64, padding::same) << relu();
+    *this << conv(224, 224, 3, 3, 64, 64, padding::same) << relu();
+    *this << max_pool(224, 224, 64, 2) << relu();
+
+    // Block 2
+    *this << conv(112, 112, 3, 3, 64, 128, padding::same) << relu();
+    *this << conv(112, 112, 3, 3, 128, 128, padding::same) << relu();
+    *this << max_pool(112, 112, 128, 2) << relu();
+
+    // Block 3
+    *this << conv(56, 56, 3, 3, 128, 256, padding::same) << relu();
+    *this << conv(56, 56, 3, 3, 256, 256, padding::same) << relu();
+    *this << conv(56, 56, 3, 3, 256, 256, padding::same) << relu();
+    *this << conv(56, 56, 3, 3, 256, 256, padding::same) << relu();
+    *this << max_pool(56, 56, 256, 2) << relu();
+
+    // Block 4
+    *this << conv(28, 28, 3, 3, 256, 512, padding::same) << relu();
+    *this << conv(28, 28, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(28, 28, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(28, 28, 3, 3, 512, 512, padding::same) << relu();
+    *this << max_pool(28, 28, 512, 2) << relu();
+
+    // Block 5
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << conv(14, 14, 3, 3, 512, 512, padding::same) << relu();
+    *this << max_pool(14, 14, 512, 2) << relu();
+
+    if (include_top) {
+      *this << dense(7 * 7 * 512, 4096) << relu();
+      *this << dense(4096, 4096) << relu();
+      *this << dense(4096, 1000) << relu();
+      *this << softmax();
+    } else {
+      // following the Network-in-Network architecture to use a Global
+      // Average Pooling layer instead of Fully Connected Layers.
+      *this << global_average_pooling_layer(1000, 1, 1);
+    }
+
+    if (load_pretrained) {
+      throw nn_error("Pretrained weights loading support coming soon.");
+    } else {
+      // If not loading pretrained model then initialize as per strategy
+      // mentioned in paper.
+      this->weight_init(parameter_init::gaussian(0.01));
+      this->bias_init(parameter_init::constant(0.0));
+      this->init_parameters();
+    }
+  }
+};
+
+}  // namespace models
+}  // namespace tiny_dnn


### PR DESCRIPTION
This PR adds an implementation for VGG16 and VGG19 model. This class can be found as `models::vgg16` / `models::vgg19`. We can choose to include fully connected layers or prefer global average pooling like Network-in-Network architecture.

Once the HDF loading API is tested and merged, it shall be used to load pretrained model from official Keras weights file.

Initialization strategy if Imagenet weights are not loaded, is kept same as that mentioned in the paper.

### References:

1. Keras HDF Files: https://github.com/fchollet/deep-learning-models/releases/tag/v0.1
2. VGG paper: https://arxiv.org/pdf/1409.1556.pdf