### PR TITLE
Update Docker image to Ubuntu 18.04

### DIFF
--- a/docker/dev-env/Dockerfile
+++ b/docker/dev-env/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 MAINTAINER Edgar Riba <edgar.riba@gmail.com>
 

--- a/docker/dev-env/Dockerfile.full
+++ b/docker/dev-env/Dockerfile.full
@@ -1,4 +1,4 @@
-FROM ubuntu:17.04
+FROM ubuntu:18.04
 
 MAINTAINER Edgar Riba <edgar.riba@gmail.com>
 

--- a/docker/dev-env/build.sh
+++ b/docker/dev-env/build.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 tag_prefix="tinydnn/tinydnn"
 
-docker_images=('dev-ubuntu17.04' 'dev-full-ubuntu17.04')
+docker_images=('dev-ubuntu18.04' 'dev-full-ubuntu18.04')
 
 if [ $# -eq 0 ] ; then
     docker_tag=$tag_prefix/${docker_images[0]}


### PR DESCRIPTION
Ubuntu 17.04 is End-of-life. Use 18.04 LTS instead.

Signed-off-by: Davor Micunovic <dmicunov@gmail.com>