### PR TITLE
Add ceil_mode to max pooling and average pooling

### DIFF
--- a/examples/cifar10/train.cpp
+++ b/examples/cifar10/train.cpp
@@ -25,17 +25,17 @@ void construct_net(N &nn, tiny_dnn::core::backend_t backend_type) {
 
   nn << conv(32, 32, 5, 3, n_fmaps, tiny_dnn::padding::same, true, 1, 1, 1, 1,
              backend_type)                      // C1
-     << pool(32, 32, n_fmaps, 2, backend_type)  // P2
+     << pool(32, 32, n_fmaps, 2, false, backend_type)  // P2
      << relu()                                  // activation
      << conv(16, 16, 5, n_fmaps, n_fmaps, tiny_dnn::padding::same, true, 1, 1,
              1, 1,
              backend_type)                      // C3
-     << pool(16, 16, n_fmaps, 2, backend_type)  // P4
+     << pool(16, 16, n_fmaps, 2, false, backend_type)  // P4
      << relu()                                  // activation
      << conv(8, 8, 5, n_fmaps, n_fmaps2, tiny_dnn::padding::same, true, 1, 1, 1,
              1,
              backend_type)                                // C5
-     << pool(8, 8, n_fmaps2, 2, backend_type)             // P6
+     << pool(8, 8, n_fmaps2, 2, false, backend_type)             // P6
      << relu()                                            // activation
      << fc(4 * 4 * n_fmaps2, n_fc, true, backend_type)    // FC7
      << relu()                                            // activation

--- a/test/test_average_pooling_layer.h
+++ b/test/test_average_pooling_layer.h
@@ -41,7 +41,7 @@ TEST(ave_pool, forward) {
 }
 
 TEST(ave_pool, forward_stride) {
-  average_pooling_layer l(4, 4, 1, 2, 1);
+  average_pooling_layer l(4, 4, 1, 2, 1, false);
   // clang-format off
     vec_t in = {
         0,  1,  2,  3,

--- a/test/test_integration.h
+++ b/test/test_integration.h
@@ -375,7 +375,7 @@ TEST(integration, gradient_check19) {  // padding-same
   using network    = network<sequential>;
 
   network nn;
-  nn << average_pooling_layer(4, 2, 1, 2, 2, 1, 1, padding::same)
+  nn << average_pooling_layer(4, 2, 1, 2, 2, 1, 1, false, padding::same)
      << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());

--- a/test/test_integration.h
+++ b/test/test_integration.h
@@ -342,7 +342,7 @@ TEST(integration, gradient_check17) {  // x-stride
 
   network nn;
   nn << fully_connected_layer(3, 8) << activation()
-     << average_pooling_layer(4, 2, 1, 2, 1, 2, 1)  // 4x2 => 2x2
+     << average_pooling_layer(4, 2, 1, 2, 1, 2, 1, false)  // 4x2 => 2x2
      << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());
@@ -359,7 +359,7 @@ TEST(integration, gradient_check18) {  // y-stride
 
   network nn;
   nn << fully_connected_layer(3, 8) << activation()
-     << average_pooling_layer(4, 2, 1, 1, 2, 1, 2)  // 4x2 => 4x1
+     << average_pooling_layer(4, 2, 1, 1, 2, 1, 2, false)  // 4x2 => 4x1
      << activation();
 
   const auto test_data = generate_gradient_check_data(nn.in_data_size());

--- a/test/test_max_pooling_layer.h
+++ b/test/test_max_pooling_layer.h
@@ -85,7 +85,7 @@ TEST(max_pool, forward_stride_internal) {
 }
 
 TEST(max_pool, forward_padding_same) {
-  max_pooling_layer l(4, 4, 1, 2, 2, 1, 1, padding::same,
+  max_pooling_layer l(4, 4, 1, 2, 2, 1, 1, false, padding::same,
                       core::backend_t::internal);
 
   // clang-format off
@@ -114,7 +114,7 @@ TEST(max_pool, forward_padding_same) {
 }
 
 TEST(max_pool, forward_stride_x) {
-  max_pooling_layer l(4, 4, 1, 2, 1, 2, 1, padding::valid);
+  max_pooling_layer l(4, 4, 1, 2, 1, 2, 1, false, padding::valid);
   // clang-format off
     vec_t in = {
         0,  1,  2,  3,
@@ -144,7 +144,7 @@ TEST(max_pool, forward_stride_x) {
 }
 
 TEST(max_pool, forward_stride_y) {
-  max_pooling_layer l(4, 4, 1, 1, 2, 1, 2, padding::valid);
+  max_pooling_layer l(4, 4, 1, 1, 2, 1, 2, false, padding::valid);
   // clang-format off
     vec_t in = {
         0,  1,  2,  3,
@@ -223,7 +223,7 @@ TEST(max_pool, forward_stride_nnp_not_2x2) {
 #endif
 
 TEST(max_pool, forward_stride) {
-  max_pooling_layer l(4, 4, 1, 2, 1);
+  max_pooling_layer l(4, 4, 1, 2, 1, false);
   // clang-format off
     vec_t in = {
         0,  1,  2,  3,
@@ -312,7 +312,7 @@ TEST(max_pool, serialization) {
 }
 
 TEST(max_pool, serialization_stride) {
-  max_pooling_layer src(4, 4, 1, 2, 1, 1, 2, padding::valid);
+  max_pooling_layer src(4, 4, 1, 2, 1, 1, 2, false, padding::valid);
 
   std::string str = layer_to_json(src);
 
@@ -342,7 +342,7 @@ TEST(max_pool, serialization_stride) {
 }
 
 TEST(max_pool, serialization_padding) {
-  max_pooling_layer src(4, 4, 1, 2, 2, 1, 1, padding::same);
+  max_pooling_layer src(4, 4, 1, 2, 2, 1, 1, false, padding::same);
 
   std::string str = layer_to_json(src);
 

--- a/test/test_node.h
+++ b/test/test_node.h
@@ -13,8 +13,8 @@
 namespace tiny_dnn {
 
 TEST(layer_tuple, comma_operator_layer_layer1) {
-  max_pooling_layer maxpool(4, 4, 1, 2, 1);
-  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  max_pooling_layer maxpool(4, 4, 1, 2, 1, false);
+  average_pooling_layer avepool(4, 4, 1, 2, 1, false);
   sigmoid_layer sgm(4, 4, 1);
 
   layer_tuple<layer *> tuple_1 = (maxpool, avepool);
@@ -27,8 +27,8 @@ TEST(layer_tuple, comma_operator_layer_layer1) {
 }
 
 TEST(layer_tuple, comma_operator_layer_layer2) {
-  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
-  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1, false);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1, false);
   auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
 
   layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);
@@ -41,8 +41,8 @@ TEST(layer_tuple, comma_operator_layer_layer2) {
 }
 
 TEST(layer_tuple, comma_operator_tuple_layer1) {
-  max_pooling_layer maxpool(4, 4, 1, 2, 1);
-  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  max_pooling_layer maxpool(4, 4, 1, 2, 1, false);
+  average_pooling_layer avepool(4, 4, 1, 2, 1, false);
   sigmoid_layer sgm(4, 4, 1);
 
   layer_tuple<layer *> tuple_1 = (maxpool, avepool);
@@ -54,8 +54,8 @@ TEST(layer_tuple, comma_operator_tuple_layer1) {
 }
 
 TEST(layer_tuple, comma_operator_tuple_layer2) {
-  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
-  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1, false);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1, false);
   auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
 
   layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);
@@ -67,8 +67,8 @@ TEST(layer_tuple, comma_operator_tuple_layer2) {
 }
 
 TEST(layer_tuple, comma_operator_layer_tuple1) {
-  max_pooling_layer maxpool(4, 4, 1, 2, 1);
-  average_pooling_layer avepool(4, 4, 1, 2, 1);
+  max_pooling_layer maxpool(4, 4, 1, 2, 1, false);
+  average_pooling_layer avepool(4, 4, 1, 2, 1, false);
   sigmoid_layer sgm(4, 4, 1);
 
   layer_tuple<layer *> tuple_1 = (maxpool, avepool);
@@ -80,8 +80,8 @@ TEST(layer_tuple, comma_operator_layer_tuple1) {
 }
 
 TEST(layer_tuple, comma_operator_layer_tuple2) {
-  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1);
-  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1);
+  auto maxpool = std::make_shared<max_pooling_layer>(4, 4, 1, 2, 1, false);
+  auto avepool = std::make_shared<average_pooling_layer>(4, 4, 1, 2, 1, false);
   auto sgm     = std::make_shared<sigmoid_layer>(4, 4, 1);
 
   layer_tuple<std::shared_ptr<layer>> tuple_1 = (maxpool, avepool);

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -45,7 +45,7 @@ TEST(serialization, serialize_avepool) {
                 "pool_size_y": 2,
                 "stride_x": 2,
                 "stride_y": 2,
-                "ceil_mode", false,
+                "ceil_mode": false,
                 "pad_type": 0
             }
         ]
@@ -487,7 +487,7 @@ TEST(serialization, serialize_maxpool) {
                 "pool_size_y": 2,
                 "stride_x": 1,
                 "stride_y": 1,
-                "ceil_mode", false,
+                "ceil_mode": false,
                 "pad_type": 1
             }
         ]

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -45,6 +45,7 @@ TEST(serialization, serialize_avepool) {
                 "pool_size_y": 2,
                 "stride_x": 2,
                 "stride_y": 2,
+                "ceil_mode", false,
                 "pad_type": 0
             }
         ]
@@ -486,6 +487,7 @@ TEST(serialization, serialize_maxpool) {
                 "pool_size_y": 2,
                 "stride_x": 1,
                 "stride_y": 1,
+                "ceil_mode", false,
                 "pad_type": 1
             }
         ]

--- a/tiny_dnn/core/params/maxpool_params.h
+++ b/tiny_dnn/core/params/maxpool_params.h
@@ -22,6 +22,7 @@ class maxpool_params : public Params {
   size_t pool_size_y;
   size_t stride_x;
   size_t stride_y;
+  bool ceil_mode;
   padding pad_type;
 
   /* mapping out => max_index(in) (1:1) */

--- a/tiny_dnn/io/caffe/caffe.proto
+++ b/tiny_dnn/io/caffe/caffe.proto
@@ -905,6 +905,9 @@ message PoolingParameter {
   // If global_pooling then it will pool over the size of the bottom by doing
   // kernel_h = bottom->height and kernel_w = bottom->width
   optional bool global_pooling = 12 [default = false];
+  // Specify floor/ceil mode
+  // See pull request # 3057 in caffe
+  optional bool ceil_mode = 13 [default = false];
 }
 
 message PowerParameter {

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -130,13 +130,14 @@ inline std::shared_ptr<layer> create_max_pool(layer_size_t pool_size_w,
                                               layer_size_t pool_size_h,
                                               layer_size_t stride_w,
                                               layer_size_t stride_h,
+                                              bool ceil_mode,
                                               padding pad_type,
                                               const shape_t &bottom_shape,
                                               shape_t *top_shape) {
   using max_pool = max_pooling_layer;
   auto mp        = std::make_shared<max_pool>(
     bottom_shape.width_, bottom_shape.height_, bottom_shape.depth_, pool_size_w,
-    pool_size_h, stride_w, stride_h, pad_type);
+    pool_size_h, stride_w, stride_h, ceil_mode, pad_type);
 
   *top_shape = mp->out_shape()[0];
   mp->init_weight();
@@ -148,13 +149,14 @@ inline std::shared_ptr<layer> create_ave_pool(layer_size_t pool_size_w,
                                               layer_size_t pool_size_h,
                                               layer_size_t stride_w,
                                               layer_size_t stride_h,
+                                              bool ceil_mode,
                                               padding pad_type,
                                               const shape_t &bottom_shape,
                                               shape_t *top_shape) {
   using ave_pool = average_pooling_layer;
   auto ap        = std::make_shared<ave_pool>(
     bottom_shape.width_, bottom_shape.height_, bottom_shape.depth_, pool_size_w,
-    pool_size_h, stride_w, stride_h, pad_type);
+    pool_size_h, stride_w, stride_h, ceil_mode, pad_type);
 
   // tiny-dnn has trainable parameter in average-pooling layer
   float_t weight = 1.0 / (pool_size_w * pool_size_h);
@@ -217,6 +219,7 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
   layer_size_t pool_size_h = 0;
   layer_size_t h_pad       = 0;
   layer_size_t w_pad       = 0;
+  bool ceil_mode           = false;
   padding pad_type         = padding::valid;
 
   if (!get_kernel_size_2d(pool_param, &pool_size_w, &pool_size_h)) {
@@ -267,17 +270,17 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
     switch (type) {
       case caffe::PoolingParameter_PoolMethod_MAX:
         return create_max_pool(pool_size_w, pool_size_h, w_stride, h_stride,
-                               pad_type, bottom_shape, top_shape);
+                               ceil_mode, pad_type, bottom_shape, top_shape);
       case caffe::PoolingParameter_PoolMethod_AVE:
         return create_ave_pool(pool_size_w, pool_size_h, w_stride, h_stride,
-                               pad_type, bottom_shape, top_shape);
+                               ceil_mode, pad_type, bottom_shape, top_shape);
       default: throw nn_error("unsupported layer type");
     }
   }
 
   // default: max-pool
-  return create_max_pool(pool_size_w, pool_size_h, w_stride, h_stride, pad_type,
-                         bottom_shape, top_shape);
+  return create_max_pool(pool_size_w, pool_size_h, w_stride, h_stride, ceil_mode,
+                         pad_type, bottom_shape, top_shape);
 }
 
 inline std::shared_ptr<layer> create_relu(const caffe::LayerParameter &layer,

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -264,6 +264,10 @@ inline std::shared_ptr<layer> create_pooling(const caffe::LayerParameter &layer,
     //     if such a type existed
   }
 
+  if (pool_param.has_ceil_mode()) {
+    ceil_mode = pool_param.ceil_mode();
+  }
+
   if (pool_param.has_pool()) {
     auto type = pool_param.pool();
 

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -169,24 +169,6 @@ class average_pooling_layer : public partial_connected_layer {
                             ceil_mode,
                             padding::valid) {}
 
-  average_pooling_layer(size_t in_width,
-                        size_t in_height,
-                        size_t in_channels,
-                        size_t pool_size_x,
-                        size_t pool_size_y,
-                        size_t stride_x,
-                        size_t stride_y,
-                        padding pad_type = padding::valid) 
-    : average_pooling_layer(in_width,
-                            in_height,
-                            in_channels,
-                            pool_size_x,
-                            pool_size_y,
-                            stride_x,
-                            stride_y,
-                            false,
-                            padding::valid) {}
-
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image

--- a/tiny_dnn/layers/average_pooling_layer.h
+++ b/tiny_dnn/layers/average_pooling_layer.h
@@ -169,6 +169,24 @@ class average_pooling_layer : public partial_connected_layer {
                             ceil_mode,
                             padding::valid) {}
 
+  average_pooling_layer(size_t in_width,
+                        size_t in_height,
+                        size_t in_channels,
+                        size_t pool_size_x,
+                        size_t pool_size_y,
+                        size_t stride_x,
+                        size_t stride_y,
+                        padding pad_type = padding::valid) 
+    : average_pooling_layer(in_width,
+                            in_height,
+                            in_channels,
+                            pool_size_x,
+                            pool_size_y,
+                            stride_x,
+                            stride_y,
+                            false,
+                            padding::valid) {}
+
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -82,14 +82,35 @@ class max_pooling_layer : public layer {
                         padding::valid,
                         backend_type) {}
 
+  max_pooling_layer(size_t in_width,
+                    size_t in_height,
+                    size_t in_channels,
+                    size_t pooling_size_x,
+                    size_t pooling_size_y,
+                    size_t stride_x,
+                    size_t stride_y,
+                    padding pad_type             = padding::valid,
+                    core::backend_t backend_type = core::default_engine())
+    : max_pooling_layer(in_width,
+                        in_height,
+                        in_channels,
+                        pooling_size_x,
+                        pooling_size_y,
+                        stride_x,
+                        stride_y,
+                        false,
+                        padding::valid,
+                        backend_type) {}
+
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image
    * @param in_channels  [in] the number of input image channels(depth)
    * @param pooling_size [in] factor by which to downscale
    * @param stride       [in] interval at which to apply the filters to the
+   *input
    * @param ceil_mode    [in] when True, will use `ceil` instead of `floor` to
-   *compute the output shape input
+   *compute the output shape
    **/
   max_pooling_layer(size_t in_width,
                     size_t in_height,

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -33,29 +33,35 @@ class max_pooling_layer : public layer {
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image
    * @param in_channels  [in] the number of input image channels(depth)
+   * @param ceil_mode    [in] when True, will use `ceil` instead of `floor` to
+   *compute the output shape
    * @param pooling_size [in] factor by which to downscale
    **/
   max_pooling_layer(size_t in_width,
                     size_t in_height,
                     size_t in_channels,
                     size_t pooling_size,
+                    bool ceil_mode               = false,
                     core::backend_t backend_type = core::default_engine())
     : max_pooling_layer(in_width,
                         in_height,
                         in_channels,
                         pooling_size,
                         (in_height == 1 ? 1 : pooling_size),
+                        ceil_mode,
                         backend_type) {}
 
   max_pooling_layer(const shape3d &in_shape,
                     size_t pooling_size,
                     size_t stride,
+                    bool ceil_mode               = false,
                     core::backend_t backend_type = core::default_engine())
     : max_pooling_layer(in_shape.width_,
                         in_shape.height_,
                         in_shape.depth_,
                         pooling_size,
                         stride,
+                        ceil_mode,
                         backend_type) {}
 
   max_pooling_layer(size_t in_width,
@@ -63,6 +69,7 @@ class max_pooling_layer : public layer {
                     size_t in_channels,
                     size_t pooling_size,
                     size_t stride,
+                    bool ceil_mode               = false,
                     core::backend_t backend_type = core::default_engine())
     : max_pooling_layer(in_width,
                         in_height,
@@ -71,6 +78,7 @@ class max_pooling_layer : public layer {
                         (in_height == 1 ? 1 : pooling_size),
                         stride,
                         stride,
+                        ceil_mode,
                         padding::valid,
                         backend_type) {}
 
@@ -80,7 +88,8 @@ class max_pooling_layer : public layer {
    * @param in_channels  [in] the number of input image channels(depth)
    * @param pooling_size [in] factor by which to downscale
    * @param stride       [in] interval at which to apply the filters to the
-   *input
+   * @param ceil_mode    [in] when True, will use `ceil` instead of `floor` to
+   *compute the output shape input
    **/
   max_pooling_layer(size_t in_width,
                     size_t in_height,
@@ -89,15 +98,18 @@ class max_pooling_layer : public layer {
                     size_t pooling_size_y,
                     size_t stride_x,
                     size_t stride_y,
+                    bool ceil_mode               = false,
                     padding pad_type             = padding::valid,
                     core::backend_t backend_type = core::default_engine())
     : layer({vector_type::data}, {vector_type::data}) {
-    set_maxpool_params(
-      shape3d(in_width, in_height, in_channels),
-      shape3d(conv_out_length(in_width, pooling_size_x, stride_x, 1, pad_type),
-              conv_out_length(in_height, pooling_size_y, stride_y, 1, pad_type),
-              in_channels),
-      pooling_size_x, pooling_size_y, stride_x, stride_y, pad_type);
+    set_maxpool_params(shape3d(in_width, in_height, in_channels),
+                       shape3d(pool_out_length(in_width, pooling_size_x,
+                                               stride_x, ceil_mode, pad_type),
+                               pool_out_length(in_height, pooling_size_y,
+                                               stride_y, ceil_mode, pad_type),
+                               in_channels),
+                       pooling_size_x, pooling_size_y, stride_x, stride_y,
+                       ceil_mode, pad_type);
 
     init_connection();
     init_backend(backend_type);
@@ -192,7 +204,7 @@ class max_pooling_layer : public layer {
 
     for (size_t dy = 0; dy < dymax; dy++) {
       for (size_t dx = 0; dx < dxmax; dx++) {
-        size_t in_index = params_.in.get_index(outx * params_.stride_x + dx,
+        size_t in_index  = params_.in.get_index(outx * params_.stride_x + dx,
                                                outy * params_.stride_y + dy, c);
         size_t out_index = params_.out.get_index(outx, outy, c);
 
@@ -242,6 +254,7 @@ class max_pooling_layer : public layer {
                           size_t pooling_size_y,
                           size_t stride_x,
                           size_t stride_y,
+                          bool ceil_mode,
                           padding pad_type) {
     params_.in          = in;
     params_.out         = out;
@@ -249,6 +262,7 @@ class max_pooling_layer : public layer {
     params_.pool_size_y = pooling_size_y;
     params_.stride_x    = stride_x;
     params_.stride_y    = stride_y;
+    params_.ceil_mode   = ceil_mode;
     params_.pad_type    = pad_type;
   }
 };

--- a/tiny_dnn/layers/max_pooling_layer.h
+++ b/tiny_dnn/layers/max_pooling_layer.h
@@ -82,26 +82,6 @@ class max_pooling_layer : public layer {
                         padding::valid,
                         backend_type) {}
 
-  max_pooling_layer(size_t in_width,
-                    size_t in_height,
-                    size_t in_channels,
-                    size_t pooling_size_x,
-                    size_t pooling_size_y,
-                    size_t stride_x,
-                    size_t stride_y,
-                    padding pad_type             = padding::valid,
-                    core::backend_t backend_type = core::default_engine())
-    : max_pooling_layer(in_width,
-                        in_height,
-                        in_channels,
-                        pooling_size_x,
-                        pooling_size_y,
-                        stride_x,
-                        stride_y,
-                        false,
-                        padding::valid,
-                        backend_type) {}
-
   /**
    * @param in_width     [in] width of input image
    * @param in_height    [in] height of input image

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -147,6 +147,7 @@ struct LoadAndConstruct<tiny_dnn::average_pooling_layer> {
     cereal::construct<tiny_dnn::average_pooling_layer> &construct) {
     tiny_dnn::shape3d in;
     size_t stride_x, stride_y, pool_size_x, pool_size_y;
+    bool ceil_mode;
     tiny_dnn::padding pad_type;
 
     ::detail::arc(ar, ::detail::make_nvp("in_size", in),
@@ -154,9 +155,10 @@ struct LoadAndConstruct<tiny_dnn::average_pooling_layer> {
                   ::detail::make_nvp("pool_size_y", pool_size_y),
                   ::detail::make_nvp("stride_x", stride_x),
                   ::detail::make_nvp("stride_y", stride_y),
+                  ::detail::make_nvp("ceil_mode", ceil_mode),
                   ::detail::make_nvp("pad_type", pad_type));
     construct(in.width_, in.height_, in.depth_, pool_size_x, pool_size_y,
-              stride_x, stride_y, pad_type);
+              stride_x, stride_y, ceil_mode, pad_type);
   }
 };
 
@@ -365,6 +367,7 @@ struct LoadAndConstruct<tiny_dnn::max_pooling_layer> {
     Archive &ar, cereal::construct<tiny_dnn::max_pooling_layer> &construct) {
     tiny_dnn::shape3d in;
     size_t stride_x, stride_y, pool_size_x, pool_size_y;
+    bool ceil_mode;
     tiny_dnn::padding pad_type;
 
     ::detail::arc(ar, ::detail::make_nvp("in_size", in),
@@ -372,9 +375,10 @@ struct LoadAndConstruct<tiny_dnn::max_pooling_layer> {
                   ::detail::make_nvp("pool_size_y", pool_size_y),
                   ::detail::make_nvp("stride_x", stride_x),
                   ::detail::make_nvp("stride_y", stride_y),
+                  ::detail::make_nvp("ceil_mode", ceil_mode),
                   ::detail::make_nvp("pad_type", pad_type));
     construct(in.width_, in.height_, in.depth_, pool_size_x, pool_size_y,
-              stride_x, stride_y, pad_type);
+              stride_x, stride_y, ceil_mode, pad_type);
   }
 };
 

--- a/tiny_dnn/util/serialization_functions.h
+++ b/tiny_dnn/util/serialization_functions.h
@@ -751,6 +751,7 @@ struct serialization_buddy {
                   ::detail::make_nvp("pool_size_y", layer.pool_size_y_),
                   ::detail::make_nvp("stride_x", layer.stride_x_),
                   ::detail::make_nvp("stride_y", layer.stride_y_),
+                  ::detail::make_nvp("ceil_mode", layer.ceil_mode_),
                   ::detail::make_nvp("pad_type", layer.pad_type_));
   }
 
@@ -865,6 +866,7 @@ struct serialization_buddy {
                   ::detail::make_nvp("pool_size_y", params_.pool_size_y),
                   ::detail::make_nvp("stride_x", params_.stride_x),
                   ::detail::make_nvp("stride_y", params_.stride_y),
+                  ::detail::make_nvp("ceil_mode", params_.ceil_mode),
                   ::detail::make_nvp("pad_type", params_.pad_type));
   }
 

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -343,6 +343,28 @@ inline size_t conv_out_length(size_t in_length,
   return (output_length + stride - 1) / stride;
 }
 
+inline size_t pool_out_length(size_t in_length,
+                              size_t window_size,
+                              size_t stride,
+                              bool ceil_mode,
+                              padding pad_type) {
+  size_t output_length;
+
+  if (pad_type == padding::same) {
+    output_length = in_length;
+  } else if (pad_type == padding::valid) {
+    output_length = in_length - window_size + 1;
+  } else {
+    throw nn_error("Not recognized pad_type.");
+  }
+
+  if ( ceil_mode ) {
+    return static_cast<int>(ceil(static_cast<float>((output_length + stride - 1)) / stride));
+  } else {
+    return static_cast<int>(floor(static_cast<float>((output_length + stride - 1)) / stride));
+  }
+}
+
 // get all platforms (drivers), e.g. NVIDIA
 // https://github.com/CNugteren/CLCudaAPI/blob/master/samples/device_info.cc
 

--- a/tiny_dnn/util/util.h
+++ b/tiny_dnn/util/util.h
@@ -358,11 +358,8 @@ inline size_t pool_out_length(size_t in_length,
     throw nn_error("Not recognized pad_type.");
   }
 
-  if ( ceil_mode ) {
-    return static_cast<int>(ceil(static_cast<float>((output_length + stride - 1)) / stride));
-  } else {
-    return static_cast<int>(floor(static_cast<float>((output_length + stride - 1)) / stride));
-  }
+  float tmp = static_cast<float>((output_length + stride - 1)) / stride;
+  return static_cast<int>(ceil_mode ? ceil(tmp) : floor(tmp));
 }
 
 // get all platforms (drivers), e.g. NVIDIA


### PR DESCRIPTION
See PR [#3057 in Caffe](https://github.com/BVLC/caffe/pull/3057).

**However**, I cannot build tests and examples.
I think it is caused  by something defined in `caffe.proto`.

I've added following line into `caffe.proto`, but still not working.
```
optional bool ceil_mode = 13 [default = false];
```

And here's the error message:
```
In file included from /usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/x86_64-pc-linux-gnu/bits/c++allocator.h:33:0,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/allocator.h:46,
                 from /usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/string:41,
                 from /home/hzxie/Development/tiny-dnn/test/cotire/tiny_dnn_test_CXX_prefix.cxx:6,
                 from /home/hzxie/Development/tiny-dnn/test/cotire/tiny_dnn_test_CXX_prefix.hxx:4:
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/ext/new_allocator.h: In instantiation of ‘void __gnu_cxx::new_allocator<_Tp>::construct(_Up*, _Args&& ...) [with _Up = tiny_dnn::max_pooling_layer; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; _Tp = tiny_dnn::max_pooling_layer]’:
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/alloc_traits.h:475:4:   required from ‘static void std::allocator_traits<std::allocator<_CharT> >::construct(std::allocator_traits<std::allocator<_CharT> >::allocator_type&, _Up*, _Args&& ...) [with _Up = tiny_dnn::max_pooling_layer; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; _Tp = tiny_dnn::max_pooling_layer; std::allocator_traits<std::allocator<_CharT> >::allocator_type = std::allocator<tiny_dnn::max_pooling_layer>]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr_base.h:526:39:   required from ‘std::_Sp_counted_ptr_inplace<_Tp, _Alloc, _Lp>::_Sp_counted_ptr_inplace(_Alloc, _Args&& ...) [with _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; _Tp = tiny_dnn::max_pooling_layer; _Alloc = std::allocator<tiny_dnn::max_pooling_layer>; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr_base.h:637:4:   required from ‘std::__shared_count<_Lp>::__shared_count(std::_Sp_make_shared_tag, _Tp*, const _Alloc&, _Args&& ...) [with _Tp = tiny_dnn::max_pooling_layer; _Alloc = std::allocator<tiny_dnn::max_pooling_layer>; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr_base.h:1295:35:   required from ‘std::__shared_ptr<_Tp, _Lp>::__shared_ptr(std::_Sp_make_shared_tag, const _Alloc&, _Args&& ...) [with _Alloc = std::allocator<tiny_dnn::max_pooling_layer>; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; _Tp = tiny_dnn::max_pooling_layer; __gnu_cxx::_Lock_policy _Lp = (__gnu_cxx::_Lock_policy)2]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr.h:344:64:   required from ‘std::shared_ptr<_Tp>::shared_ptr(std::_Sp_make_shared_tag, const _Alloc&, _Args&& ...) [with _Alloc = std::allocator<tiny_dnn::max_pooling_layer>; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}; _Tp = tiny_dnn::max_pooling_layer]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr.h:690:14:   required from ‘std::shared_ptr<_Tp> std::allocate_shared(const _Alloc&, _Args&& ...) [with _Tp = tiny_dnn::max_pooling_layer; _Alloc = std::allocator<tiny_dnn::max_pooling_layer>; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}]’
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/bits/shared_ptr.h:706:39:   required from ‘std::shared_ptr<_Tp> std::make_shared(_Args&& ...) [with _Tp = tiny_dnn::max_pooling_layer; _Args = {const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&}]’
/home/hzxie/Development/tiny-dnn/tiny_dnn/io/caffe/layer_factory_impl.h:139:46:   required from here
/usr/lib/gcc/x86_64-pc-linux-gnu/7.3.1/include/c++/ext/new_allocator.h:136:4: error: no matching function for call to ‘tiny_dnn::max_pooling_layer::max_pooling_layer(const long unsigned int&, const long unsigned int&, const long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, long unsigned int&, tiny_dnn::padding&)’
  { ::new((void *)__p) _Up(std::forward<_Args>(__args)...); }
```

What should I do to fix this error?
