### PR TITLE
Supported CBLAS for fully_connected_op. 

### DIFF
--- a/tiny_dnn/core/backend.h
+++ b/tiny_dnn/core/backend.h
@@ -27,7 +27,7 @@ namespace core {
 // TODO(edgar): remove this
 class context;
 
-enum class backend_t { internal, nnpack, libdnn, avx, opencl };
+enum class backend_t { internal, nnpack, libdnn, avx, opencl, cblas };
 
 inline std::ostream &operator<<(std::ostream &os, backend_t type) {
   switch (type) {

--- a/tiny_dnn/core/kernels/fully_connected_op.h
+++ b/tiny_dnn/core/kernels/fully_connected_op.h
@@ -10,6 +10,7 @@
 #include "tiny_dnn/core/framework/op_kernel.h"
 
 #include "tiny_dnn/core/kernels/fully_connected_op_avx.h"
+#include "tiny_dnn/core/kernels/fully_connected_op_cblas.h"
 #include "tiny_dnn/core/kernels/fully_connected_op_internal.h"
 #include "tiny_dnn/core/kernels/fully_connected_op_nnpack.h"
 
@@ -48,6 +49,10 @@ class FullyConnectedOp : public core::OpKernel {
       kernels::fully_connected_op_avx(in_data, W[0],
                                       params.has_bias_ ? (*bias)[0] : vec_t(),
                                       out_data, params, context.parallelize());
+    } else if (engine == core::backend_t::cblas) {
+      kernels::fully_connected_op_cblas(
+        in_data, W[0], params.has_bias_ ? (*bias)[0] : vec_t(), out_data,
+        params, context.parallelize());
     } else {
       throw nn_error("Not supported engine: " + to_string(engine));
     }

--- a/tiny_dnn/core/kernels/fully_connected_op_cblas.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_cblas.h
@@ -11,7 +11,7 @@
 
 #ifdef CNN_USE_CBLAS
 extern "C" {
-  #include <cblas.h>
+#include <cblas.h>
 }
 #endif
 
@@ -19,17 +19,17 @@ namespace tiny_dnn {
 namespace kernels {
 
 inline void fully_connected_op_cblas(const tensor_t &in_data,
-                                        const vec_t &W,
-                                        const vec_t &bias,
-                                        tensor_t &out_data,
-                                        const core::fully_params &params,
-                                        const bool layer_parallelize) {
+                                     const vec_t &W,
+                                     const vec_t &bias,
+                                     tensor_t &out_data,
+                                     const core::fully_params &params,
+                                     const bool layer_parallelize) {
 #ifdef CNN_USE_CBLAS
   size_t out_size = params.out_size_;
-  size_t in_size = params.in_size_;
-  float_t alpha = 1;
-  float_t beta = 1;
-  float_t *input = reinterpret_cast<float_t *>(in_data[0].data());
+  size_t in_size  = params.in_size_;
+  float_t alpha   = 1;
+  float_t beta    = 1;
+  float_t *input  = reinterpret_cast<float_t *>(in_data[0].data());
   float_t *weight = reinterpret_cast<float_t *>(W.data());
   float_t *output = out_data[0].data();
   memcpy(output, bias.data(), sizeof(float_t) * out_size);

--- a/tiny_dnn/core/kernels/fully_connected_op_cblas.h
+++ b/tiny_dnn/core/kernels/fully_connected_op_cblas.h
@@ -1,0 +1,48 @@
+/*
+    Copyright (c) 2013, Taiga Nomi and the respective contributors
+    All rights reserved.
+
+    Use of this source code is governed by a BSD-style license that can be found
+    in the LICENSE file.
+*/
+#pragma once
+
+#include "tiny_dnn/core/params/fully_params.h"
+
+#ifdef CNN_USE_CBLAS
+extern "C" {
+  #include <cblas.h>
+}
+#endif
+
+namespace tiny_dnn {
+namespace kernels {
+
+inline void fully_connected_op_cblas(const tensor_t &in_data,
+                                        const vec_t &W,
+                                        const vec_t &bias,
+                                        tensor_t &out_data,
+                                        const core::fully_params &params,
+                                        const bool layer_parallelize) {
+#ifdef CNN_USE_CBLAS
+  size_t out_size = params.out_size_;
+  size_t in_size = params.in_size_;
+  float_t alpha = 1;
+  float_t beta = 1;
+  float_t *input = reinterpret_cast<float_t *>(in_data[0].data());
+  float_t *weight = reinterpret_cast<float_t *>(W.data());
+  float_t *output = out_data[0].data();
+  memcpy(output, bias.data(), sizeof(float_t) * out_size);
+#ifdef CNN_USE_DOUBLE
+  cblas_dgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 1, out_size, in_size,
+              alpha, input, in_size, weight, out_size, beta, output, out_size);
+#else
+  cblas_sgemm(CblasRowMajor, CblasNoTrans, CblasNoTrans, 1, out_size, in_size,
+              alpha, input, in_size, weight, out_size, beta, output, out_size);
+#endif
+
+#endif  // CNN_USE_CBLAS
+}
+
+}  // namespace kernels
+}  // namespace tiny_dnn


### PR DESCRIPTION
Add a new fully connected op: fully_connected_op_cblas, which uses CBLAS as its back-end.