### PR TITLE
Fix trivial warnings and error reported by VS2015

### DIFF
--- a/test/test_batch_norm_layer.h
+++ b/test/test_batch_norm_layer.h
@@ -215,13 +215,13 @@ TEST(batchnorm, forward) {
     /* y = (x - mean) ./ sqrt(variance + eps) */
     tensor_t expect = {
         {
-            0.0,    0.0,    0.0,   0.0,    // ch-0 of data#0
-           -1.225,  0.408,  0.0,   1.225,  // ch-1 of data#0
-           -0.573, -0.879, -0.573, 0.038,  // ch-2 of data#0
+            0.0f,    0.0f,    0.0f,    0.0f,    // ch-0 of data#0
+           -1.225f,  0.408f,  0.0f,    1.225f,  // ch-1 of data#0
+           -0.573f, -0.879f, -0.573f,  0.038f,  // ch-2 of data#0
         }, {
-            0.0,   0.0,    0.0,    0.0,    // ch-0 of data#1
-            1.225, 0.408, -1.225, -0.816,  // ch-1 of data#1
-           -0.268, 0.650, -0.573,  2.179f  // ch-2 of data#1
+            0.0f,    0.0f,    0.0f,    0.0f,    // ch-0 of data#1
+            1.225f,  0.408f, -1.225f, -0.816f,  // ch-1 of data#1
+           -0.268f,  0.650f, -0.573f,  2.179f   // ch-2 of data#1
         }
     };
 

--- a/test/test_dropout_layer.h
+++ b/test/test_dropout_layer.h
@@ -14,7 +14,7 @@ namespace tiny_dnn {
 
 TEST(dropout, randomized) {
   int num_units                  = 10000;
-  tiny_dnn::float_t dropout_rate = 0.1;
+  tiny_dnn::float_t dropout_rate = float_t(0.1);
   dropout_layer l(num_units, dropout_rate, net_phase::train);
   vec_t v(num_units, 1.0);
 

--- a/test/test_integration.h
+++ b/test/test_integration.h
@@ -40,7 +40,7 @@ TEST(integration, train1) {
     train.push_back(t);
     train.push_back(t2);
   }
-  optimizer.alpha = 0.1;
+  optimizer.alpha = float_t(0.1);
   nn.train<mse>(optimizer, data, train, 1, 10);
 
   vec_t predicted = nn.predict(a);
@@ -83,7 +83,7 @@ TEST(integration, train_different_batches1) {
       train.push_back(t);
       train.push_back(t2);
     }
-    optimizer.alpha = 0.1;
+    optimizer.alpha = float_t(0.1);
     nn.train<mse>(optimizer, data, train, batch_sz, 10);
 
     vec_t predicted = nn.predict(a);

--- a/test/test_l2_norm_layer.h
+++ b/test/test_l2_norm_layer.h
@@ -12,7 +12,7 @@
 namespace tiny_dnn {
 
 TEST(l2norm, forward) {
-  l2_normalization_layer l2_norm(4, 3, 1e-10, 20);
+  l2_normalization_layer l2_norm(4, 3, float_t(1e-10), 20);
   
   // clang-format off
   tensor_t in = {
@@ -29,13 +29,13 @@ TEST(l2norm, forward) {
 
   tensor_t expect = {
       {
-          0.0000,   0.0000,    0.0000,   0.0000,  // ch-0 of data#0
-        -19.4029,   0.0000,  -14.1421,  11.0940,  // ch-1 of data#0
-          4.8507,   0.0000,   14.1421,  16.6410,  // ch-2 of data#0
-      }, {
-          0.0000,   0.0000,   0.0000,   0.0000,   // ch-0 of data#1
-         14.1421,   0.0000, -19.4029,  -5.7470,   // ch-1 of data#1
-         14.1421,  20.0000,   4.8507,  19.1565    // ch-2 of data#1
+          0.0000f,   0.0000f,    0.0000f,    0.0000f,  // ch-0 of data#0
+        -19.4029f,   0.0000f,  -14.1421f,   11.0940f,  // ch-1 of data#0
+          4.8507f,   0.0000f,   14.1421f,   16.6410f,  // ch-2 of data#0
+      }, {                            
+          0.0000f,   0.0000f,    0.0000f,    0.0000f,   // ch-0 of data#1
+         14.1421f,   0.0000f,  -19.4029f,   -5.7470f,   // ch-1 of data#1
+         14.1421f,  20.0000f,    4.8507f,   19.1565f    // ch-2 of data#1
       }
   };
   // clang-format on

--- a/test/test_optimizers.h
+++ b/test/test_optimizers.h
@@ -11,13 +11,13 @@ namespace tiny_dnn {
 TEST(optimizers, adagrad_update) {
   adagrad optimizer;
 
-  vec_t weights   = {0.20, 0.40, 0.006, -0.77, -0.010};
-  vec_t gradients = {1.00, -3.24, -0.600, 2.79, 1.820};
+  vec_t weights   = {0.20f,  0.40f,  0.006f, -0.77f, -0.010f};
+  vec_t gradients = {1.00f, -3.24f, -0.600f,  2.79f, 1.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.1900, 0.4100, 0.0160, -0.7800, -0.0200};
-  vec_t second_update = {0.1829, 0.4170, 0.0230, -0.7870, -0.0270};
+  vec_t first_update  = {0.1900f, 0.4100f, 0.0160f, -0.7800f, -0.0200f};
+  vec_t second_update = {0.1829f, 0.4170f, 0.0230f, -0.7870f, -0.0270f};
 
   // Testing
 
@@ -37,13 +37,13 @@ TEST(optimizers, adagrad_update) {
 TEST(optimizers, rmsprop_update) {
   RMSprop optimizer;
 
-  vec_t weights   = {-0.021, 1.03, -0.05, -.749, 0.009};
-  vec_t gradients = {1.000, -3.24, -0.60, 2.79, 1.820};
+  vec_t weights   = {-0.021f,  1.03f, -0.05f, -0.749f, 0.009f};
+  vec_t gradients = { 1.000f, -3.24f, -0.60f,  2.79f, 1.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {-0.0220, 1.0310, -0.0490, -0.7500, 0.0080};
-  vec_t second_update = {-0.0227, 1.0317, -0.0482, -0.7507, 0.0072};
+  vec_t first_update  = {-0.0220f, 1.0310f, -0.0490f, -0.7500f, 0.0080f};
+  vec_t second_update = {-0.0227f, 1.0317f, -0.0482f, -0.7507f, 0.0072f};
 
   // Testing
 
@@ -63,13 +63,13 @@ TEST(optimizers, rmsprop_update) {
 TEST(optimizers, adam_update) {
   adam optimizer;
 
-  vec_t weights   = {1.00, 0.081, -0.6201, 0.96, -0.007};
-  vec_t gradients = {6.45, -3.240, -0.6000, 2.79, 1.820};
+  vec_t weights   = {1.00f,  0.081f, -0.6201f, 0.96f, -0.007f};
+  vec_t gradients = {6.45f, -3.240f, -0.6000f, 2.79f, 1.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.9992, 0.0817, -0.6193, 0.9592, -0.0077};
-  vec_t second_update = {0.9983, 0.0826, -0.6184, 0.9583, -0.0086};
+  vec_t first_update  = {0.9992f, 0.0817f, -0.6193f, 0.9592f, -0.0077f};
+  vec_t second_update = {0.9983f, 0.0826f, -0.6184f, 0.9583f, -0.0086f};
 
   // Testing
 
@@ -89,13 +89,13 @@ TEST(optimizers, adam_update) {
 TEST(optimizers, adamax_update) {
   adamax optimizer;
 
-  vec_t weights   = {1.00, 0.081, -0.6201, 0.96, -0.007};
-  vec_t gradients = {6.45, -3.240, -0.6000, 2.79, 1.820};
+  vec_t weights   = {1.00f,  0.081f, -0.6201f, 0.96f, -0.007f};
+  vec_t gradients = {6.45f, -3.240f, -0.6000f, 2.79f,  1.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.9980, 0.0830, -0.6181, 0.9580, -0.0090};
-  vec_t second_update = {0.9960, 0.0850, -0.6161, 0.9560, -0.0109};
+  vec_t first_update  = {0.9980f, 0.0830f, -0.6181f, 0.9580f, -0.0090f};
+  vec_t second_update = {0.9960f, 0.0850f, -0.6161f, 0.9560f, -0.0109f};
 
   // Testing
 
@@ -115,13 +115,13 @@ TEST(optimizers, adamax_update) {
 TEST(optimizers, naive_sgd_update) {
   gradient_descent optimizer;
 
-  vec_t weights   = {-0.001, -0.90, 0.005, -0.74, 0.003};
-  vec_t gradients = {-2.240, -3.24, 0.600, 0.39, 0.820};
+  vec_t weights   = {-0.001f, -0.90f, 0.005f, -0.74f, 0.003f};
+  vec_t gradients = {-2.240f, -3.24f, 0.600f, 0.39f, 0.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.0214, -0.8676, -0.0010, -0.7439, -0.0052};
-  vec_t second_update = {0.0438, -0.8352, -0.0070, -0.7478, -0.0134};
+  vec_t first_update  = {0.0214f, -0.8676f, -0.0010f, -0.7439f, -0.0052f};
+  vec_t second_update = {0.0438f, -0.8352f, -0.0070f, -0.7478f, -0.0134f};
 
   // Testing
 
@@ -141,13 +141,13 @@ TEST(optimizers, naive_sgd_update) {
 TEST(optimizers, momentum_update) {
   momentum optimizer;
 
-  vec_t weights   = {-0.001, -0.90, 0.005, -0.74, 0.003};
-  vec_t gradients = {-2.240, -3.24, 0.600, 0.39, 0.820};
+  vec_t weights   = {-0.001f, -0.90f, 0.005f, -0.74f, 0.003f};
+  vec_t gradients = {-2.240f, -3.24f, 0.600f,  0.39f, 0.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.0214, -0.8676, -0.0010, -0.7439, -0.0052};
-  vec_t second_update = {0.0639, -0.8060, -0.0124, -0.7513, -0.0207};
+  vec_t first_update  = {0.0214f, -0.8676f, -0.0010f, -0.7439f, -0.0052f};
+  vec_t second_update = {0.0639f, -0.8060f, -0.0124f, -0.7513f, -0.0207f};
 
   // Testing
 
@@ -167,13 +167,13 @@ TEST(optimizers, momentum_update) {
 TEST(optimizers, nesterov_momentum_update) {
   nesterov_momentum optimizer;
 
-  vec_t weights   = {0.1, 0.30, 0.005, -0.74, -0.008};
-  vec_t gradients = {1.0, -3.24, -0.600, 2.79, 1.820};
+  vec_t weights   = {0.1f, 0.30f, 0.005f, -0.74f, -0.008f};
+  vec_t gradients = {1.0f, -3.24f, -0.600f, 2.79f, 1.820f};
 
   // Defining the expected updates
 
-  vec_t first_update  = {0.0810, 0.3615, 0.0164, -0.7930, -0.0425};
-  vec_t second_update = {0.0539, 0.4493, 0.0326, -0.8686, -0.0919};
+  vec_t first_update  = {0.0810f, 0.3615f, 0.0164f, -0.7930f, -0.0425f};
+  vec_t second_update = {0.0539f, 0.4493f, 0.0326f, -0.8686f, -0.0919f};
 
   // Testing
 

--- a/test/test_serialization.h
+++ b/test/test_serialization.h
@@ -1057,7 +1057,7 @@ TEST(serialization, sequential_to_json) {
   network<sequential> net1, net2;
 
   net1 << fully_connected_layer(10, 100) << tanh_layer()
-       << dropout_layer(100, 0.3, net_phase::test)
+       << dropout_layer(100, float_t(0.3), net_phase::test)
        << fully_connected_layer(100, 9) << softmax()
        << recurrent_layer(gru(9, 9), 1) << recurrent_layer(lstm(9, 9), 1)
        << recurrent_layer(rnn(9, 9), 1) << convolutional_layer(3, 3, 3, 1, 1)
@@ -1111,7 +1111,7 @@ TEST(serialization, sequential_weights) {
   auto res1 = net1.predict(data);
   auto res2 = net2.predict(data);
 
-  EXPECT_TRUE(net1.has_same_weights(net2, 1e-3));
+  EXPECT_TRUE(net1.has_same_weights(net2, float_t(1e-3)));
 
   for (int i = 0; i < 2; i++) {
     EXPECT_FLOAT_EQ(res1[i], res2[i]);
@@ -1123,9 +1123,9 @@ TEST(serialization, sequential_weights2) {
   network<sequential> net1, net2;
   vec_t data = {1, 2, 3, 4, 5, 0};
 
-  net1 << batch_normalization_layer(3, 2, 0.01, 0.99, net_phase::train)
-       << linear_layer(3 * 2, 2.0, 0.5) << elu()
-       << power_layer(shape3d(3, 2, 1), 2.0, 1.5) << leaky_relu();
+  net1 << batch_normalization_layer(3, 2, float_t(0.01), float_t(0.99), net_phase::train)
+       << linear_layer(3 * 2, float_t(2.0), float_t(0.5) ) << elu()
+       << power_layer(shape3d(3, 2, 1), float_t(2.0), float_t(1.5)) << leaky_relu();
 
   net1.init_weight();
   net1.at<batch_normalization_layer>(0).update_immidiately(true);
@@ -1140,7 +1140,7 @@ TEST(serialization, sequential_weights2) {
   auto res1 = net1.predict(data);
   auto res2 = net2.predict(data);
 
-  EXPECT_TRUE(net1.has_same_weights(net2, 1e-3));
+  EXPECT_TRUE(net1.has_same_weights(net2, float_t(1e-3)));
 
   for (int i = 0; i < 6; i++) {
     EXPECT_FLOAT_EQ(res1[i], res2[i]);

--- a/tiny_dnn/activations/elu_layer.h
+++ b/tiny_dnn/activations/elu_layer.h
@@ -17,22 +17,22 @@ namespace tiny_dnn {
 
 class elu_layer : public activation_layer {
  public:
-  explicit elu_layer(const float_t alpha = 1.0)
+  explicit elu_layer(const float_t alpha = float_t(1))
     : elu_layer(shape3d(0, 0, 0), alpha) {}
 
-  explicit elu_layer(size_t in_dim, const float_t alpha = 1.0)
+  explicit elu_layer(size_t in_dim, const float_t alpha = float_t(1))
     : elu_layer(shape3d(in_dim, 1, 1), alpha) {}
 
   elu_layer(size_t in_width,
             size_t in_height,
             size_t in_channels,
-            const float_t alpha = 1.0)
+            const float_t alpha = float_t(1))
     : elu_layer(shape3d(in_width, in_height, in_channels), alpha) {}
 
-  explicit elu_layer(const shape3d &in_shape, const float_t alpha = 1.0)
+  explicit elu_layer(const shape3d &in_shape, const float_t alpha = float_t(1))
     : activation_layer(in_shape), alpha_(alpha) {}
 
-  explicit elu_layer(const layer &prev_layer, const float_t alpha = 1.0)
+  explicit elu_layer(const layer &prev_layer, const float_t alpha = float_t(1))
     : activation_layer(prev_layer), alpha_(alpha) {}
 
   std::string layer_type() const override { return "elu-activation"; }

--- a/tiny_dnn/activations/selu_layer.h
+++ b/tiny_dnn/activations/selu_layer.h
@@ -94,7 +94,7 @@ class selu_layer : public activation_layer {
     // dx = dy * (gradient of selu)
     for (size_t j = 0; j < x.size(); j++) {
       dx[j] =
-        dy[j] * lambda_ * (x[j] > float_t(0) ? 1.0 : alpha_ * std::exp(x[j]));
+        dy[j] * lambda_ * (x[j] > float_t(0) ?  float_t(1) : alpha_ * std::exp(x[j]));
     }
   }
 

--- a/tiny_dnn/activations/softplus_layer.h
+++ b/tiny_dnn/activations/softplus_layer.h
@@ -23,8 +23,8 @@ class softplus_layer : public activation_layer {
    * layer. Connection happens like ( layer1 << act_layer1 ) and shape of this
    * layer is inferred at that time.
    */
-  explicit softplus_layer(const float_t beta      = 1.0,
-                          const float_t threshold = 20.0)
+  explicit softplus_layer(const float_t beta      = float_t(1),
+                          const float_t threshold = float_t(20))
     : softplus_layer(shape3d(0, 0, 0), beta, threshold) {}
 
   /**
@@ -35,8 +35,8 @@ class softplus_layer : public activation_layer {
    * @param in_dim      [in] number of elements of the input
    */
   softplus_layer(size_t in_dim,
-                 const float_t beta      = 1.0,
-                 const float_t threshold = 20.0)
+                 const float_t beta      = float_t(1),
+                 const float_t threshold = float_t(20))
     : softplus_layer(shape3d(in_dim, 1, 1), beta, threshold) {}
 
   /**
@@ -51,8 +51,8 @@ class softplus_layer : public activation_layer {
   softplus_layer(size_t in_width,
                  size_t in_height,
                  size_t in_channels,
-                 const float_t beta      = 1.0,
-                 const float_t threshold = 20.0)
+                 const float_t beta      = float_t(1),
+                 const float_t threshold = float_t(20))
     : softplus_layer(
         shape3d(in_width, in_height, in_channels), beta, threshold) {}
 
@@ -62,8 +62,8 @@ class softplus_layer : public activation_layer {
    * @param in_shape [in] shape of input tensor
    */
   softplus_layer(const shape3d &in_shape,
-                 const float_t beta      = 1.0,
-                 const float_t threshold = 20.0)
+                 const float_t beta      = float_t(1),
+                 const float_t threshold = float_t(20))
     : activation_layer(in_shape), beta_(beta), threshold_(threshold) {}
 
   /**
@@ -71,8 +71,8 @@ class softplus_layer : public activation_layer {
    * @param prev_layer previous layer
    */
   softplus_layer(const layer &prev_layer,
-                 const float_t beta      = 1.0,
-                 const float_t threshold = 20.0)
+                 const float_t beta      = float_t(1),
+                 const float_t threshold = float_t(20))
     : activation_layer(prev_layer), beta_(beta), threshold_(threshold) {}
 
   std::string layer_type() const override { return "softplus-activation"; }

--- a/tiny_dnn/activations/softsign_layer.h
+++ b/tiny_dnn/activations/softsign_layer.h
@@ -23,7 +23,7 @@ class softsign_layer : public activation_layer {
 
   void forward_activation(const vec_t &x, vec_t &y) override {
     for (size_t j = 0; j < x.size(); j++) {
-      y[j] = x[j] / (1.0 + std::abs(x[j]));
+      y[j] = x[j] / ( float_t(1) + std::abs(x[j]));
     }
   }
 
@@ -34,7 +34,7 @@ class softsign_layer : public activation_layer {
     CNN_UNREFERENCED_PARAMETER(y);
     for (size_t j = 0; j < x.size(); j++) {
       // dx = dy * (gradient of softsign)
-      auto d = 1.0 + std::abs(x[j]);
+      float_t d =  float_t(1) + std::abs(x[j]);
       dx[j]  = dy[j] / (d * d);
     }
   }

--- a/tiny_dnn/io/caffe/layer_factory_impl.h
+++ b/tiny_dnn/io/caffe/layer_factory_impl.h
@@ -159,7 +159,7 @@ inline std::shared_ptr<layer> create_ave_pool(layer_size_t pool_size_w,
     pool_size_h, stride_w, stride_h, ceil_mode, pad_type);
 
   // tiny-dnn has trainable parameter in average-pooling layer
-  float_t weight = 1.0 / (pool_size_w * pool_size_h);
+  float_t weight = float_t(1) / (pool_size_w * pool_size_h);
 
   vec_t &w = *ap->weights()[0];
   vec_t &b = *ap->weights()[1];
@@ -519,7 +519,7 @@ inline void load_weights_pool(const caffe::LayerParameter &src, layer *dst) {
     }
 
     // tiny-dnn has trainable parameter in average-pooling layer
-    float_t weight = 1.0 / sqr(pool_size);
+    float_t weight = float_t(1) / sqr(pool_size);
 
     // TODO(karan)
     /*if (!dst->weight().empty()) {

--- a/tiny_dnn/layers/lrn_layer.h
+++ b/tiny_dnn/layers/lrn_layer.h
@@ -24,8 +24,8 @@ class lrn_layer : public layer {
  public:
   lrn_layer(const shape3d &in_shape,
             size_t local_size,
-            float_t alpha      = 1.0,
-            float_t beta       = 5.0,
+            float_t alpha      = float_t( 1 ),
+            float_t beta       = float_t( 5 ),
             norm_region region = norm_region::across_channels)
     : layer({vector_type::data}, {vector_type::data}),
       in_shape_(in_shape),
@@ -44,8 +44,8 @@ class lrn_layer : public layer {
    **/
   lrn_layer(layer *prev,
             size_t local_size,
-            float_t alpha      = 1.0,
-            float_t beta       = 5.0,
+            float_t alpha      = float_t( 1 ),
+            float_t beta       = float_t( 5 ),
             norm_region region = norm_region::across_channels)
     : lrn_layer(prev->out_data_shape()[0], local_size, alpha, beta, region) {}
 
@@ -61,8 +61,8 @@ class lrn_layer : public layer {
             size_t in_height,
             size_t local_size,
             size_t in_channels,
-            float_t alpha      = 1.0,
-            float_t beta       = 5.0,
+            float_t alpha      = float_t( 1 ),
+            float_t beta       = float_t( 5 ),
             norm_region region = norm_region::across_channels)
     : lrn_layer(shape3d{in_width, in_height, in_channels},
                 local_size,

--- a/tiny_dnn/layers/power_layer.h
+++ b/tiny_dnn/layers/power_layer.h
@@ -85,11 +85,11 @@ class power_layer : public layer {
         //      = dy * scale * factor * (scale * x)^factor * (scale *
         //      x)^(-1)
         //      = dy * factor * y / x
-        if (std::abs(x[i][j]) > 1e-10) {
+        if (std::abs(x[i][j]) > float_t(1e-10) ) {
           dx[i][j] = dy[i][j] * factor_ * y[i][j] / x[i][j];
         } else {
           dx[i][j] = dy[i][j] * scale_ * factor_ *
-                     std::pow(scale_ * x[i][j], factor_ - 1.0);
+                     std::pow(scale_ * x[i][j], factor_ - float_t(1));
         }
       }
     }

--- a/tiny_dnn/optimizers/optimizer.h
+++ b/tiny_dnn/optimizers/optimizer.h
@@ -159,7 +159,7 @@ struct adamax : public stateful_optimizer<2> {
       ut[i] = std::max(b2 * ut[i], std::abs(dW[i]));
 
       // Lp norm based update rule
-      W[i] -= (alpha / (1.0 - b1_t)) * (mt[i] / (ut[i] + eps));
+      W[i] -= (alpha / ( float_t(1) - b1_t)) * (mt[i] / (ut[i] + eps));
     });
 
     b1_t *= b1;

--- a/tiny_dnn/util/gradient_check.h
+++ b/tiny_dnn/util/gradient_check.h
@@ -122,7 +122,7 @@ float_t analytical_gradient(layer &layer,
 float_t relative_error(const float_t analytical_grad,
                        const float_t numeric_grad) {
   float_t max = std::max(std::abs(analytical_grad), std::abs(numeric_grad));
-  return (max == 0) ? 0.0 : std::abs(analytical_grad - numeric_grad) / max;
+  return (max == 0) ? float_t(0) : std::abs(analytical_grad - numeric_grad) / max;
 }
 
 }  // namespace tiny_dnn

--- a/tiny_dnn/util/target_cost.h
+++ b/tiny_dnn/util/target_cost.h
@@ -58,7 +58,7 @@ inline float_t get_sample_weight_for_balanced_target_cost(
 //    function)
 //    * use a value between 0 and 1 to have something between the two extremes
 inline std::vector<vec_t> create_balanced_target_cost(
-  const std::vector<label_t> &t, float_t w = 1.0) {
+  const std::vector<label_t> &t, float_t w = float_t(1)) {
   const auto label_counts         = calculate_label_counts(t);
   const size_t total_sample_count = t.size();
   const size_t class_count        = label_counts.size();


### PR DESCRIPTION
 - warning C4838: conversion from 'double' to 'tiny_dnn::float_t' requires a narrowing conversion
 - error   C2398: Element '_': conversion from 'double' to 'float' requires a narrowing conversion