### PR TITLE
Fix minor mistakes in numeric and analytic gradient checks.

### DIFF
--- a/tiny_dnn/core/kernels/fully_connected_op_internal.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_internal.h
@@ -33,11 +33,11 @@ inline void fully_connected_op_internal(const Tensor<float_t, S1> &in_data,
       out_data.host_at(sample, i) = float_t{0};
       for (size_t c = 0; c < in_size; c++) {
         out_data.host_at(sample, i) +=
-          weights.host_at(0, c * out_size + i) * in_data.host_at(sample, c);
+          weights.host_at(c * out_size + i) * in_data.host_at(sample, c);
       }
 
       if (bias.size() >= out_size) {
-        out_data.host_at(sample, i) += bias.host_at(0, i);
+        out_data.host_at(sample, i) += bias.host_at(i);
       }
     }
   });
@@ -75,7 +75,7 @@ inline void fully_connected_op_internal(const Tensor<float_t, S1> &prev_out,
       // prev_delta[c] += current_delta[r] * W_[c * out_size_ + r]
       prev_delta.host_at(sample, c) +=
         vectorize::dot(curr_delta.host_pointer(sample, 0),
-                       weigths.host_pointer(0, c * out_size), out_size);
+                       weigths.host_pointer(c * out_size), out_size);
     }
 
     for_(layer_parallelize, 0, size_t(out_size), [&](const blocked_range &r) {

--- a/tiny_dnn/util/gradient_check.h
+++ b/tiny_dnn/util/gradient_check.h
@@ -16,13 +16,13 @@
 namespace tiny_dnn {
 
 /**
- * Auxiliar function to convert a vector of tensors to a vector of tensor
+ * Auxiliary function to convert a vector of Tensors to a vector of Tensor
  * pointers.
- * @param input vector of tensors.
- * @return vector of tensor pointers.
+ * @param input vector of Tensors.
+ * @return vector of Tensor pointers.
  */
-std::vector<tensor_t *> tensor2ptr(std::vector<tensor_t> &input) {
-  std::vector<tensor_t *> ret(input.size());
+std::vector<Tensor<> *> tensor2ptr(std::vector<Tensor<>> &input) {
+  std::vector<Tensor<> *> ret(input.size());
   for (size_t i = 0; i < input.size(); i++) {
     ret[i] = &input[i];
   }
@@ -59,24 +59,32 @@ float_t numeric_gradient(layer &layer,
   // sqrt(machine epsilon) is assumed to be safe
   float_t h = std::sqrt(std::numeric_limits<float_t>::epsilon());
   // initialize input/output
-  Tensor<> in_tens(in_data), out_tens(out_data), out_grads_tens(out_grads);
-  out_tens.fill(0);
-  out_grads_tens.fill(0);
-  std::vector<Tensor<> *> in_tens_, out_tens_, out_grads_tens_;
-  in_tens_.push_back(&in_tens);
-  out_tens_.push_back(&out_tens);
-  out_grads_tens_.push_back(&out_grads_tens);
+  std::vector<Tensor<>> in_tens, out_tens, out_grads_tens;
+  for (size_t i = 0; i < in_data.size(); i++) {
+    in_tens.push_back(Tensor<>(in_data[i]));
+  }
+  for (size_t i = 0; i < out_data.size(); i++) {
+    Tensor<> out_data_i(out_data[i]), out_grads_i(out_grads[i]);
+    out_data_i.fill(0);
+    out_grads_i.fill(0);
+    out_tens.push_back(out_data_i);
+    out_grads_tens.push_back(out_grads_i);
+  }
+
+  std::vector<Tensor<> *> in_tens_(tensor2ptr(in_tens));
+  std::vector<Tensor<> *> out_tens_(tensor2ptr(out_tens));
+  std::vector<Tensor<> *> out_grads_tens_(tensor2ptr(out_grads_tens));
 
   // Set output gradient to 1 so that input grad is 1*f'(x)
-  out_grads_tens[out_edge].host_at(0, out_pos) = 1.0;
+  out_grads_tens_[out_edge]->host_at(0, out_pos) = 1.0;
   // Save current input value to perturb
   float_t prev_in = in_tens[in_edge].host_at(0, in_pos);
   // Perturb by a small amount (-h)
-  in_tens[in_edge].host_at(0, in_pos) = prev_in - h;
+  in_tens_[in_edge]->host_at(0, in_pos) = prev_in - h;
   layer.forward_propagation(in_tens_, out_tens_);
   float_t out_1 = out_tens_[out_edge]->host_at(0, out_pos);
   // Perturb by a small amount (+h)
-  in_tens[in_edge].host_at(0, in_pos) = prev_in + h;
+  in_tens_[in_edge]->host_at(0, in_pos) = prev_in + h;
   layer.forward_propagation(in_tens_, out_tens_);
   float_t out_2 = out_tens_[out_edge]->host_at(0, out_pos);
   // numerical gradient
@@ -105,23 +113,31 @@ float_t analytical_gradient(layer &layer,
                             const size_t out_edge,
                             const size_t out_pos) {
   // initialize input/output
-  Tensor<> in_tens(in_data), out_tens(out_data), out_grads_tens(out_grads),
-    in_grads_tens = in_tens;
-  out_tens.fill(0);
-  out_grads_tens.fill(0);
-  in_grads_tens = in_tens;
-  std::vector<Tensor<> *> in_tens_, in_grads_tens_, out_tens_, out_grads_tens_;
+  std::vector<Tensor<>> in_tens, out_tens, out_grads_tens, in_grads_tens;
+  for (size_t i = 0; i < in_data.size(); i++) {
+    Tensor<> in_data_i(in_data[i]), in_grads_i(in_data[i]);
+    in_grads_i.fill(0);
+    in_tens.push_back(in_data_i);
+    in_grads_tens.push_back(in_grads_i);
+  }
+  for (size_t i = 0; i < out_data.size(); i++) {
+    Tensor<> out_data_i(out_data[i]), out_grads_i(out_grads[i]);
+    out_data_i.fill(0);
+    out_grads_i.fill(0);
+    out_tens.push_back(out_data_i);
+    out_grads_tens.push_back(out_grads_i);
+  }
 
-  in_tens_.push_back(&in_tens);
-  out_tens_.push_back(&out_tens);
-  out_grads_tens_.push_back(&out_grads_tens);
-  in_grads_tens_.push_back(&in_grads_tens);
+  std::vector<Tensor<> *> in_tens_(tensor2ptr(in_tens));
+  std::vector<Tensor<> *> in_grads_tens_(tensor2ptr(in_grads_tens));
+  std::vector<Tensor<> *> out_tens_(tensor2ptr(out_tens));
+  std::vector<Tensor<> *> out_grads_tens_(tensor2ptr(out_grads_tens));
 
-  out_grads_tens[out_edge].host_at(0, out_pos) = 1.0;  // set target grad to 1.
+  out_grads_tens_[out_edge]->host_at(0, out_pos) = 1.0;  // set target grad 1
   // get gradient by plain backpropagation
   layer.forward_propagation(in_tens_, out_tens_);
   layer.back_propagation(in_tens_, out_tens_, out_grads_tens_, in_grads_tens_);
-  return in_grads_tens[in_edge].host_at(0, in_pos);
+  return in_grads_tens_[in_edge]->host_at(0, in_pos);
 }
 
 /**


### PR DESCRIPTION
Earlier, target gradient was not set as 1 because the value was not referenced, but instead a copy of actual. Hence both numeric and analytic gradients remained zero for many tests, passing them all.