### PR TITLE
Remove osx build jobs from .travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: required
 dist: trusty
-osx_image: xcode8
+#osx_image: xcode8
 
 language: cpp
 
 os:
   - linux
-  - osx
+  #- osx
 
 compiler:
   - gcc
@@ -55,10 +55,10 @@ env:
     - USE_SSE=ON  USE_AVX=ON USE_DOUBLE=OFF
     - USE_SSE=ON  USE_AVX=ON USE_DOUBLE=ON
 
-matrix:
-  exclude: # On OSX g++ is a symlink to clang++ by default
-    - os: osx
-      compiler: gcc
+#matrix:
+#  exclude: # On OSX g++ is a symlink to clang++ by default
+#    - os: osx
+#      compiler: gcc
 
 before_install:
   - if [ "$TRAVIS_OS_NAME" == "linux" ] && [ "$CXX" == "g++" ]; then
@@ -91,11 +91,11 @@ before_script:
             -DBUILD_TESTS=$BUILD_TESTS
             -DBUILD_EXAMPLES=$BUILD_EXAMPLES .;
     fi
-  - if [ "$TRAVIS_OS_NAME" == "osx" ]; then
-      cmake -DUSE_TBB=$USE_TBB
-            -DUSE_AVX=OFF
-            -DBUILD_TESTS=$BUILD_TESTS .;
-    fi
+  #- if [ "$TRAVIS_OS_NAME" == "osx" ]; then
+  #    cmake -DUSE_TBB=$USE_TBB
+  #          -DUSE_AVX=OFF
+  #          -DBUILD_TESTS=$BUILD_TESTS .;
+  #  fi
   #- if [ "$TRAVIS_OS_NAME" == "linux" ]; then
   #    make test_lints;
   #  fi


### PR DESCRIPTION
This PR removes osx build jobs from `.travis.yml` file.

OSX build jobs haven't been maintained for a while and they've failed but passing travis-ci jobs is required before merging pull requests.

https://github.com/tiny-dnn/tiny-dnn/pull/1008#issuecomment-451611662
