### PR TITLE
Consistent use of preprocessor macros

### DIFF
--- a/cereal/external/rapidjson/writer.h
+++ b/cereal/external/rapidjson/writer.h
@@ -37,7 +37,7 @@ public:
 	Writer(Stream& stream, int precision = 20, Allocator* allocator = 0, size_t levelDepth = kDefaultLevelDepth) :
 		stream_(stream), level_stack_(allocator, levelDepth * sizeof(Level))
   {
-#if _MSC_VER
+#ifdef _MSC_VER
     (void) sprintf_s(double_format, sizeof(double_format), "%%0.%dg", precision);
     (void) sprintf_s( long_double_format, sizeof( long_double_format ), "%%0.%dLg", precision );
 #else
@@ -211,7 +211,7 @@ protected:
 	//! \todo Optimization with custom double-to-string converter.
 	void WriteDouble(double d) {
 		char buffer[100];
-#if _MSC_VER
+#ifdef _MSC_VER
 		int ret = sprintf_s(buffer, sizeof(buffer), double_format, d);
 #else
 		int ret = snprintf(buffer, sizeof(buffer), double_format, d);
@@ -223,7 +223,7 @@ protected:
 
 	void WriteLongDouble(long double d) {
 		char buffer[256];
-#if _MSC_VER
+#ifdef _MSC_VER
 		int ret = sprintf_s(buffer, sizeof(buffer), long_double_format, d);
 #else
 		int ret = snprintf(buffer, sizeof(buffer), long_double_format, d);
@@ -235,7 +235,7 @@ protected:
 
 	void WriteLongLong(long long d) {
 		char buffer[256];
-#if _MSC_VER
+#ifdef _MSC_VER
 		int ret = sprintf_s(buffer, sizeof(buffer), "%lld", d);
 #else
 		int ret = snprintf(buffer, sizeof(buffer), "%lld", d);
@@ -247,7 +247,7 @@ protected:
 
 	void WriteULongLong(unsigned long long d) {
 		char buffer[256];
-#if _MSC_VER
+#ifdef _MSC_VER
 		int ret = sprintf_s(buffer, sizeof(buffer), "%llu", d);
 #else
 		int ret = snprintf(buffer, sizeof(buffer), "%llu", d);


### PR DESCRIPTION
On non-MSVC platforms, `_MSC_VER` is not defined, which results in a warning. When you treat warnings as errors, it doesn't compile at all.

`#if` vs. `#ifdef` is inconsistent in this file anyways, so I changed them all to `#ifdef`.