### PR TITLE
32bit and 64bit portability issue with serialization

### DIFF
--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -35,7 +35,11 @@ enum class content_type {
   weights_and_model  ///< save/load both the weights and the architecture
 };
 
-enum class file_format { binary, json };
+enum class file_format {
+  binary,
+  portable_binary,
+  json
+};
 
 struct result {
   result() : num_success(0), num_total(0) {}
@@ -685,6 +689,10 @@ class network {
         cereal::BinaryInputArchive bi(ifs);
         from_archive(bi, what);
       } break;
+      case file_format::portable_binary: {
+        cereal::PortableBinaryInputArchive bi(ifs);
+        from_archive(bi, what);
+      } break;
       case file_format::json: {
         cereal::JSONInputArchive ji(ifs);
         from_archive(ji, what);
@@ -706,6 +714,10 @@ class network {
     switch (format) {
       case file_format::binary: {
         cereal::BinaryOutputArchive bo(ofs);
+        to_archive(bo, what);
+      } break;
+      case file_format::portable_binary: {
+        cereal::PortableBinaryOutputArchive bo(ofs);
         to_archive(bo, what);
       } break;
       case file_format::json: {

--- a/tiny_dnn/network.h
+++ b/tiny_dnn/network.h
@@ -35,11 +35,7 @@ enum class content_type {
   weights_and_model  ///< save/load both the weights and the architecture
 };
 
-enum class file_format {
-  binary,
-  portable_binary,
-  json
-};
+enum class file_format { binary, portable_binary, json };
 
 struct result {
   result() : num_success(0), num_total(0) {}

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -29,57 +29,75 @@ static inline cereal::NameValuePair<T> make_nvp(const char *name, T &&value) {
   return cereal::make_nvp(name, value);
 }
 
-template < typename T > struct is_binary_input_archive { static const bool value = false; };
-template < typename T > struct is_binary_output_archive { static const bool value = false; };
-template<> struct is_binary_input_archive<cereal::BinaryInputArchive> { static const bool value = true; };
-template<> struct is_binary_input_archive<cereal::PortableBinaryInputArchive> { static const bool value = true; };
-template<> struct is_binary_output_archive<cereal::BinaryOutputArchive> { static const bool value = true; };
-template<> struct is_binary_output_archive<cereal::PortableBinaryOutputArchive> { static const bool value = true; };
+template <typename T>
+struct is_binary_input_archive {
+  static const bool value = false;
+};
+template <typename T>
+struct is_binary_output_archive {
+  static const bool value = false;
+};
+template <>
+struct is_binary_input_archive<cereal::BinaryInputArchive> {
+  static const bool value = true;
+};
+template <>
+struct is_binary_input_archive<cereal::PortableBinaryInputArchive> {
+  static const bool value = true;
+};
+template <>
+struct is_binary_output_archive<cereal::BinaryOutputArchive> {
+  static const bool value = true;
+};
+template <>
+struct is_binary_output_archive<cereal::PortableBinaryOutputArchive> {
+  static const bool value = true;
+};
 
 template <class Archive, typename dummy = Archive>
 struct ArchiveWrapper {
-  ArchiveWrapper(Archive& ar) : ar(ar) {}
+  ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
-  void operator () (T& arg) {
+  void operator()(T &arg) {
     ar(arg);
   }
-  Archive& ar;
+  Archive &ar;
 };
 
 template <typename Archive>
 struct ArchiveWrapper<
   Archive,
-  typename std::enable_if<is_binary_input_archive<Archive>::value, Archive>::type
-> {
-  ArchiveWrapper(Archive& ar) : ar(ar) {}
+  typename std::enable_if<is_binary_input_archive<Archive>::value,
+                          Archive>::type> {
+  ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
-  void operator () (T& arg) {
+  void operator()(T &arg) {
     ar(arg);
   }
-  void operator () (cereal::NameValuePair<size_t&>& arg) {
+  void operator()(cereal::NameValuePair<size_t &> &arg) {
     cereal::NameValuePair<serial_size_t> arg2(arg.name, 0);
     ar(arg2);
     arg.value = arg2.value;
   }
-  Archive& ar;
+  Archive &ar;
 };
 
 template <typename Archive>
 struct ArchiveWrapper<
   Archive,
-  typename std::enable_if<is_binary_output_archive<Archive>::value, Archive>::type
-> {
-  ArchiveWrapper(Archive& ar) : ar(ar) {}
+  typename std::enable_if<is_binary_output_archive<Archive>::value,
+                          Archive>::type> {
+  ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
-  void operator () (T& arg) {
+  void operator()(T &arg) {
     ar(arg);
   }
-  void operator () (cereal::NameValuePair<size_t&>& arg) {
+  void operator()(cereal::NameValuePair<size_t &> &arg) {
     cereal::NameValuePair<serial_size_t> arg2(arg.name, 0);
     arg2.value = static_cast<serial_size_t>(arg.value);
     ar(arg2);
   }
-  Archive& ar;
+  Archive &ar;
 };
 
 template <class Archive, typename T>

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -56,7 +56,7 @@ struct is_binary_output_archive<cereal::PortableBinaryOutputArchive> {
 
 template <class Archive, typename dummy = Archive>
 struct ArchiveWrapper {
-  ArchiveWrapper(Archive &ar) : ar(ar) {}
+  explicit ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
   void operator()(T &arg) {
     ar(arg);
@@ -69,7 +69,7 @@ struct ArchiveWrapper<
   Archive,
   typename std::enable_if<is_binary_input_archive<Archive>::value,
                           Archive>::type> {
-  ArchiveWrapper(Archive &ar) : ar(ar) {}
+  explicit ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
   void operator()(T &arg) {
     ar(arg);
@@ -87,7 +87,7 @@ struct ArchiveWrapper<
   Archive,
   typename std::enable_if<is_binary_output_archive<Archive>::value,
                           Archive>::type> {
-  ArchiveWrapper(Archive &ar) : ar(ar) {}
+  explicit ArchiveWrapper(Archive &ar) : ar(ar) {}
   template <typename T>
   void operator()(T &arg) {
     ar(arg);

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -102,7 +102,7 @@ struct ArchiveWrapper<
 
 template <class Archive, typename T>
 void arc(Archive &ar, T &&arg) {
-  ArchiveWrapper<typename Archive> wa(ar);
+  ArchiveWrapper<Archive> wa(ar);
   wa(arg);
 }
 

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -28,6 +28,7 @@
 
 #ifndef CNN_NO_SERIALIZATION
 #include <cereal/archives/binary.hpp>
+#include <cereal/archives/portable_binary.hpp>
 #include <cereal/archives/json.hpp>
 #include <cereal/cereal.hpp>
 #include <cereal/types/deque.hpp>

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -28,8 +28,8 @@
 
 #ifndef CNN_NO_SERIALIZATION
 #include <cereal/archives/binary.hpp>
-#include <cereal/archives/portable_binary.hpp>
 #include <cereal/archives/json.hpp>
+#include <cereal/archives/portable_binary.hpp>
 #include <cereal/cereal.hpp>
 #include <cereal/types/deque.hpp>
 #include <cereal/types/polymorphic.hpp>


### PR DESCRIPTION
This PR fixes 32bit and 64bit portability issue with serialization.
I also added support for cereal library's portable binary archive.
