### PR TITLE
Remove some dead code found by Clang Static Code Analyzer

### DIFF
--- a/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_conv2d_kernel.h
@@ -287,7 +287,6 @@ inline void tiny_quantized_conv2d_back_kernel(const conv_params &params,
   vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(
     prev_delta_requantized, min_prev_delta_requantized,
     max_prev_delta_requantized);
-  prev_delta = &prev_delta_vec;
 
   // Accumulate dw
   for_i(params.in.depth_, [&](size_t inc) {
@@ -367,15 +366,6 @@ inline void tiny_quantized_conv2d_kernel(const conv_params &params,
   if (W_r[0] == W_r[1]) {
     max_filter = W_r[1] + 1e-3f;
     min_filter = W_r[0] - 1e-3f;
-  }
-  // bias range
-  float_t min_bias(b_r[0]);
-  float_t max_bias(b_r[1]);
-  if (params.has_bias) {
-    if (min_bias == max_bias) {
-      max_bias = b_r[1] + 1e-3f;
-      min_bias = b_r[0] - 1e-3f;
-    }
   }
   // output range
   float_t min_output_value;

--- a/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
+++ b/tiny_dnn/core/kernels/tiny_quantized_deconv2d_kernel.h
@@ -284,7 +284,6 @@ inline void tiny_quantized_deconv2d_back_kernel(const deconv_params &params,
   vec_t prev_delta_vec = quantized_tensor_to_float<uint8_t>(
     prev_delta_requantized, min_prev_delta_requantized,
     max_prev_delta_requantized);
-  prev_delta = &prev_delta_vec;
 
   // Accumulate dw
   for_i(params.in.depth_, [&](size_t inc) {
@@ -363,15 +362,6 @@ inline void tiny_quantized_deconv2d_kernel(const deconv_params &params,
   if (W_r[0] == W_r[1]) {
     max_filter = W_r[1] + 1e-3f;
     min_filter = W_r[0] - 1e-3f;
-  }
-  // bias range
-  float_t min_bias(b_r[0]);
-  float_t max_bias(b_r[1]);
-  if (params.has_bias) {
-    if (min_bias == max_bias) {
-      max_bias = b_r[1] + 1e-3f;
-      min_bias = b_r[0] - 1e-3f;
-    }
   }
   // output range
   float_t min_output_value;


### PR DESCRIPTION
This is the continuation of my previous PR: #518

Remove some dead code. If you have doubt just look for these variables in a text editor, they have no effect. Straightforward.